### PR TITLE
[rdkafka] Topics created by context should contain default topic config

### DIFF
--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -25,6 +25,11 @@ class RdKafkaContext implements PsrContext
     private $conf;
 
     /**
+     * @var TopicConf
+     */
+    private $defaultTopicConf;
+
+    /**
      * @var Producer
      */
     private $producer;
@@ -54,7 +59,7 @@ class RdKafkaContext implements PsrContext
      */
     public function createTopic($topicName)
     {
-        return new RdKafkaTopic($topicName);
+        return new RdKafkaTopic($topicName, $this->getTopicConf());
     }
 
     /**
@@ -64,7 +69,7 @@ class RdKafkaContext implements PsrContext
      */
     public function createQueue($queueName)
     {
-        return new RdKafkaTopic($queueName);
+        return new RdKafkaTopic($queueName, $this->getTopicConf());
     }
 
     /**
@@ -140,16 +145,16 @@ class RdKafkaContext implements PsrContext
             return $this->conf;
         }
 
-        $topicConf = new TopicConf();
+        $this->defaultTopicConf = new TopicConf();
 
         if (isset($this->config['topic']) && is_array($this->config['topic'])) {
             foreach ($this->config['topic'] as $key => $value) {
-                $topicConf->set($key, $value);
+                $this->defaultTopicConf->set($key, $value);
             }
         }
 
         if (isset($this->config['partitioner'])) {
-            $topicConf->setPartitioner($this->config['partitioner']);
+            $this->defaultTopicConf->setPartitioner($this->config['partitioner']);
         }
 
         $this->conf = new Conf();
@@ -172,8 +177,18 @@ class RdKafkaContext implements PsrContext
             $this->conf->setRebalanceCb($this->config['rebalance_cb']);
         }
 
-        $this->conf->setDefaultTopicConf($topicConf);
+        $this->conf->setDefaultTopicConf($this->defaultTopicConf);
 
         return $this->conf;
+    }
+
+    /**
+     * @return TopicConf
+     */
+    private function getTopicConf()
+    {
+        $this->getConf();
+
+        return $this->defaultTopicConf;
     }
 }

--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -136,41 +136,43 @@ class RdKafkaContext implements PsrContext
      */
     private function getConf()
     {
-        if (null === $this->conf) {
-            $topicConf = new TopicConf();
-
-            if (isset($this->config['topic']) && is_array($this->config['topic'])) {
-                foreach ($this->config['topic'] as $key => $value) {
-                    $topicConf->set($key, $value);
-                }
-            }
-
-            if (isset($this->config['partitioner'])) {
-                $topicConf->setPartitioner($this->config['partitioner']);
-            }
-
-            $this->conf = new Conf();
-
-            if (isset($this->config['global']) && is_array($this->config['global'])) {
-                foreach ($this->config['global'] as $key => $value) {
-                    $this->conf->set($key, $value);
-                }
-            }
-
-            if (isset($this->config['dr_msg_cb'])) {
-                $this->conf->setDrMsgCb($this->config['dr_msg_cb']);
-            }
-
-            if (isset($this->config['error_cb'])) {
-                $this->conf->setErrorCb($this->config['error_cb']);
-            }
-
-            if (isset($this->config['rebalance_cb'])) {
-                $this->conf->setRebalanceCb($this->config['rebalance_cb']);
-            }
-
-            $this->conf->setDefaultTopicConf($topicConf);
+        if (null !== $this->conf) {
+            return $this->conf;
         }
+
+        $topicConf = new TopicConf();
+
+        if (isset($this->config['topic']) && is_array($this->config['topic'])) {
+            foreach ($this->config['topic'] as $key => $value) {
+                $topicConf->set($key, $value);
+            }
+        }
+
+        if (isset($this->config['partitioner'])) {
+            $topicConf->setPartitioner($this->config['partitioner']);
+        }
+
+        $this->conf = new Conf();
+
+        if (isset($this->config['global']) && is_array($this->config['global'])) {
+            foreach ($this->config['global'] as $key => $value) {
+                $this->conf->set($key, $value);
+            }
+        }
+
+        if (isset($this->config['dr_msg_cb'])) {
+            $this->conf->setDrMsgCb($this->config['dr_msg_cb']);
+        }
+
+        if (isset($this->config['error_cb'])) {
+            $this->conf->setErrorCb($this->config['error_cb']);
+        }
+
+        if (isset($this->config['rebalance_cb'])) {
+            $this->conf->setRebalanceCb($this->config['rebalance_cb']);
+        }
+
+        $this->conf->setDefaultTopicConf($topicConf);
 
         return $this->conf;
     }

--- a/pkg/rdkafka/RdKafkaTopic.php
+++ b/pkg/rdkafka/RdKafkaTopic.php
@@ -29,12 +29,18 @@ class RdKafkaTopic implements PsrTopic, PsrQueue
     private $key;
 
     /**
-     * @param string $name
+     * @param string         $name
+     * @param TopicConf|null $conf
      */
-    public function __construct($name)
+    public function __construct($name, TopicConf $conf = null)
     {
         $this->name = $name;
-        $this->conf = new TopicConf();
+
+        if (!$conf) {
+            $conf = new TopicConf();
+        }
+
+        $this->conf = $conf;
     }
 
     /**

--- a/pkg/rdkafka/Tests/RdKafkaContextTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaContextTest.php
@@ -5,6 +5,7 @@ namespace Enqueue\RdKafka\Tests;
 use Enqueue\Null\NullQueue;
 use Enqueue\RdKafka\JsonSerializer;
 use Enqueue\RdKafka\RdKafkaContext;
+use Enqueue\RdKafka\RdKafkaTopic;
 use Enqueue\RdKafka\Serializer;
 use Interop\Queue\InvalidDestinationException;
 use PHPUnit\Framework\TestCase;
@@ -67,5 +68,21 @@ class RdKafkaContextTest extends TestCase
         $producer = $context->createConsumer($context->createQueue('aQueue'));
 
         $this->assertSame($context->getSerializer(), $producer->getSerializer());
+    }
+
+    public function testTopicCreatedByContextShouldContainDefaultTopicConf()
+    {
+        $context = new RdKafkaContext(
+            [
+                'topic' => [
+                    'request.required.acks' => '-1', // all ISRs must ack the message
+                ],
+            ]
+        );
+
+        $rdKafkaTopic = $context->createTopic('test-topic');
+
+        $this->assertInstanceOf(RdKafkaTopic::class, $rdKafkaTopic);
+        $this->assertSame('-1', $rdKafkaTopic->getConf()->dump()['request.required.acks']);
     }
 }

--- a/pkg/rdkafka/Tests/RdKafkaContextTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaContextTest.php
@@ -81,8 +81,9 @@ class RdKafkaContextTest extends TestCase
         );
 
         $rdKafkaTopic = $context->createTopic('test-topic');
+        $configDump = $rdKafkaTopic->getConf()->dump();
 
         $this->assertInstanceOf(RdKafkaTopic::class, $rdKafkaTopic);
-        $this->assertSame('-1', $rdKafkaTopic->getConf()->dump()['request.required.acks']);
+        $this->assertSame('-1', $configDump['request.required.acks']);
     }
 }


### PR DESCRIPTION
Currently the topics created via `RdKakfaContext::createTopic` do not contain the default topic configuration. This is unexpected, since the context knows about the topic config and should pass this information on to created topics.
