### PR TITLE
[client] Use default as router topic.

### DIFF
--- a/pkg/enqueue-bundle/DependencyInjection/Configuration.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('traceable_producer')->defaultFalse()->end()
                 ->scalarNode('prefix')->defaultValue('enqueue')->end()
                 ->scalarNode('app_name')->defaultValue('app')->end()
-                ->scalarNode('router_topic')->defaultValue('router')->cannotBeEmpty()->end()
+                ->scalarNode('router_topic')->defaultValue(Config::DEFAULT_PROCESSOR_QUEUE_NAME)->cannotBeEmpty()->end()
                 ->scalarNode('router_queue')->defaultValue(Config::DEFAULT_PROCESSOR_QUEUE_NAME)->cannotBeEmpty()->end()
                 ->scalarNode('router_processor')->defaultValue('enqueue.client.router_processor')->end()
                 ->scalarNode('default_processor_queue')->defaultValue(Config::DEFAULT_PROCESSOR_QUEUE_NAME)->cannotBeEmpty()->end()

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -145,7 +145,7 @@ class ConfigurationTest extends TestCase
                 'prefix' => 'enqueue',
                 'app_name' => 'app',
                 'router_processor' => 'enqueue.client.router_processor',
-                'router_topic' => 'router',
+                'router_topic' => 'default',
                 'router_queue' => 'default',
                 'default_processor_queue' => 'default',
                 'traceable_producer' => false,

--- a/pkg/simple-client/SimpleClientContainerExtension.php
+++ b/pkg/simple-client/SimpleClientContainerExtension.php
@@ -172,7 +172,7 @@ class SimpleClientContainerExtension extends Extension
             ->arrayNode('client')->children()
                 ->scalarNode('prefix')->defaultValue('enqueue')->end()
                 ->scalarNode('app_name')->defaultValue('app')->end()
-                ->scalarNode('router_topic')->defaultValue('router')->cannotBeEmpty()->end()
+                ->scalarNode('router_topic')->defaultValue(Config::DEFAULT_PROCESSOR_QUEUE_NAME)->cannotBeEmpty()->end()
                 ->scalarNode('router_queue')->defaultValue(Config::DEFAULT_PROCESSOR_QUEUE_NAME)->cannotBeEmpty()->end()
                 ->scalarNode('default_processor_queue')->defaultValue(Config::DEFAULT_PROCESSOR_QUEUE_NAME)->cannotBeEmpty()->end()
                 ->integerNode('redelivered_delay_time')->min(0)->defaultValue(0)->end()

--- a/pkg/test/RetryTrait.php
+++ b/pkg/test/RetryTrait.php
@@ -14,6 +14,12 @@ trait RetryTrait
                 parent::runBare();
 
                 return;
+            } catch (\PHPUnit_Framework_IncompleteTestError $e) {
+                throw $e;
+            } catch (\PHPUnit_Framework_SkippedTestError $e) {
+                throw $e;
+            } catch (\Throwable $e) {
+                // last one thrown below
             } catch (\Exception $e) {
                 // last one thrown below
             }


### PR DESCRIPTION
It fixes issues with fs transport when client's default config is used.

fixes https://github.com/php-enqueue/enqueue-dev/issues/135