### PR TITLE
[consumption][amqp] onIdle is never called.

### DIFF
--- a/pkg/enqueue/Consumption/QueueConsumer.php
+++ b/pkg/enqueue/Consumption/QueueConsumer.php
@@ -204,6 +204,9 @@ class QueueConsumer
                     }
 
                     $this->psrContext->consume($this->receiveTimeout);
+
+                    usleep($this->idleTimeout * 1000);
+                    $extension->onIdle($context);
                 } else {
                     /** @var PsrQueue $queue */
                     foreach ($this->boundProcessors as list($queue, $processor)) {


### PR DESCRIPTION
fixes https://github.com/php-enqueue/enqueue-dev/issues/260

use https://github.com/formapro-forks/enqueue/tree/consumption-amqp-on-idle-not-called for tests in your app. 