### PR TITLE
Missing client configuration in the documentation

### DIFF
--- a/docs/elastica-bundle/populate-command-optimization.md
+++ b/docs/elastica-bundle/populate-command-optimization.md
@@ -62,6 +62,7 @@ Here's an example of what your EnqueueBundle configuration may look like:
 enqueue:
     transport:
         default: 'file://%kernel.root_dir%/../var/messages'
+    client: ~
 ```
 
 Sure you can configure other transports like: [rabbitmq, amqp, stomp and so on](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/bundle/config_reference.md)


### PR DESCRIPTION
If `client: ~` is not added you will get an error `The service "fos_elastica.provider.app.channel" has a dependency on a non-existent service "enqueue.client.producer".` because the client services are not loaded until you add `client: ~`