### PR TITLE
[bundle] Set null transport as default. Prevent errors on bundle install.

### DIFF
--- a/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
+++ b/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
@@ -4,6 +4,8 @@ namespace Enqueue\Bundle\DependencyInjection;
 
 use Enqueue\Client\TraceableProducer;
 use Enqueue\JobQueue\Job;
+use Enqueue\Null\Symfony\NullTransportFactory;
+use Enqueue\Symfony\DefaultTransportFactory;
 use Enqueue\Symfony\TransportFactoryInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
@@ -23,6 +25,9 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
     public function __construct()
     {
         $this->factories = [];
+
+        $this->addTransportFactory(new DefaultTransportFactory());
+        $this->addTransportFactory(new NullTransportFactory());
     }
 
     /**
@@ -47,6 +52,14 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        // enable null transport by default.
+        array_unshift($configs, [
+            'transport' => [
+                'default' => 'null',
+                'null' => [],
+            ]
+        ]);
+
         $config = $this->processConfiguration(new Configuration($this->factories), $configs);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
+++ b/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
@@ -52,13 +52,6 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        // enable null transport by default.
-        array_unshift($configs, [
-            'transport' => [
-                'default' => 'null://',
-            ],
-        ]);
-
         $config = $this->processConfiguration(new Configuration($this->factories), $configs);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
+++ b/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
@@ -55,9 +55,8 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
         // enable null transport by default.
         array_unshift($configs, [
             'transport' => [
-                'default' => 'null',
-                'null' => [],
-            ]
+                'default' => 'null://',
+            ],
         ]);
 
         $config = $this->processConfiguration(new Configuration($this->factories), $configs);

--- a/pkg/enqueue-bundle/EnqueueBundle.php
+++ b/pkg/enqueue-bundle/EnqueueBundle.php
@@ -44,8 +44,6 @@ class EnqueueBundle extends Bundle
 
         /** @var EnqueueExtension $extension */
         $extension = $container->getExtension('enqueue');
-        $extension->addTransportFactory(new DefaultTransportFactory());
-        $extension->addTransportFactory(new NullTransportFactory());
 
         if (class_exists(StompContext::class)) {
             $extension->addTransportFactory(new StompTransportFactory());

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
@@ -9,8 +9,8 @@ use Enqueue\Client\Producer;
 use Enqueue\Client\TraceableProducer;
 use Enqueue\Null\NullContext;
 use Enqueue\Null\Symfony\NullTransportFactory;
-use Enqueue\Symfony\TransportFactoryInterface;
 use Enqueue\Symfony\DefaultTransportFactory;
+use Enqueue\Symfony\TransportFactoryInterface;
 use Enqueue\Test\ClassExtensionTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -112,30 +112,6 @@ class EnqueueExtensionTest extends TestCase
         );
         self::assertEquals(
             'enqueue.transport.null.context',
-            (string) $container->getAlias('enqueue.transport.default.context')
-        );
-    }
-
-    public function testShouldUseNullTransportAsDefaultConfiguredViaDSN()
-    {
-        $container = new ContainerBuilder();
-
-        $extension = new EnqueueExtension();
-        $extension->addTransportFactory(new NullTransportFactory());
-        $extension->addTransportFactory(new DefaultTransportFactory());
-
-        $extension->load([[
-            'transport' => [
-                'default' => 'null://',
-            ],
-        ]], $container);
-
-        self::assertEquals(
-            'enqueue.transport.default.context',
-            (string) $container->getAlias('enqueue.transport.context')
-        );
-        self::assertEquals(
-            'enqueue.transport.default_null.context',
             (string) $container->getAlias('enqueue.transport.default.context')
         );
     }

--- a/pkg/enqueue-bundle/Tests/Unit/EnqueueBundleTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/EnqueueBundleTest.php
@@ -84,7 +84,7 @@ class EnqueueBundleTest extends TestCase
         $bundle->build($container);
     }
 
