### PR TITLE
[RFC][client] Add ability to send events or commands.

### DIFF
--- a/pkg/enqueue-bundle/DependencyInjection/Compiler/ExtractProcessorTagSubscriptionsTrait.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Compiler/ExtractProcessorTagSubscriptionsTrait.php
@@ -50,7 +50,7 @@ trait ExtractProcessorTagSubscriptionsTrait
             $params = $processorClass::getSubscribedCommand();
             if (is_string($params)) {
                 if (empty($params)) {
-                    throw new \LogicException('The command name must not be empty');
+                    throw new \LogicException('The processor name (it is also the command name) must not be empty.');
                 }
 
                 $data[] = [
@@ -61,8 +61,7 @@ trait ExtractProcessorTagSubscriptionsTrait
                 ];
             } elseif (is_array($params)) {
                 $params = array_replace($subscriptionPrototype, $params);
-
-                if ($processorName = $resolve($params['processorName'])) {
+                if (false == $processorName = $resolve($params['processorName'])) {
                     throw new \LogicException('The processor name (it is also the command name) must not be empty.');
                 }
 

--- a/pkg/enqueue-bundle/DependencyInjection/Compiler/ExtractProcessorTagSubscriptionsTrait.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Compiler/ExtractProcessorTagSubscriptionsTrait.php
@@ -2,6 +2,8 @@
 
 namespace Enqueue\Bundle\DependencyInjection\Compiler;
 
+use Enqueue\Client\CommandSubscriberInterface;
+use Enqueue\Client\Config;
 use Enqueue\Client\TopicSubscriberInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
@@ -43,7 +45,43 @@ trait ExtractProcessorTagSubscriptionsTrait
         ];
 
         $data = [];
+        if (is_subclass_of($processorClass, CommandSubscriberInterface::class)) {
+            /** @var CommandSubscriberInterface $processorClass */
+            $params = $processorClass::getSubscribedCommand();
+            if (is_string($params)) {
+                if (empty($params)) {
+                    throw new \LogicException('The command name must not be empty');
+                }
+
+                $data[] = [
+                    'topicName' => Config::COMMAND_TOPIC,
+                    'queueName' => $defaultQueueName,
+                    'queueNameHardcoded' => false,
+                    'processorName' => $params,
+                ];
+            } elseif (is_array($params)) {
+                $params = array_replace($subscriptionPrototype, $params);
+
+                if ($processorName = $resolve($params['processorName'])) {
+                    throw new \LogicException('The processor name (it is also the command name) must not be empty.');
+                }
+
+                $data[] = [
+                    'topicName' => Config::COMMAND_TOPIC,
+                    'queueName' => $resolve($params['queueName']) ?: $defaultQueueName,
+                    'queueNameHardcoded' => $resolve($params['queueNameHardcoded']),
+                    'processorName' => $processorName,
+                ];
+            } else {
+                throw new \LogicException(sprintf(
+                    'Command subscriber configuration is invalid. "%s"',
+                    json_encode($processorClass::getSubscribedCommand())
+                ));
+            }
+        }
+
         if (is_subclass_of($processorClass, TopicSubscriberInterface::class)) {
+            /** @var TopicSubscriberInterface $processorClass */
             foreach ($processorClass::getSubscribedTopics() as $topicName => $params) {
                 if (is_string($params)) {
                     $data[] = [
@@ -68,7 +106,12 @@ trait ExtractProcessorTagSubscriptionsTrait
                     ));
                 }
             }
-        } else {
+        }
+
+        if (false == (
+            is_subclass_of($processorClass, CommandSubscriberInterface::class) ||
+            is_subclass_of($processorClass, TopicSubscriberInterface::class)
+        )) {
             foreach ($tagAttributes as $tagAttribute) {
                 $tagAttribute = array_replace($subscriptionPrototype, $tagAttribute);
 

--- a/pkg/enqueue-bundle/Resources/config/client.yml
+++ b/pkg/enqueue-bundle/Resources/config/client.yml
@@ -23,6 +23,12 @@ services:
     enqueue.producer:
         alias: 'enqueue.client.producer'
 
+    enqueue.client.producer_v2:
+        class: 'Enqueue\Client\ProducerV2'
+        arguments:
+            - '@enqueue.client.producer'
+            - '@enqueue.client.rpc_client'
+
     enqueue.spool_producer:
         alias: 'enqueue.client.spool_producer'
 

--- a/pkg/enqueue-bundle/Tests/Functional/App/TestCommandSubscriberProcessor.php
+++ b/pkg/enqueue-bundle/Tests/Functional/App/TestCommandSubscriberProcessor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Enqueue\Bundle\Tests\Functional\App;
+
+use Enqueue\Client\CommandSubscriberInterface;
+use Enqueue\Consumption\Result;
+use Enqueue\Psr\PsrContext;
+use Enqueue\Psr\PsrMessage;
+use Enqueue\Psr\PsrProcessor;
+
+class TestCommandSubscriberProcessor implements PsrProcessor, CommandSubscriberInterface
+{
+    public $calls = [];
+
+    public function process(PsrMessage $message, PsrContext $context)
+    {
+        $this->calls[] = $message;
+
+        return Result::reply(
+            $context->createMessage($message->getBody().'Reply')
+        );
+    }
+
+    public static function getSubscribedCommand()
+    {
+        return 'test_command_subscriber';
+    }
+}

--- a/pkg/enqueue-bundle/Tests/Functional/App/config/config.yml
+++ b/pkg/enqueue-bundle/Tests/Functional/App/config/config.yml
@@ -47,6 +47,11 @@ services:
         tags:
             - { name: 'kernel.event_listener', async: true, event: 'test_async', method: 'onEvent' }
 
+    test_command_subscriber_processor:
+        class: 'Enqueue\Bundle\Tests\Functional\App\TestCommandSubscriberProcessor'
+        tags:
+            - { name: 'enqueue.client.processor' }
+
     test_async_subscriber:
         class: 'Enqueue\Bundle\Tests\Functional\App\TestAsyncSubscriber'
         tags:

--- a/pkg/enqueue-bundle/Tests/Functional/Client/ProducerV2Test.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Client/ProducerV2Test.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Enqueue\Bundle\Tests\Functional\Client;
+
+use Enqueue\Bundle\Tests\Functional\WebTestCase;
+use Enqueue\Client\Config;
+use Enqueue\Client\ProducerV2Interface;
+use Enqueue\Client\TraceableProducer;
+use Enqueue\Rpc\Promise;
+
+/**
+ * @group functional
+ */
+class ProducerV2Test extends WebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->container->get('enqueue.client.producer')->clearTraces();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->container->get('enqueue.client.producer')->clearTraces();
+    }
+
+    public function testCouldBeGetFromContainerAsService()
+    {
+        $producer = $this->container->get('enqueue.client.producer_v2');
+
+        $this->assertInstanceOf(ProducerV2Interface::class, $producer);
+    }
+
+    public function testShouldSendEvent()
+    {
+        /** @var ProducerV2Interface $producer */
+        $producer = $this->container->get('enqueue.client.producer_v2');
+
+        $producer->sendEvent('theTopic', 'theMessage');
+
+        $traces = $this->getTraceableProducer()->getTopicTraces('theTopic');
+
+        $this->assertCount(1, $traces);
+        $this->assertEquals('theMessage', $traces[0]['body']);
+    }
+
+    public function testShouldSendCommandWithoutNeedForReply()
+    {
+        /** @var ProducerV2Interface $producer */
+        $producer = $this->container->get('enqueue.client.producer_v2');
+
+        $result = $producer->sendCommand('theCommand', 'theMessage', false);
+
+        $this->assertNull($result);
+
+        $traces = $this->getTraceableProducer()->getTopicTraces(Config::COMMAND_TOPIC);
+
+        $this->assertCount(1, $traces);
+        $this->assertEquals('theMessage', $traces[0]['body']);
+        $this->assertEquals([
+            'enqueue.topic_name' => Config::COMMAND_TOPIC,
+            'enqueue.processor_name' => 'theCommand',
+            'enqueue.processor_queue_name' => 'default',
+        ], $traces[0]['properties']);
+    }
+
+    public function testShouldSendCommandWithNeedForReply()
+    {
+        /** @var ProducerV2Interface $producer */
+        $producer = $this->container->get('enqueue.client.producer_v2');
+
+        $result = $producer->sendCommand('theCommand', 'theMessage', true);
+
+        $this->assertInstanceOf(Promise::class, $result);
+
+        $traces = $this->getTraceableProducer()->getTopicTraces(Config::COMMAND_TOPIC);
+
+        $this->assertCount(1, $traces);
+        $this->assertEquals('theMessage', $traces[0]['body']);
+        $this->assertEquals([
+            'enqueue.topic_name' => Config::COMMAND_TOPIC,
+            'enqueue.processor_name' => 'theCommand',
+            'enqueue.processor_queue_name' => 'default',
+        ], $traces[0]['properties']);
+    }
+
+    /**
+     * @return TraceableProducer|object
+     */
+    private function getTraceableProducer()
+    {
+        return $this->container->get('enqueue.client.producer');
+    }
+}

