### PR TITLE
[Sqs] Allow array-based DSN configuration

### DIFF
--- a/pkg/sqs/SqsConnectionFactory.php
+++ b/pkg/sqs/SqsConnectionFactory.php
@@ -39,11 +39,18 @@ class SqsConnectionFactory implements PsrConnectionFactory
     {
         if (empty($config) || 'sqs:' === $config) {
             $config = [];
-        } elseif (is_string($config)) {
+        }
+
+        if (is_string($config)) {
             $config = $this->parseDsn($config);
-        } elseif (is_array($config)) {
-        } else {
-            throw new \LogicException('The config must be either an array of options, a DSN string or null');
+        }
+
+        if (!is_array($config)) {
+            throw new \LogicException('The config must be either an array of options, a DSN string, or null');
+        }
+
+        if (count($config) == 1 && array_key_exists('dsn', $config)) {
+            $config = $this->parseDsn($config['dsn']);
         }
 
         $this->config = array_replace($this->defaultConfig(), $config);

--- a/pkg/sqs/SqsConnectionFactory.php
+++ b/pkg/sqs/SqsConnectionFactory.php
@@ -39,18 +39,17 @@ class SqsConnectionFactory implements PsrConnectionFactory
     {
         if (empty($config) || 'sqs:' === $config) {
             $config = [];
-        }
-
-        if (is_string($config)) {
+        } elseif (is_string($config)) {
             $config = $this->parseDsn($config);
-        }
+        } elseif (is_array($config)) {
+            $dsn = array_key_exists('dsn', $config) ? $config['dsn'] : null;
+            unset($config['dsn']);
 
-        if (!is_array($config)) {
-            throw new \LogicException('The config must be either an array of options, a DSN string, or null');
-        }
-
-        if (count($config) == 1 && array_key_exists('dsn', $config)) {
-            $config = $this->parseDsn($config['dsn']);
+            if ($dsn) {
+                $config = array_replace($config, $this->parseDsn($dsn));
+            }
+        } else {
+            throw new \LogicException('The config must be either an array of options, a DSN string or null');
         }
 
         $this->config = array_replace($this->defaultConfig(), $config);

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -16,7 +16,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The config must be either an array of options, a DSN string, or null');
+        $this->expectExceptionMessage('The config must be either an array of options, a DSN string or null');
 
         new SqsConnectionFactory(new \stdClass());
     }

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -103,7 +103,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'lazy' => false,
             ],
         ];
-        
+
         yield [
             ['dsn' => 'sqs:?key=theKey&secret=theSecret&token=theToken&lazy=0'],
             [

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -16,7 +16,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The config must be either an array of options, a DSN string or null');
+        $this->expectExceptionMessage('The config must be either an array of options, a DSN string, or null');
 
         new SqsConnectionFactory(new \stdClass());
     }
@@ -93,6 +93,19 @@ class SqsConnectionFactoryConfigTest extends TestCase
 
         yield [
             'sqs:?key=theKey&secret=theSecret&token=theToken&lazy=0',
+            [
+                'key' => 'theKey',
+                'secret' => 'theSecret',
+                'token' => 'theToken',
+                'region' => null,
+                'retries' => 3,
+                'version' => '2012-11-05',
+                'lazy' => false,
+            ],
+        ];
+        
+        yield [
+            ['dsn' => 'sqs:?key=theKey&secret=theSecret&token=theToken&lazy=0'],
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',


### PR DESCRIPTION
I encountered a problem with using DSN-based configuration in Symfony 4, where the 'dsn' value was always being passed as an array key. The constructor did not properly handle this, and the primary symptom of this was a constant complaint that the 'region' was not set, even though it was present in the DSN.