### PR TITLE
Remove maxDepth option on profiler dump.

### DIFF
--- a/pkg/enqueue-bundle/Resources/views/Profiler/panel.html.twig
+++ b/pkg/enqueue-bundle/Resources/views/Profiler/panel.html.twig
@@ -30,7 +30,7 @@
                             <span>{{ sentMessage.body[0:40] }}... </span><a class="btn btn-link text-small sf-toggle" data-toggle-selector="#message-body-{{ loop.index }}" data-toggle-alt-content="Hide trace">Show trace</a>
 
                             <div id="message-body-{{ loop.index }}" class="context sf-toggle-content sf-toggle-hidden">
-                                {{ profiler_dump(sentMessage.body, maxDepth=1) }}
+                                {{ profiler_dump(sentMessage.body) }}
                             </div>
                         </span>
                     <td><span title="{{ sentMessage.priority }}">{{ collector.prettyPrintPriority(sentMessage.priority) }}</span></td>


### PR DESCRIPTION
MaxDepth was introduced in Symfony 3.2 so to maintain 2.8 compatibility
we should remove this option.

Fixes: #158