--- a/pkg/enqueue-bundle/Tests/Functional/QueuesCommandTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/QueuesCommandTest.php
@@ -30,4 +30,16 @@ class QueuesCommandTest extends WebTestCase
         $this->assertContains('enqueue.app.default', $display);
         $this->assertContains('enqueue.client.router_processor', $display);
     }
+
+    public function testShouldDisplayRegisteredCommand()
+    {
+        $command = $this->container->get('enqueue.client.meta.queues_command');
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $display = $tester->getDisplay();
+
+        $this->assertContains('test_command_subscriber', $display);
+    }
 }

--- a/pkg/enqueue-bundle/Tests/Functional/TopicsCommandTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/TopicsCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\Tests\Functional;
 
+use Enqueue\Client\Config;
 use Enqueue\Symfony\Client\Meta\TopicsCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -28,5 +29,18 @@ class TopicsCommandTest extends WebTestCase
 
         $this->assertContains('__router__', $display);
         $this->assertContains('enqueue.client.router_processor', $display);
+    }
+
+    public function testShouldDisplayCommands()
+    {
+        $command = $this->container->get('enqueue.client.meta.topics_command');
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $display = $tester->getDisplay();
+
+        $this->assertContains(Config::COMMAND_TOPIC, $display);
+        $this->assertContains('test_command_subscriber', $display);
     }
 }

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/EmptyCommandSubscriber.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/EmptyCommandSubscriber.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Enqueue\Bundle\Tests\Unit\DependencyInjection\Compiler\Mock;
+
+use Enqueue\Client\CommandSubscriberInterface;
+
+class EmptyCommandSubscriber implements CommandSubscriberInterface
+{
+    public static function getSubscribedCommand()
+    {
+        return '';
+    }
+}

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/InvalidCommandSubscriber.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/InvalidCommandSubscriber.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Enqueue\Bundle\Tests\Unit\DependencyInjection\Compiler\Mock;
+
+use Enqueue\Client\CommandSubscriberInterface;
+
+class InvalidCommandSubscriber implements CommandSubscriberInterface
+{
+    public static function getSubscribedCommand()
+    {
+        return 12345;
+    }
+}

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/OnlyCommandNameSubscriber.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/OnlyCommandNameSubscriber.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Enqueue\Bundle\Tests\Unit\DependencyInjection\Compiler\Mock;
+
+use Enqueue\Client\CommandSubscriberInterface;
+
+class OnlyCommandNameSubscriber implements CommandSubscriberInterface
+{
+    public static function getSubscribedCommand()
+    {
+        return 'the-command-name';
+    }
+}

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/ProcessorNameCommandSubscriber.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/Compiler/Mock/ProcessorNameCommandSubscriber.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Enqueue\Bundle\Tests\Unit\DependencyInjection\Compiler\Mock;
+
+use Enqueue\Client\CommandSubscriberInterface;
+
+class ProcessorNameCommandSubscriber implements CommandSubscriberInterface
+{
+    public static function getSubscribedCommand()
+    {
+        return [
+            'processorName' => 'the-command-name',
+            'queueName' => 'the-command-queue-name',
+        ];
+    }
+}

