### PR TITLE
Add dsn_to_connection_factory and dsn_to_context functions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
     "friendsofphp/php-cs-fixer": "^2",
     "empi89/php-amqp-stubs": "*@dev"
   },
+  "autoload": {
+    "files": ["pkg/enqueue/functions_include.php"]
+  },
   "config": {
     "bin-dir": "bin"
   },

--- a/pkg/enqueue/Tests/Functions/DsnToConnectionFactoryFunctionTest.php
+++ b/pkg/enqueue/Tests/Functions/DsnToConnectionFactoryFunctionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Enqueue\Tests\Router;
+
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+use Enqueue\Fs\FsConnectionFactory;
+use Enqueue\Null\NullConnectionFactory;
+use PHPUnit\Framework\TestCase;
+
+class DsnToConnectionFactoryFunctionTest extends TestCase
+{
+    public function testThrowIfDsnEmpty()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The scheme could not be parsed from DSN ""');
+
+        \Enqueue\dsn_to_connection_factory('');
+    }
+
+    public function testThrowIfDsnMissingScheme()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The scheme could not be parsed from DSN "dsnMissingScheme"');
+
+        \Enqueue\dsn_to_connection_factory('dsnMissingScheme');
+    }
+
+    public function testThrowIfDsnNotSupported()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The scheme "http" is not supported. Supported "file", "amqp", "null"');
+
+        \Enqueue\dsn_to_connection_factory('http://schemeNotSupported');
+    }
+
+    /**
+     * @dataProvider provideDSNs
+     *
+     * @param mixed $dsn
+     * @param mixed $expectedFactoryClass
+     */
+    public function testReturnsExpectedFactoryInstance($dsn, $expectedFactoryClass)
+    {
+        $factory = \Enqueue\dsn_to_connection_factory($dsn);
+
+        $this->assertInstanceOf($expectedFactoryClass, $factory);
+    }
+
+    public static function provideDSNs()
+    {
+        yield ['amqp://', AmqpConnectionFactory::class];
+
+        yield ['amqp://user:pass@foo/vhost', AmqpConnectionFactory::class];
+
+        yield ['file://', FsConnectionFactory::class];
+
+        yield ['file://foo/bar/baz', FsConnectionFactory::class];
+
+        yield ['null://', NullConnectionFactory::class];
+    }
+}

--- a/pkg/enqueue/Tests/Functions/DsnToContextFunctionTest.php
+++ b/pkg/enqueue/Tests/Functions/DsnToContextFunctionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Enqueue\Tests\Router;
+
+use Enqueue\AmqpExt\AmqpContext;
+use Enqueue\Fs\FsContext;
+use Enqueue\Null\NullContext;
+use PHPUnit\Framework\TestCase;
+
+class DsnToContextFunctionTest extends TestCase
+{
+    public function testThrowIfDsnEmpty()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The scheme could not be parsed from DSN ""');
+
+        \Enqueue\dsn_to_context('');
+    }
+
+    public function testThrowIfDsnMissingScheme()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The scheme could not be parsed from DSN "dsnMissingScheme"');
+
+        \Enqueue\dsn_to_context('dsnMissingScheme');
+    }
+
+    public function testThrowIfDsnNotSupported()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The scheme "http" is not supported. Supported "file", "amqp", "null"');
+
+        \Enqueue\dsn_to_context('http://schemeNotSupported');
+    }
+
+    /**
+     * @dataProvider provideDSNs
+     *
+     * @param mixed $dsn
+     * @param mixed $expectedFactoryClass
+     */
+    public function testReturnsExpectedFactoryInstance($dsn, $expectedFactoryClass)
+    {
+        $factory = \Enqueue\dsn_to_context($dsn);
+
+        $this->assertInstanceOf($expectedFactoryClass, $factory);
+    }
+
+    public static function provideDSNs()
+    {
+        yield ['amqp://', AmqpContext::class];
+
+        yield ['amqp://user:pass@foo/vhost', AmqpContext::class];
+
+        yield ['file://', FsContext::class];
+
+        yield ['file:/'.sys_get_temp_dir(), FsContext::class];
+
+        yield ['null://', NullContext::class];
+    }
+}

--- a/pkg/enqueue/composer.json
+++ b/pkg/enqueue/composer.json
@@ -21,6 +21,8 @@
         "symfony/dependency-injection": "^2.8|^3",
         "symfony/config": "^2.8|^3",
         "enqueue/null": "^0.4",
+        "enqueue/amqp-ext": "^0.4",
+        "enqueue/fs": "^0.4",
         "enqueue/test": "^0.4",
         "enqueue/simple-client": "^0.4"
     },
@@ -37,6 +39,7 @@
     },
     "autoload": {
         "psr-4": { "Enqueue\\": "" },
+        "files": ["functions_include.php"],
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/pkg/enqueue/functions.php
+++ b/pkg/enqueue/functions.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Enqueue;
+
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+use Enqueue\Fs\FsConnectionFactory;
+use Enqueue\Null\NullConnectionFactory;
+use Enqueue\Psr\PsrConnectionFactory;
+use Enqueue\Psr\PsrContext;
+
+/**
+ * @param string $dsn
+ *
+ * @return PsrConnectionFactory
+ */
+function dsn_to_connection_factory($dsn)
+{
+    $map = [];
+
+    if (class_exists(FsConnectionFactory::class)) {
+        $map['file'] = FsConnectionFactory::class;
+    }
+
+    if (class_exists(AmqpConnectionFactory::class)) {
+        $map['amqp'] = AmqpConnectionFactory::class;
+    }
+
+    if (class_exists(NullConnectionFactory::class)) {
+        $map['null'] = NullConnectionFactory::class;
+    }
+
+    list($scheme) = explode('://', $dsn);
+    if (false == $scheme || false === strpos($dsn, '://')) {
+        throw new \LogicException(sprintf('The scheme could not be parsed from DSN "%s"', $dsn));
+    }
+
+    if (false == array_key_exists($scheme, $map)) {
+        throw new \LogicException(sprintf(
+            'The scheme "%s" is not supported. Supported "%s"',
+            $scheme,
+            implode('", "', array_keys($map))
+        ));
+    }
+
+    $factoryClass = $map[$scheme];
+
+    return new $factoryClass($dsn);
+}
+
+/**
+ * @param string $dsn
+ *
+ * @return PsrContext
+ */
+function dsn_to_context($dsn)
+{
+    return dsn_to_connection_factory($dsn)->createContext();
+}

--- a/pkg/enqueue/functions_include.php
+++ b/pkg/enqueue/functions_include.php
@@ -1,0 +1,6 @@
+<?php
+
+// Don't redefine the functions if included multiple times.
+if (false == function_exists('Enqueue\dsn_to_connection_factory')) {
+    require __DIR__.'/functions.php';
+}


### PR DESCRIPTION
```php
<?php
namespace Enqueue;

/**
 * amqp://
 * amqp://user:pass@example.com:10000/%2f
 * file://foo/bar/baz
 * null://
 *
 * and others redis, amazon sqs, stomp, mysql+doctrine etc
 */
$c = dsn_to_context('amqp://');

// These functions are  not a part of this PR but could be added later. Just an example of how dsn_to_context could be used. 
send_to_queue($c, 'a_queue_name', 'Hello world');

$message = receive($c);
```