### PR TITLE
[rdkafka] do not pass config if it was not set explisitly.

### DIFF
--- a/pkg/rdkafka/RdKafkaTopic.php
+++ b/pkg/rdkafka/RdKafkaTopic.php
@@ -34,7 +34,6 @@ class RdKafkaTopic implements PsrTopic, PsrQueue
     public function __construct($name)
     {
         $this->name = $name;
-        $this->conf = new TopicConf();
     }
 
     /**
@@ -54,11 +53,19 @@ class RdKafkaTopic implements PsrTopic, PsrQueue
     }
 
     /**
-     * @return TopicConf
+     * @return TopicConf|null
      */
     public function getConf()
     {
         return $this->conf;
+    }
+
+    /**
+     * @param TopicConf|null $conf
+     */
+    public function setConf(TopicConf $conf = null)
+    {
+        $this->conf = $conf;
     }
 
     /**

--- a/pkg/rdkafka/Tests/RdKafkaTopicTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaTopicTest.php
@@ -27,10 +27,20 @@ class RdKafkaTopicTest extends TestCase
         $this->assertSame('key', $topic->getKey());
     }
 
-    public function testShouldReturnConfInstance()
+    public function testShouldReturnNullAsConfIfNotSet()
     {
         $topic = new RdKafkaTopic('topic');
 
-        $this->assertInstanceOf(TopicConf::class, $topic->getConf());
+        $this->assertNull($topic->getConf());
+    }
+
+    public function testShouldAllowGetPreviouslySetConf()
+    {
+        $topic = new RdKafkaTopic('topic');
+
+        $conf = new TopicConf();
+        $topic->setConf($conf);
+
+        $this->assertSame($conf, $topic->getConf());
     }
 }


### PR DESCRIPTION
this is alternative to the same problem as described here https://github.com/php-enqueue/enqueue-dev/pull/256

the branch to use in app could be found here https://github.com/formapro-forks/rdkafka/tree/rdkafka-topic-default-config

@tPl0ch  could you please test it? 