--- a/pkg/enqueue/Client/CommandSubscriberInterface.php
+++ b/pkg/enqueue/Client/CommandSubscriberInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Enqueue\Client;
+
+interface CommandSubscriberInterface
+{
+    /**
+     * The result maybe either:.
+     *
+     * 'aCommandName'
+     *
+     * or
+     *
+     * [
+     *   'processorName' => 'aCommandName',
+     *   'queueName' => 'a_client_queue_name',
+     *   'queueNameHardcoded' => true,
+     * ]
+     *
+     * queueName and queueNameHardcoded are optional.
+     *
+     * Note: If you set queueNameHardcoded to true then the queueName is used as is and therefor the driver is not used to create a transport queue name.
+     *
+     * @return string|array
+     */
+    public static function getSubscribedCommand();
+}

--- a/pkg/enqueue/Client/Config.php
+++ b/pkg/enqueue/Client/Config.php
@@ -8,6 +8,7 @@ class Config
     const PARAMETER_PROCESSOR_NAME = 'enqueue.processor_name';
     const PARAMETER_PROCESSOR_QUEUE_NAME = 'enqueue.processor_queue_name';
     const DEFAULT_PROCESSOR_QUEUE_NAME = 'default';
+    const COMMAND_TOPIC = '__command__';
 
     /**
      * @var string

--- a/pkg/enqueue/Client/Producer.php
+++ b/pkg/enqueue/Client/Producer.php
@@ -5,7 +5,7 @@ namespace Enqueue\Client;
 use Enqueue\Util\JSON;
 use Enqueue\Util\UUID;
 
-class Producer implements ProducerInterface, ProducerV2Interface
+class Producer implements ProducerInterface
 {
     /**
      * @var DriverInterface
@@ -18,8 +18,7 @@ class Producer implements ProducerInterface, ProducerV2Interface
     private $extension;
 
     /**
-     * @param DriverInterface         $driver
-     * @param ExtensionInterface|null $extension
+     * @param DriverInterface $driver
      */
     public function __construct(DriverInterface $driver, ExtensionInterface $extension = null)
     {
@@ -79,32 +78,6 @@ class Producer implements ProducerInterface, ProducerV2Interface
         } else {
             throw new \LogicException(sprintf('The message scope "%s" is not supported.', $message->getScope()));
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function sendEvent($topic, $message)
-    {
-        $this->send($topic, $message);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function sendCommand($command, $message)
-    {
-        if (false == $message instanceof Message) {
-            $message = new Message($message);
-        }
-
-        $message->setProperty(Config::PARAMETER_TOPIC_NAME, Config::COMMAND_TOPIC);
-        $message->setProperty(Config::PARAMETER_PROCESSOR_NAME, $command);
-        $message->setScope(Message::SCOPE_APP);
-
-        $this->send('__command__', $message);
-
-        // TODO add support of replies
     }
 
     /**

--- a/pkg/enqueue/Client/ProducerV2.php
+++ b/pkg/enqueue/Client/ProducerV2.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Enqueue\Client;
+
+class ProducerV2 implements ProducerV2Interface
+{
+    /**
+     * @var ProducerInterface
+     */
+    private $realProducer;
+
+    /**
+     * @var RpcClient
+     */
+    private $rpcClient;
+
+    /**
+     * @param ProducerInterface $realProducer
+     * @param RpcClient         $rpcClient
+     */
+    public function __construct(ProducerInterface $realProducer, RpcClient $rpcClient)
+    {
+        $this->realProducer = $realProducer;
+        $this->rpcClient = $rpcClient;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendEvent($topic, $message)
+    {
+        $this->realProducer->send($topic, $message);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendCommand($command, $message)
+    {
+        if (false == $message instanceof Message) {
+            $message = new Message($message);
+        }
+
+        $message->setProperty(Config::PARAMETER_TOPIC_NAME, Config::COMMAND_TOPIC);
+        $message->setProperty(Config::PARAMETER_PROCESSOR_NAME, $command);
+        $message->setScope(Message::SCOPE_APP);
+
+        if ($message->getReplyTo()) {
+            return $this->rpcClient->callAsync(Config::COMMAND_TOPIC, $message, 60);
+        }
+        $this->realProducer->send(Config::COMMAND_TOPIC, $message);
+    }
+}

--- a/pkg/enqueue/Client/ProducerV2.php
+++ b/pkg/enqueue/Client/ProducerV2.php
@@ -2,6 +2,9 @@
 
 namespace Enqueue\Client;
 
+/**
+ * @experimental
+ */
 class ProducerV2 implements ProducerV2Interface
 {
     /**

--- a/pkg/enqueue/Client/ProducerV2.php
+++ b/pkg/enqueue/Client/ProducerV2.php
@@ -38,7 +38,7 @@ class ProducerV2 implements ProducerV2Interface
     /**
      * {@inheritdoc}
      */
-    public function sendCommand($command, $message)
+    public function sendCommand($command, $message, $needReply = false)
     {
         if (false == $message instanceof Message) {
             $message = new Message($message);
@@ -48,9 +48,10 @@ class ProducerV2 implements ProducerV2Interface
         $message->setProperty(Config::PARAMETER_PROCESSOR_NAME, $command);
         $message->setScope(Message::SCOPE_APP);
 
-        if ($message->getReplyTo()) {
+        if ($needReply) {
             return $this->rpcClient->callAsync(Config::COMMAND_TOPIC, $message, 60);
         }
+
         $this->realProducer->send(Config::COMMAND_TOPIC, $message);
     }
 }

--- a/pkg/enqueue/Client/ProducerV2Interface.php
+++ b/pkg/enqueue/Client/ProducerV2Interface.php
@@ -4,19 +4,18 @@ namespace Enqueue\Client;
 
 use Enqueue\Rpc\Promise;
 
+/**
+ * @experimental
+ */
 interface ProducerV2Interface
 {
     /**
-     * @experimental
-     *
      * @param string               $topic
      * @param string|array|Message $message
      */
     public function sendEvent($topic, $message);
 
     /**
-     * @experimental
-     *
      * @param string               $command
      * @param string|array|Message $message
      *

--- a/pkg/enqueue/Client/ProducerV2Interface.php
+++ b/pkg/enqueue/Client/ProducerV2Interface.php
@@ -18,8 +18,9 @@ interface ProducerV2Interface
     /**
      * @param string               $command
      * @param string|array|Message $message
+     * @param bool                 $needReply
      *
      * @return Promise|null the promise is returned if needReply argument is true
      */
-    public function sendCommand($command, $message);
+    public function sendCommand($command, $message, $needReply = false);
 }

--- a/pkg/enqueue/Client/ProducerV2Interface.php
+++ b/pkg/enqueue/Client/ProducerV2Interface.php
@@ -2,6 +2,8 @@
 
 namespace Enqueue\Client;
 
+use Enqueue\Rpc\Promise;
+
 interface ProducerV2Interface
 {
     /**
@@ -17,6 +19,8 @@ interface ProducerV2Interface
      *
      * @param string               $command
      * @param string|array|Message $message
+     *
+     * @return Promise|null the promise is returned if message has reply to set
      */
     public function sendCommand($command, $message);
 }

--- a/pkg/enqueue/Client/ProducerV2Interface.php
+++ b/pkg/enqueue/Client/ProducerV2Interface.php
@@ -19,7 +19,7 @@ interface ProducerV2Interface
      * @param string               $command
      * @param string|array|Message $message
      *
-     * @return Promise|null the promise is returned if message has reply to set
+     * @return Promise|null the promise is returned if needReply argument is true
      */
     public function sendCommand($command, $message);
 }

--- a/pkg/enqueue/Client/ProducerV2Interface.php
+++ b/pkg/enqueue/Client/ProducerV2Interface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Enqueue\Client;
+
+interface ProducerV2Interface
+{
+    /**
+     * @experimental
+     *
+     * @param string               $topic
+     * @param string|array|Message $message
+     */
+    public function sendEvent($topic, $message);
+
+    /**
+     * @experimental
+     *
+     * @param string               $command
+     * @param string|array|Message $message
+     */
+    public function sendCommand($command, $message);
+}

--- a/pkg/enqueue/Client/RouterProcessor.php
+++ b/pkg/enqueue/Client/RouterProcessor.php
@@ -20,6 +20,11 @@ class RouterProcessor implements PsrProcessor
     private $routes;
 
     /**
+     * @var array
+     */
+    private $commands;
+
+    /**
      * @param DriverInterface $driver
      * @param array           $routes
      */
@@ -36,7 +41,11 @@ class RouterProcessor implements PsrProcessor
      */
     public function add($topicName, $queueName, $processorName)
     {
-        $this->routes[$topicName][] = [$processorName, $queueName];
+        if (Config::COMMAND_TOPIC === $topicName) {
+            $this->commands[$processorName] = $queueName;
+        } else {
+            $this->routes[$topicName][] = [$processorName, $queueName];
+        }
     }
 
     /**
@@ -52,6 +61,22 @@ class RouterProcessor implements PsrProcessor
             ));
         }
 
+        if (Config::COMMAND_TOPIC === $topicName) {
+            return $this->routeCommand($message);
+        }
+
+        return $this->routeEvent($message);
+    }
+
+    /**
+     * @param PsrMessage $message
+     *
+     * @return string|Result
+     */
+    private function routeEvent(PsrMessage $message)
+    {
+        $topicName = $message->getProperty(Config::PARAMETER_TOPIC_NAME);
+
         if (array_key_exists($topicName, $this->routes)) {
             foreach ($this->routes[$topicName] as $route) {
                 $processorMessage = clone $message;
@@ -60,6 +85,31 @@ class RouterProcessor implements PsrProcessor
 
                 $this->driver->sendToProcessor($this->driver->createClientMessage($processorMessage));
             }
+        }
+
+        return self::ACK;
+    }
+
+    /**
+     * @param PsrMessage $message
+     *
+     * @return string|Result
+     */
+    private function routeCommand(PsrMessage $message)
+    {
+        $processorName = $message->getProperty(Config::PARAMETER_PROCESSOR_NAME);
+        if (false == $processorName) {
+            return Result::reject(sprintf(
+                'Got message without required parameter: "%s"',
+                Config::PARAMETER_PROCESSOR_NAME
+            ));
+        }
+
+        if (isset($this->commands[$processorName])) {
+            $processorMessage = clone $message;
+            $processorMessage->setProperty(Config::PARAMETER_PROCESSOR_QUEUE_NAME, $this->commands[$processorName]);
+
+            $this->driver->sendToProcessor($this->driver->createClientMessage($processorMessage));
         }
 
         return self::ACK;

--- a/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
@@ -48,7 +48,7 @@ class StompCommonUseCasesTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($message);
 
         $this->assertGreaterThan(1.5, $endAt - $startAt);
-        $this->assertLessThan(2.5, $endAt - $startAt);
+        $this->assertLessThan(3, $endAt - $startAt);
     }
 
     public function testReturnNullImmediatelyOnReceiveNoWait()


### PR DESCRIPTION
* Events 1 to many
* Commands 1 to 1 with possibility to get result (optionally)

ref https://github.com/php-enqueue/enqueue-dev/issues/105

A few examples:

* Send an event (same as before except the method name, instead of calling `send` use `sendEvent`.

```php
<?php

namespace Acme;
use Enqueue\Client\TopicSubscriberInterface;
use Enqueue\Psr\PsrContext;
use Enqueue\Psr\PsrMessage;
use Enqueue\Psr\PsrProcessor;

/** @var \Enqueue\Client\ProducerV2Interface $producer */

class FooProcessor implements PsrProcessor, TopicSubscriberInterface
{
    public function process(PsrMessage $message, PsrContext $context)
    {
        return self::ACK;
    }

    public static function getSubscribedTopics()
    {
        return ['aFooTopic'];
    }
}

$producer->sendEvent('aFooTopic', 'aMessage');
```

* Send command. Fire and forget scenario

```php
<?php

namespace Acme;
use Enqueue\Client\CommandSubscriberInterface;
use Enqueue\Psr\PsrContext;
use Enqueue\Psr\PsrMessage;
use Enqueue\Psr\PsrProcessor;

class FooProcessor implements PsrProcessor, CommandSubscriberInterface
{
    public function process(PsrMessage $message, PsrContext $context)
    {
        return self::ACK;
    }

    public static function getSubscribedCommand()
    {
        return 'aFooCommand';
    }
}

/** @var \Enqueue\Client\ProducerV2Interface $producer */
$producer->sendCommand('aFooCommand', 'aMessage');
```

* Send command and wait for response (non blocking)

```php
<?php
namespace Acme;

use Enqueue\Client\CommandSubscriberInterface;
use Enqueue\Client\Message;
use Enqueue\Consumption\Result;
use Enqueue\Psr\PsrContext;
use Enqueue\Psr\PsrMessage;
use Enqueue\Psr\PsrProcessor;

class FooProcessor implements PsrProcessor, CommandSubscriberInterface
{
    public function process(PsrMessage $message, PsrContext $context)
    {
        return Result::reply($context->createMessage('theReplyMessage'));
    }

    public static function getSubscribedCommand()
    {
        return 'aFooCommand';
    }
}

$message = new Message('aMessage');
$message->setReplyTo('theReplyQueue');

/** @var \Enqueue\Client\ProducerV2Interface $producer */
$promise = $producer->sendCommand('aFooCommand', $message);

$promise->setTimeout(10);
$replyMessage = $promise->getMessage(); // only here's the execution is blocked
```