### PR TITLE
Update config_reference.md

### DIFF
--- a/docs/bundle/config_reference.md
+++ b/docs/bundle/config_reference.md
@@ -251,7 +251,7 @@ enqueue:
         app_name:             app
         router_topic:         default
         router_queue:         default
-        router_processor:     enqueue.client.router_processor
+        router_processor:     Enqueue\Client\RouterProcessor
         default_processor_queue: default
         redelivered_delay_time: 0
     consumption:


### PR DESCRIPTION
it is working for me with this configuration. I use "enqueue/enqueue-bundle": 0.8.13.
with your version when I run bin/console enqueue:consume default --setup-broker i receiving Processor was not found. processorName: "enqueue.client.router_processor"