### PR TITLE
Fix compilation of command routes.

### DIFF
--- a/pkg/enqueue-bundle/DependencyInjection/Compiler/BuildClientRoutingPass.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Compiler/BuildClientRoutingPass.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\DependencyInjection\Compiler;
 
+use Enqueue\Client\Config;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -35,5 +36,15 @@ class BuildClientRoutingPass implements CompilerPassInterface
 
         $router = $container->getDefinition($routerId);
         $router->replaceArgument(1, $configs);
+
+        if (isset($configs[Config::COMMAND_TOPIC])) {
+            $commandRoutes = [];
+
+            foreach ($configs[Config::COMMAND_TOPIC] as $command) {
+                $commandRoutes[$command[0]] = $command[1];
+            }
+
+            $router->replaceArgument(2, $commandRoutes);
+        }
     }
 }

--- a/pkg/enqueue-bundle/Resources/config/client.yml
+++ b/pkg/enqueue-bundle/Resources/config/client.yml
@@ -42,6 +42,7 @@ services:
         arguments:
             - '@enqueue.client.driver'
             - []
+            - []
         tags:
             -
                 name: 'enqueue.client.processor'


### PR DESCRIPTION
All subscriptions were being added as event routes meaning that
RouterProcessor::routeCommand() wouldn't do anything as commandRoutes
were appearing empty. This fixes that by checking to see if command
subscriptions exist and extracting them into the commandRoutes argument
on RouterProcessor.

Relates to: https://github.com/php-enqueue/enqueue-dev/issues/160