### PR TITLE
Fixes the notation for Twig template names in the data collector

### DIFF
--- a/pkg/enqueue-bundle/Resources/config/client.yml
+++ b/pkg/enqueue-bundle/Resources/config/client.yml
@@ -136,7 +136,7 @@ services:
         tags:
             -
               name: 'data_collector'
-              template: 'EnqueueBundle:Profiler:panel.html.twig'
+              template: '@Enqueue/Profiler/panel.html.twig'
               id: 'enqueue.message_queue'
 
     enqueue.flush_spool_producer_listener:


### PR DESCRIPTION
Fix the error below when attempting to open the profiler in a Symfony Flex project : 

`The profiler template "EnqueueBundle:Profiler:panel.html.twig" for data collector "enqueue.message_queue" does not exist.`