### PR TITLE
Add FIFO support to Amazon SQS package

### DIFF
--- a/pkg/sqs/Client/SqsDriver.php
+++ b/pkg/sqs/Client/SqsDriver.php
@@ -85,7 +85,7 @@ class SqsDriver implements DriverInterface
     public function createQueue($queueName)
     {
         $transportName = $this->queueMetaRegistry->getQueueMeta($queueName)->getTransportName();
-        $transportName = str_replace('.', '_dot_', $transportName);
+        $transportName = preg_replace('/\.(?!fifo)/', '_dot_', $transportName);
 
         return $this->context->createQueue($transportName);
     }

--- a/pkg/sqs/Client/SqsDriver.php
+++ b/pkg/sqs/Client/SqsDriver.php
@@ -135,6 +135,11 @@ class SqsDriver implements DriverInterface
         $transportMessage->setReplyTo($message->getReplyTo());
         $transportMessage->setCorrelationId($message->getCorrelationId());
 
+        if (preg_match('/(\.fifo)$/', $message->getProperty(Config::PARAMETER_PROCESSOR_QUEUE_NAME))) {
+            $transportMessage->setMessageGroupId(md5(__METHOD__));
+            $transportMessage->setMessageDeduplicationId(md5($message->getBody()));
+        }
+
         return $transportMessage;
     }
 

--- a/pkg/sqs/Tests/Client/SqsDriverTest.php
+++ b/pkg/sqs/Tests/Client/SqsDriverTest.php
@@ -62,6 +62,28 @@ class SqsDriverTest extends TestCase
         $this->assertSame('aQueueName', $queue->getQueueName());
     }
 
+    /**
+     * @group fifo
+     */
+    public function testShouldCreateAndReturnAFIFOQueueInstance()
+    {
+        $expectedQueue = new SqsDestination('aQueueName.fifo');
+
+        $context = $this->createPsrContextMock();
+        $context
+            ->expects($this->once())
+            ->method('createQueue')
+            ->with('aprefix_dot_afooqueue.fifo')
+            ->willReturn($expectedQueue)
+        ;
+
+        $driver = new SqsDriver($context, $this->createDummyConfig(), $this->createDummyQueueMetaRegistry());
+        $queue = $driver->createQueue('aFooQueue.fifo');
+
+        $this->assertSame($expectedQueue, $queue);
+        $this->assertSame('aQueueName.fifo', $queue->getQueueName());
+    }
+
     public function testShouldCreateAndReturnQueueInstanceWithHardcodedTransportName()
     {
         $expectedQueue = new SqsDestination('aQueueName');
@@ -401,6 +423,7 @@ class SqsDriverTest extends TestCase
         $registry = new QueueMetaRegistry($this->createDummyConfig(), []);
         $registry->add('default');
         $registry->add('aFooQueue');
+        $registry->add('aFooQueue.fifo');
         $registry->add('aBarQueue', 'aBarQueue');
 
         return $registry;

--- a/pkg/sqs/Tests/Client/SqsDriverTest.php
+++ b/pkg/sqs/Tests/Client/SqsDriverTest.php
@@ -195,6 +195,61 @@ class SqsDriverTest extends TestCase
         $this->assertSame('theCorrelationId', $transportMessage->getCorrelationId());
     }
 
+    /**
+     * @group fifo
+     */
+    public function testShouldConvertClientMessageToTransportMessageForAFIFOQueue()
+    {
+        $clientMessage = new Message();
+        $clientMessage->setBody('body');
+        $clientMessage->setHeaders(['hkey' => 'hval']);
+        $clientMessage->setProperties([
+             Config::PARAMETER_PROCESSOR_QUEUE_NAME => 'aQueueName.fifo',
+         ]);
+        $clientMessage->setContentType('ContentType');
+        $clientMessage->setExpire(123);
+        $clientMessage->setPriority(MessagePriority::VERY_HIGH);
+        $clientMessage->setMessageId('MessageId');
+        $clientMessage->setTimestamp(1000);
+        $clientMessage->setReplyTo('theReplyTo');
+        $clientMessage->setCorrelationId('theCorrelationId');
+
+        $context = $this->createPsrContextMock();
+        $context
+             ->expects($this->once())
+             ->method('createMessage')
+             ->willReturn(new SqsMessage())
+         ;
+
+        $driver = new SqsDriver(
+             $context,
+             Config::create(),
+             $this->createQueueMetaRegistryMock()
+         );
+
+        $transportMessage = $driver->createTransportMessage($clientMessage);
+
+        $this->assertInstanceOf(SqsMessage::class, $transportMessage);
+        $this->assertSame('body', $transportMessage->getBody());
+        $this->assertSame([
+             'hkey' => 'hval',
+             'content_type' => 'ContentType',
+             'message_id' => 'MessageId',
+             'timestamp' => 1000,
+             'reply_to' => 'theReplyTo',
+             'correlation_id' => 'theCorrelationId',
+         ], $transportMessage->getHeaders());
+        $this->assertSame([
+             Config::PARAMETER_PROCESSOR_QUEUE_NAME => 'aQueueName.fifo',
+         ], $transportMessage->getProperties());
+        $this->assertSame('MessageId', $transportMessage->getMessageId());
+        $this->assertSame(1000, $transportMessage->getTimestamp());
+        $this->assertSame('theReplyTo', $transportMessage->getReplyTo());
+        $this->assertSame('theCorrelationId', $transportMessage->getCorrelationId());
+        $this->assertSame(md5('Enqueue\Sqs\Client\SqsDriver::createTransportMessage'), $transportMessage->getMessageGroupId());
+        $this->assertSame(md5('body'), $transportMessage->getMessageDeduplicationId());
+    }
+
     public function testShouldSendMessageToRouterQueue()
     {
         $topic = new SqsDestination('aDestinationName');


### PR DESCRIPTION
Allows for FIFO queues on Amazons SQS platform to be used. These queues have two characteristics that needed to be addressed in the adapter:

1. FIFO queues have a suffix of `.fifo`
2. Each message should have a `messageGroupId` and a `messageDeduplicationId`

In order to define a queue as FIFO I apply the suffix to the queue name eg
```yml
enqueue:
    client:
        default_processor_queue: default.fifo
```

The messageGroupId is a md5 hash of the method name that created the `$transportMessage` object and the `messageDeduplicationId` is a md5 hash of the body of the message.


Question:
I notice in SqsDestination that there are methods `setFifoQueue` & `setContentBasedDeduplication`. Should these be set as part of `createQueue`?