### PR TITLE
[client] SpoolProducer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
     "symfony/monolog-bundle": "^2.8|^3",
     "symfony/browser-kit": "^2.8|^3",
     "symfony/expression-language": "^2.8|^3",
+    "symfony/event-dispatcher": "^2.8|^3",
+    "symfony/console": "^2.8|^3",
     "friendsofphp/php-cs-fixer": "^2",
     "empi89/php-amqp-stubs": "*@dev",
     "phpstan/phpstan": "^0.7.0"

--- a/docs/bundle/message_producer.md
+++ b/docs/bundle/message_producer.md
@@ -1,0 +1,51 @@
+# Message producer
+
+You can choose how to send messages either using a transport directly or with the client. 
+Transport gives you the access to all transport specific features so you can tune things where the client provides you with easy to use abstraction.
+ 
+## Transport
+ 
+```php
+<?php
+
+/** @var Symfony\Component\DependencyInjection\ContainerInterface $container */
+
+/** @var Enqueue\Psr\PsrContext $context */
+$context = $container->get('enqueue.transport.context');
+
+$context->createProducer()->send(
+    $context->createQueue('a_queue'),
+    $context->createMessage('Hello there!')
+);
+```
+
+## Client
+
+The client is shipped with two types of producers. The first one sends messages immediately 
+where another one (it is called spool producer) collects them in memory and sends them `onTerminate` event (the response is already sent).
+
+
+  
+```php
+<?php
+
+/** @var Symfony\Component\DependencyInjection\ContainerInterface $container */
+
+/** @var \Enqueue\Client\ProducerInterface $producer */
+$producer = $container->get('enqueue.producer');
+
+// message is being sent right now
+$producer->send('a_topic', 'Hello there!');
+
+
+/** @var \Enqueue\Client\SpoolProducer $spoolProducer */
+$spoolProducer = $container->get('enqueue.spool_producer');
+
+// message is being sent on console.terminate or kernel.terminate event
+$spoolProducer->send('a_topic', 'Hello there!');
+
+// you could send queued messages manually by calling flush method 
+$spoolProducer->flush();
+```
+
+[back to index](../index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@
     - [Quick tour](bundle/quick_tour.md)
     - [Config reference](bundle/config_reference.md)
     - [Cli commands](bundle/cli_commands.md)
+    - [Message producer](bundle/message_producer.md)
     - [Message processor](bundle/message_processor.md)
     - [Job queue](bundle/job_queue.md)
     - [Consumption extension](bundle/consumption_extension.md)

--- a/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
+++ b/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
@@ -64,6 +64,7 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
 
         if (isset($config['client'])) {
             $loader->load('client.yml');
+            $loader->load('extensions/flush_spool_producer_extension.yml');
 
             foreach ($config['transport'] as $name => $transportConfig) {
                 $this->factories[$name]->createDriver($container, $transportConfig);
@@ -88,10 +89,10 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
             $container->setParameter('enqueue.client.default_queue_name', $config['client']['default_processor_queue']);
 
             if (false == empty($config['client']['traceable_producer'])) {
-                $producerId = 'enqueue.client.traceable_message_producer';
+                $producerId = 'enqueue.client.traceable_producer';
                 $container->register($producerId, TraceableProducer::class)
                     ->setDecoratedService('enqueue.client.producer')
-                    ->addArgument(new Reference('enqueue.client.traceable_message_producer.inner'))
+                    ->addArgument(new Reference('enqueue.client.traceable_producer.inner'))
                 ;
             }
 

--- a/pkg/enqueue-bundle/Resources/config/client.yml
+++ b/pkg/enqueue-bundle/Resources/config/client.yml
@@ -9,6 +9,11 @@ services:
             - '@enqueue.client.driver'
             - '@enqueue.client.extensions'
 
+    enqueue.client.spool_producer:
+        class: 'Enqueue\Client\SpoolProducer'
+        arguments:
+            - '@enqueue.client.producer'
+
     enqueue.client.extensions:
         class: 'Enqueue\Client\ChainExtension'
         public: false
@@ -17,6 +22,9 @@ services:
 
     enqueue.producer:
         alias: 'enqueue.client.producer'
+
+    enqueue.spool_producer:
+        alias: 'enqueue.client.spool_producer'
 
     enqueue.client.rpc_client:
         class: 'Enqueue\Client\RpcClient'
@@ -123,3 +131,10 @@ services:
               name: 'data_collector'
               template: 'EnqueueBundle:Profiler:panel.html.twig'
               id: 'enqueue.message_queue'
+
+    enqueue.flush_spool_producer_listener:
+        class: 'Enqueue\Symfony\Client\FlushSpoolProducerListener'
+        arguments:
+            - '@enqueue.client.spool_producer'
+        tags:
+            - { name: 'kernel.event_subscriber' }

--- a/pkg/enqueue-bundle/Resources/config/extensions/flush_spool_producer_extension.yml
+++ b/pkg/enqueue-bundle/Resources/config/extensions/flush_spool_producer_extension.yml
@@ -1,0 +1,8 @@
+services:
+    enqueue.client.flush_spool_producer_extension:
+        class: 'Enqueue\Client\ConsumptionExtension\FlushSpoolProducerExtension'
+        public: false
+        arguments:
+            - '@enqueue.client.spool_producer'
+        tags:
+            - { name: 'enqueue.consumption.extension', priority: -100 }

--- a/pkg/enqueue-bundle/Tests/Functional/Client/SpoolProducerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Client/SpoolProducerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Enqueue\Bundle\Tests\Functional\Client;
+
+use Enqueue\Bundle\Tests\Functional\WebTestCase;
+use Enqueue\Client\SpoolProducer;
+
+/**
+ * @group functional
+ */
+class SpoolProducerTest extends WebTestCase
+{
+    public function testCouldBeGetFromContainerAsService()
+    {
+        $producer = $this->container->get('enqueue.client.spool_producer');
+
+        $this->assertInstanceOf(SpoolProducer::class, $producer);
+    }
+
+    public function testCouldBeGetFromContainerAsShortenAlias()
+    {
+        $producer = $this->container->get('enqueue.client.spool_producer');
+        $aliasProducer = $this->container->get('enqueue.spool_producer');
+
+        $this->assertSame($producer, $aliasProducer);
+    }
+}

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
@@ -246,7 +246,7 @@ class EnqueueExtensionTest extends TestCase
             ],
         ]], $container);
 