-    public function testShouldRegisterDefaultAndNullTransportFactories()
+    public function testShouldRegisterStompAndRabbitMqStompTransportFactories()
     {
         $extensionMock = $this->createEnqueueExtensionMock();
 
@@ -94,32 +94,10 @@ class EnqueueBundleTest extends TestCase
         $extensionMock
             ->expects($this->at(0))
             ->method('addTransportFactory')
-            ->with($this->isInstanceOf(DefaultTransportFactory::class))
-        ;
-        $extensionMock
-            ->expects($this->at(1))
-            ->method('addTransportFactory')
-            ->with($this->isInstanceOf(NullTransportFactory::class))
-        ;
-
-        $bundle = new EnqueueBundle();
-        $bundle->build($container);
-    }
-
-    public function testShouldRegisterStompAndRabbitMqStompTransportFactories()
-    {
-        $extensionMock = $this->createEnqueueExtensionMock();
-
-        $container = new ContainerBuilder();
-        $container->registerExtension($extensionMock);
-
-        $extensionMock
-            ->expects($this->at(2))
-            ->method('addTransportFactory')
             ->with($this->isInstanceOf(StompTransportFactory::class))
         ;
         $extensionMock
-            ->expects($this->at(3))
+            ->expects($this->at(1))
             ->method('addTransportFactory')
             ->with($this->isInstanceOf(RabbitMqStompTransportFactory::class))
         ;
@@ -136,12 +114,12 @@ class EnqueueBundleTest extends TestCase
         $container->registerExtension($extensionMock);
 
         $extensionMock
-            ->expects($this->at(4))
+            ->expects($this->at(2))
             ->method('addTransportFactory')
             ->with($this->isInstanceOf(AmqpTransportFactory::class))
         ;
         $extensionMock
-            ->expects($this->at(5))
+            ->expects($this->at(3))
             ->method('addTransportFactory')
             ->with($this->isInstanceOf(RabbitMqAmqpTransportFactory::class))
         ;
@@ -158,7 +136,7 @@ class EnqueueBundleTest extends TestCase
         $container->registerExtension($extensionMock);
 
         $extensionMock
-            ->expects($this->at(6))
+            ->expects($this->at(4))
             ->method('addTransportFactory')
             ->with($this->isInstanceOf(FsTransportFactory::class))
         ;
@@ -175,7 +153,7 @@ class EnqueueBundleTest extends TestCase
         $container->registerExtension($extensionMock);
 
         $extensionMock
-            ->expects($this->at(7))
+            ->expects($this->at(5))
             ->method('addTransportFactory')
             ->with($this->isInstanceOf(RedisTransportFactory::class))
         ;
@@ -192,7 +170,7 @@ class EnqueueBundleTest extends TestCase
         $container->registerExtension($extensionMock);
 
         $extensionMock
-            ->expects($this->at(8))
+            ->expects($this->at(6))
             ->method('addTransportFactory')
             ->with($this->isInstanceOf(DbalTransportFactory::class))
         ;
@@ -209,7 +187,7 @@ class EnqueueBundleTest extends TestCase
         $container->registerExtension($extensionMock);
 
         $extensionMock
-            ->expects($this->at(9))
+            ->expects($this->at(7))
             ->method('addTransportFactory')
             ->with($this->isInstanceOf(SqsTransportFactory::class))
         ;

--- a/pkg/enqueue/Tests/Symfony/DefaultTransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/DefaultTransportFactoryTest.php
@@ -72,7 +72,7 @@ class DefaultTransportFactoryTest extends TestCase
         $this->assertEquals(['dsn' => 'dsn://'], $config);
     }
 
-    public function testThrowIfNeitherDsnNorAliasConfiguredOnCreateConnectionFactory()
+    public function testShouldSetNullTransportByDefault()
     {
         $transport = new DefaultTransportFactory();
         $tb = new TreeBuilder();
@@ -80,17 +80,15 @@ class DefaultTransportFactoryTest extends TestCase
 
         $transport->addConfiguration($rootNode);
         $processor = new Processor();
-        $config = $processor->process($tb->buildTree(), [[]]);
 
-        // guard
-        $this->assertEquals([], $config);
+        $config = $processor->process($tb->buildTree(), [null]);
+        $this->assertEquals(['dsn' => 'null://'], $config);
 
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Either dsn or alias option must be set');
-        $transport->createConnectionFactory(new ContainerBuilder(), $config);
+        $config = $processor->process($tb->buildTree(), ['']);
+        $this->assertEquals(['dsn' => 'null://'], $config);
     }
 
-    public function testThrowIfNeitherDsnNorAliasConfiguredOnCreateContext()
+    public function testThrowIfNeitherDsnNorAliasConfigured()
     {
         $transport = new DefaultTransportFactory();
         $tb = new TreeBuilder();
@@ -98,32 +96,10 @@ class DefaultTransportFactoryTest extends TestCase
 
         $transport->addConfiguration($rootNode);
         $processor = new Processor();
-        $config = $processor->process($tb->buildTree(), [[]]);
-
-        // guard
-        $this->assertEquals([], $config);
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Either dsn or alias option must be set');
-        $transport->createContext(new ContainerBuilder(), $config);
-    }
-
-    public function testThrowIfNeitherDsnNorAliasConfiguredOnCreateDriver()
-    {
-        $transport = new DefaultTransportFactory();
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
-
-        $transport->addConfiguration($rootNode);
-        $processor = new Processor();
-        $config = $processor->process($tb->buildTree(), [[]]);
-
-        // guard
-        $this->assertEquals([], $config);
-
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Either dsn or alias option must be set');
-        $transport->createDriver(new ContainerBuilder(), $config);
+        $processor->process($tb->buildTree(), [[]]);
     }
 
     public function testShouldCreateConnectionFactoryFromAlias()

--- a/pkg/enqueue/composer.json
+++ b/pkg/enqueue/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": ">=5.6",
         "enqueue/psr-queue": "^0.4",
+        "enqueue/null": "^0.4",
         "ramsey/uuid": "^2|^3.5"
     },
     "require-dev": {
@@ -20,7 +21,6 @@
         "symfony/console": "^2.8|^3",
         "symfony/dependency-injection": "^2.8|^3",
         "symfony/config": "^2.8|^3",
-        "enqueue/null": "^0.4",
         "enqueue/amqp-ext": "^0.4",
         "enqueue/fs": "^0.4",
         "enqueue/test": "^0.4",


### PR DESCRIPTION
ref https://github.com/symfony/recipes-contrib/pull/16