### PR TITLE
[consumption] Add support of QueueSubscriberInterface to transport consume command.

### DIFF
--- a/docs/bundle/cli_commands.md
+++ b/docs/bundle/cli_commands.md
@@ -138,18 +138,18 @@ Help:
 ## enqueue:transport:consume
  
 ```
-./bin/console enqueue:transport:consume   --help
+./bin/console enqueue:transport:consume --help
 Usage:
-  enqueue:transport:consume [options] [--] <queue> <processor-service>
+  enqueue:transport:consume [options] [--] <processor-service>
 
 Arguments:
-  queue                              Queues to consume from
   processor-service                  A message processor service
 
 Options:
       --message-limit=MESSAGE-LIMIT  Consume n messages and exit
       --time-limit=TIME-LIMIT        Consume messages during this time
       --memory-limit=MEMORY-LIMIT    Consume messages until process reaches this memory limit in MB
+      --queue[=QUEUE]                Queues to consume from (multiple values allowed)
   -h, --help                         Display this help message
   -q, --quiet                        Do not output any message
   -V, --version                      Display this application version

--- a/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
@@ -148,7 +148,7 @@ class UseCasesTest extends WebTestCase
         $tester->execute([
             '--message-limit' => 1,
             '--time-limit' => '+10sec',
-            'queue' => 'enqueue.test',
+            '--queue' => ['enqueue.test'],
             'processor-service' => 'test.message.processor',
         ]);
 

--- a/pkg/enqueue/Tests/Symfony/Consumption/Mock/QueueSubscriberProcessor.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/Mock/QueueSubscriberProcessor.php
@@ -1,0 +1,19 @@
+<?php
+namespace Enqueue\Tests\Symfony\Consumption\Mock;
+
+use Enqueue\Consumption\QueueSubscriberInterface;
+use Enqueue\Psr\PsrContext;
+use Enqueue\Psr\PsrMessage;
+use Enqueue\Psr\PsrProcessor;
+
+class QueueSubscriberProcessor implements PsrProcessor, QueueSubscriberInterface
+{
+    public function process(PsrMessage $message, PsrContext $context)
+    {
+    }
+
+    public static function getSubscribedQueues()
+    {
+        return ['fooSubscribedQueues', 'barSubscribedQueues'];
+    }
+}


### PR DESCRIPTION
Aslo adds ability to bind the processor to several queues at once.  Fixes https://github.com/php-enqueue/enqueue-dev/issues/53