### PR TITLE
Fix typo in configuration parameter

### DIFF
--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -157,7 +157,7 @@ class RdKafkaContext implements PsrContext
             }
 
             if (isset($this->config['rebalance_cb'])) {
-                $this->conf->setRebalanceCb($this->config['errorebalance_cbr_cb']);
+                $this->conf->setRebalanceCb($this->config['rebalance_cb']);
             }
 
             $this->conf->setDefaultTopicConf($topicConf);


### PR DESCRIPTION
Hey-hey 👋 
Copy-paste typo in RdKafkaContext configuration.