### PR TITLE
[RdKafka] Enable serializers to serialize message keys

### DIFF
--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -41,8 +41,8 @@ class RdKafkaProducer implements PsrProducer
         InvalidMessageException::assertMessageInstanceOf($message, RdKafkaMessage::class);
 
         $partition = $message->getPartition() ?: $destination->getPartition() ?: RD_KAFKA_PARTITION_UA;
-        $key = $message->getKey() ?: $destination->getKey() ?: null;
         $payload = $this->serializer->toString($message);
+        $key = $message->getKey() ?: $destination->getKey() ?: null;
 
         $topic = $this->producer->newTopic($destination->getTopicName(), $destination->getConf());
         $topic->produce($partition, 0 /* must be 0 */, $payload, $key);


### PR DESCRIPTION
Currently the `RdKafkaProducer` is serializing just the message, which I guess us fine for JSON serialization.

But when you want to use an AvroSerializer that integrates with the Confluent Platform, it is possible to use complex types as keys as well, which in turn means that keys need to be serialized, too.

This change leverages the mutability of the Message by shifting the `getKey` method call after the call to the Serializer.