-        $producer = $container->getDefinition('enqueue.client.traceable_message_producer');
+        $producer = $container->getDefinition('enqueue.client.traceable_producer');
         self::assertEquals(TraceableProducer::class, $producer->getClass());
         self::assertEquals(
             ['enqueue.client.producer', null, 0],
@@ -255,7 +255,7 @@ class EnqueueExtensionTest extends TestCase
 
         self::assertInstanceOf(Reference::class, $producer->getArgument(0));
         self::assertEquals(
-            'enqueue.client.traceable_message_producer.inner',
+            'enqueue.client.traceable_producer.inner',
             (string) $producer->getArgument(0)
         );
     }

--- a/pkg/enqueue/Client/ConsumptionExtension/FlushSpoolProducerExtension.php
+++ b/pkg/enqueue/Client/ConsumptionExtension/FlushSpoolProducerExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Enqueue\Client\ConsumptionExtension;
+
+use Enqueue\Client\SpoolProducer;
+use Enqueue\Consumption\Context;
+use Enqueue\Consumption\EmptyExtensionTrait;
+use Enqueue\Consumption\ExtensionInterface;
+
+class FlushSpoolProducerExtension implements ExtensionInterface
+{
+    use EmptyExtensionTrait;
+
+    /**
+     * @var SpoolProducer
+     */
+    private $producer;
+
+    /**
+     * @param SpoolProducer $producer
+     */
+    public function __construct(SpoolProducer $producer)
+    {
+        $this->producer = $producer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onPostReceived(Context $context)
+    {
+        $this->producer->flush();
+    }
+
+    public function onInterrupted(Context $context)
+    {
+        $this->producer->flush();
+    }
+}

--- a/pkg/enqueue/Client/SpoolProducer.php
+++ b/pkg/enqueue/Client/SpoolProducer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Enqueue\Client;
+
+class SpoolProducer implements ProducerInterface
+{
+    /**
+     * @var ProducerInterface
+     */
+    private $realProducer;
+
+    /**
+     * @var array
+     */
+    private $queue;
+
+    /**
+     * @param ProducerInterface $realProducer
+     */
+    public function __construct(ProducerInterface $realProducer)
+    {
+        $this->realProducer = $realProducer;
+
+        $this->queue = new \SplQueue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send($topic, $message)
+    {
+        $this->queue->enqueue([$topic, $message]);
+    }
+
+    /**
+     * When it is called it sends all previously queued messages.
+     */
+    public function flush()
+    {
+        while (false == $this->queue->isEmpty()) {
+            list($topic, $message) = $this->queue->dequeue();
+
+            $this->realProducer->send($topic, $message);
+        }
+    }
+}

--- a/pkg/enqueue/Symfony/Client/FlushSpoolProducerListener.php
+++ b/pkg/enqueue/Symfony/Client/FlushSpoolProducerListener.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Enqueue\Symfony\Client;
+
+use Enqueue\Client\SpoolProducer;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class FlushSpoolProducerListener implements EventSubscriberInterface
+{
+    /**
+     * @var SpoolProducer
+     */
+    private $producer;
+
+    /**
+     * @param SpoolProducer $producer
+     */
+    public function __construct(SpoolProducer $producer)
+    {
+        $this->producer = $producer;
+    }
+
+    public function flushMessages()
+    {
+        $this->producer->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        $events = [];
+
+        if (class_exists(KernelEvents::class)) {
+            $events[KernelEvents::TERMINATE] = 'flushMessages';
+        }
+
+        if (class_exists(ConsoleEvents::class)) {
+            $events[ConsoleEvents::TERMINATE] = 'flushMessages';
+        }
+
+        return $events;
+    }
+}

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/FlushSpoolProducerExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/FlushSpoolProducerExtensionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Enqueue\Tests\Client\ConsumptionExtension;
+
+use Enqueue\Client\ConsumptionExtension\FlushSpoolProducerExtension;
+use Enqueue\Client\SpoolProducer;
+use Enqueue\Consumption\Context;
+use Enqueue\Consumption\ExtensionInterface;
+use Enqueue\Test\ClassExtensionTrait;
+use PHPUnit\Framework\TestCase;
+
+class FlushSpoolProducerExtensionTest extends TestCase
+{
+    use ClassExtensionTrait;
+
+    public function testShouldImplementExtensionInterface()
+    {
+        $this->assertClassImplements(ExtensionInterface::class, FlushSpoolProducerExtension::class);
+    }
+
+    public function testCouldBeConstructedWithSpoolProducerAsFirstArgument()
+    {
+        new FlushSpoolProducerExtension($this->createSpoolProducerMock());
+    }
+
+    public function testShouldDoNothingOnStart()
+    {
+        $producer = $this->createSpoolProducerMock();
+        $producer
+            ->expects(self::never())
+            ->method('flush')
+        ;
+
+        $extension = new FlushSpoolProducerExtension($producer);
+        $extension->onStart($this->createContextMock());
+    }
+
+    public function testShouldDoNothingOnBeforeReceive()
+    {
+        $producer = $this->createSpoolProducerMock();
+        $producer
+            ->expects(self::never())
+            ->method('flush')
+        ;
+
+        $extension = new FlushSpoolProducerExtension($producer);
+        $extension->onBeforeReceive($this->createContextMock());
+    }
+
+    public function testShouldDoNothingOnPreReceived()
+    {
+        $producer = $this->createSpoolProducerMock();
+        $producer
+            ->expects(self::never())
+            ->method('flush')
+        ;
+
+        $extension = new FlushSpoolProducerExtension($producer);
+        $extension->onPreReceived($this->createContextMock());
+    }
+
+    public function testShouldDoNothingOnResult()
+    {
+        $producer = $this->createSpoolProducerMock();
+        $producer
+            ->expects(self::never())
+            ->method('flush')
+        ;
+
+        $extension = new FlushSpoolProducerExtension($producer);
+        $extension->onResult($this->createContextMock());
+    }
+
+    public function testShouldDoNothingOnIdle()
+    {
+        $producer = $this->createSpoolProducerMock();
+        $producer
+            ->expects(self::never())
+            ->method('flush')
+        ;
+
+        $extension = new FlushSpoolProducerExtension($producer);
+        $extension->onIdle($this->createContextMock());
+    }
+
+    public function testShouldFlushSpoolProducerOnInterrupted()
+    {
+        $producer = $this->createSpoolProducerMock();
+        $producer
+            ->expects(self::once())
+            ->method('flush')
+        ;
+
+        $extension = new FlushSpoolProducerExtension($producer);
+        $extension->onInterrupted($this->createContextMock());
+    }
+
+    public function testShouldFlushSpoolProducerOnPostReceived()
+    {
+        $producer = $this->createSpoolProducerMock();
+        $producer
+            ->expects(self::once())
+            ->method('flush')
+        ;
+
+        $extension = new FlushSpoolProducerExtension($producer);
+        $extension->onPostReceived($this->createContextMock());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Context
+     */
+    private function createContextMock()
+    {
+        return $this->createMock(Context::class);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|SpoolProducer
+     */
+    private function createSpoolProducerMock()
+    {
+        return $this->createMock(SpoolProducer::class);
+    }
+}

--- a/pkg/enqueue/Tests/Client/SpoolProducerTest.php
+++ b/pkg/enqueue/Tests/Client/SpoolProducerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Enqueue\Tests\Client;
+
+use Enqueue\Client\Message;
+use Enqueue\Client\ProducerInterface;
+use Enqueue\Client\SpoolProducer;
+use Enqueue\Test\ClassExtensionTrait;
+use PHPUnit\Framework\TestCase;
+
+class SpoolProducerTest extends TestCase
+{
+    use ClassExtensionTrait;
+
+    public function testShouldImplementProducerInterface()
+    {
+        self::assertClassImplements(ProducerInterface::class, SpoolProducer::class);
+    }
+
+    public function testCouldBeConstructedWithRealProducer()
+    {
+        new SpoolProducer($this->createProducerMock());
+    }
+
+    public function testShouldQueueMessageOnSend()
+    {
+        $message = new Message();
+
+        $realProducer = $this->createProducerMock();
+        $realProducer
+            ->expects($this->never())
+            ->method('send')
+        ;
+
+        $producer = new SpoolProducer($realProducer);
+        $producer->send('foo_topic', $message);
+        $producer->send('bar_topic', $message);
+    }
+
+    public function testShouldSendQueuedMessagesOnFlush()
+    {
+        $message = new Message();
+        $message->setScope('third');
+
+        $realProducer = $this->createProducerMock();
+        $realProducer
+            ->expects($this->at(0))
+            ->method('send')
+            ->with('foo_topic', 'first')
+        ;
+        $realProducer
+            ->expects($this->at(1))
+            ->method('send')
+            ->with('bar_topic', ['second'])
+        ;
+        $realProducer
+            ->expects($this->at(2))
+            ->method('send')
+            ->with('baz_topic', $this->identicalTo($message))
+        ;
+
+        $producer = new SpoolProducer($realProducer);
+
+        $producer->send('foo_topic', 'first');
+        $producer->send('bar_topic', ['second']);
+        $producer->send('baz_topic', $message);
+
+        $producer->flush();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ProducerInterface
+     */
+    protected function createProducerMock()
+    {
+        return $this->createMock(ProducerInterface::class);
+    }
+}

--- a/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Enqueue\Tests\Symfony;
+
+use Enqueue\Client\SpoolProducer;
+use Enqueue\Symfony\Client\FlushSpoolProducerListener;
+use Enqueue\Test\ClassExtensionTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class FlushSpoolProducerListenerTest extends TestCase
+{
+    use ClassExtensionTrait;
+
+    public function testShouldImplementEventSubscriberInterface()
+    {
+        $this->assertClassImplements(EventSubscriberInterface::class, FlushSpoolProducerListener::class);
+    }
+
+    public function testShouldSubscribeOnKernelTerminateEvent()
+    {
+        $events = FlushSpoolProducerListener::getSubscribedEvents();
+
+        $this->assertInternalType('array', $events);
+        $this->assertArrayHasKey(KernelEvents::TERMINATE, $events);
+
+        $this->assertEquals('flushMessages', $events[KernelEvents::TERMINATE]);
+    }
+
+    public function testShouldSubscribeOnConsoleTerminateEvent()
+    {
+        $events = FlushSpoolProducerListener::getSubscribedEvents();
+
+        $this->assertInternalType('array', $events);
+        $this->assertArrayHasKey(ConsoleEvents::TERMINATE, $events);
+
+        $this->assertEquals('flushMessages', $events[ConsoleEvents::TERMINATE]);
+    }
+
+    public function testCouldBeConstructedWithSpoolProducerAsFirstArgument()
+    {
+        new FlushSpoolProducerListener($this->createSpoolProducerMock());
+    }
+
+    public function testShouldFlushSpoolProducerOnFlushMessagesCall()
+    {
+        $producerMock = $this->createSpoolProducerMock();
+        $producerMock
+            ->expects($this->once())
+            ->method('flush')
+        ;
+
+        $listener = new FlushSpoolProducerListener($producerMock);
+
+        $listener->flushMessages();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|SpoolProducer
+     */
+    private function createSpoolProducerMock()
+    {
+        return $this->createMock(SpoolProducer::class);
+    }
+}

--- a/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enqueue\Tests\Symfony;
+namespace Enqueue\Tests\Symfony\Client;
 
 use Enqueue\Client\SpoolProducer;
 use Enqueue\Symfony\Client\FlushSpoolProducerListener;

--- a/pkg/enqueue/composer.json
+++ b/pkg/enqueue/composer.json
@@ -21,6 +21,7 @@
         "symfony/console": "^2.8|^3",
         "symfony/dependency-injection": "^2.8|^3",
         "symfony/config": "^2.8|^3",
+        "symfony/event-dispatcher": "^2.8|^3",
         "enqueue/amqp-ext": "^0.4",
         "enqueue/fs": "^0.4",
         "enqueue/test": "^0.4",


### PR DESCRIPTION
fixes https://github.com/php-enqueue/enqueue-dev/issues/91, required by https://github.com/php-enqueue/enqueue-dev/pull/86

For Symfony developers, it works just out of the box. The spool producer (enqueue.spool_producer service) is flushed on `kernel.terminate` and `console.terminate` events.