### PR TITLE
Calling AmqpContext::declareQueue() now returns an integer holding the queue message count

### DIFF
--- a/pkg/amqp-ext/AmqpContext.php
+++ b/pkg/amqp-ext/AmqpContext.php
@@ -114,6 +114,8 @@ class AmqpContext implements PsrContext
 
     /**
      * @param AmqpQueue|PsrDestination $destination
+     *
+     * @return int
      */
     public function declareQueue(PsrDestination $destination)
     {
@@ -127,11 +129,13 @@ class AmqpContext implements PsrContext
             $extQueue->setName($destination->getQueueName());
         }
 
-        $extQueue->declareQueue();
+        $count = $extQueue->declareQueue();
 
         if (false == $destination->getQueueName()) {
             $destination->setQueueName($extQueue->getName());
         }
+
+        return $count;
     }
 
     /**


### PR DESCRIPTION
Calling AmqpContext::declareQueue() now returns an integer holding the queue message count.

See #64.