### PR TITLE
[fs] Filesystem transport must create a storage dir if it does not exists.

### DIFF
--- a/pkg/fs/FsContext.php
+++ b/pkg/fs/FsContext.php
@@ -7,6 +7,7 @@ use Enqueue\Psr\PsrContext;
 use Enqueue\Psr\PsrDestination;
 use Enqueue\Psr\PsrQueue;
 use Makasim\File\TempFile;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\LockHandler;
 
 class FsContext implements PsrContext
@@ -38,6 +39,9 @@ class FsContext implements PsrContext
      */
     public function __construct($storeDir, $preFetchCount, $chmod)
     {
+        $fs = new Filesystem();
+        $fs->mkdir($storeDir);
+
         $this->storeDir = $storeDir;
         $this->preFetchCount = $preFetchCount;
         $this->chmod = $chmod;

--- a/pkg/fs/Tests/Functional/FsContextTest.php
+++ b/pkg/fs/Tests/Functional/FsContextTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Enqueue\Fs\Tests\Functional;
+
+use Enqueue\Fs\FsConnectionFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FsContextTest extends TestCase
+{
+    public function tearDown()
+    {
+        $fs = new Filesystem();
+        $fs->remove(sys_get_temp_dir().'/enqueue');
+    }
+
+    public function testShouldCreateFoldersIfNotExistOnConstruct()
+    {
+        $fs = new Filesystem();
+        $fs->remove(sys_get_temp_dir().'/enqueue');
+
+        $this->fsContext = (new FsConnectionFactory(['store_dir' => sys_get_temp_dir().'/enqueue/dir/notexiststest']))->createContext();
+
+        $this->assertDirectoryExists(sys_get_temp_dir().'/enqueue/dir/notexiststest');
+    }
+}


### PR DESCRIPTION
fixes https://github.com/symfony/recipes-contrib/pull/16#discussion_r116027232