### PR TITLE
[bundle][dx] Add a message that suggest installing a pkg to use the transport.

### DIFF
--- a/pkg/enqueue-bundle/EnqueueBundle.php
+++ b/pkg/enqueue-bundle/EnqueueBundle.php
@@ -69,7 +69,7 @@ class EnqueueBundle extends Bundle
             $extension->addTransportFactory(new AmqpTransportFactory('amqp'));
             $extension->addTransportFactory(new RabbitMqAmqpTransportFactory('rabbitmq_amqp'));
         } else {
-            $amppPackages = ['enqueue/stomp', 'enqueue/amqp-ext', 'enqueue/amqp-bunny', 'enqueue/amqp-lib'];
+            $amppPackages = ['enqueue/amqp-ext', 'enqueue/amqp-bunny', 'enqueue/amqp-lib'];
             $extension->addTransportFactory(new MissingTransportFactory('amqp', $amppPackages));
             $extension->addTransportFactory(new MissingTransportFactory('rabbitmq_amqp', $amppPackages));
         }

--- a/pkg/enqueue-bundle/EnqueueBundle.php
+++ b/pkg/enqueue-bundle/EnqueueBundle.php
@@ -29,6 +29,7 @@ use Enqueue\Stomp\StompConnectionFactory;
 use Enqueue\Stomp\Symfony\RabbitMqStompTransportFactory;
 use Enqueue\Stomp\Symfony\StompTransportFactory;
 use Enqueue\Symfony\AmqpTransportFactory;
+use Enqueue\Symfony\MissingTransportFactory;
 use Enqueue\Symfony\RabbitMqAmqpTransportFactory;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -53,8 +54,11 @@ class EnqueueBundle extends Bundle
         $extension = $container->getExtension('enqueue');
 
         if (class_exists(StompConnectionFactory::class)) {
-            $extension->addTransportFactory(new StompTransportFactory());
-            $extension->addTransportFactory(new RabbitMqStompTransportFactory());
+            $extension->addTransportFactory(new StompTransportFactory('stomp'));
+            $extension->addTransportFactory(new RabbitMqStompTransportFactory('rabbitmq_stomp'));
+        } else {
+            $extension->addTransportFactory(new MissingTransportFactory('stomp', ['enqueue/stomp']));
+            $extension->addTransportFactory(new MissingTransportFactory('rabbitmq_stomp', ['enqueue/stomp']));
         }
 
         if (
@@ -64,26 +68,40 @@ class EnqueueBundle extends Bundle
         ) {
             $extension->addTransportFactory(new AmqpTransportFactory('amqp'));
             $extension->addTransportFactory(new RabbitMqAmqpTransportFactory('rabbitmq_amqp'));
+        } else {
+            $amppPackages = ['enqueue/stomp', 'enqueue/amqp-ext', 'enqueue/amqp-bunny', 'enqueue/amqp-lib'];
+            $extension->addTransportFactory(new MissingTransportFactory('amqp', $amppPackages));
+            $extension->addTransportFactory(new MissingTransportFactory('rabbitmq_amqp', $amppPackages));
         }
 
         if (class_exists(FsConnectionFactory::class)) {
-            $extension->addTransportFactory(new FsTransportFactory());
+            $extension->addTransportFactory(new FsTransportFactory('fs'));
+        } else {
+            $extension->addTransportFactory(new MissingTransportFactory('fs', ['enqueue/fs']));
         }
 
         if (class_exists(RedisConnectionFactory::class)) {
-            $extension->addTransportFactory(new RedisTransportFactory());
+            $extension->addTransportFactory(new RedisTransportFactory('redis'));
+        } else {
+            $extension->addTransportFactory(new MissingTransportFactory('redis', ['enqueue/redis']));
         }
 
         if (class_exists(DbalConnectionFactory::class)) {
-            $extension->addTransportFactory(new DbalTransportFactory());
+            $extension->addTransportFactory(new DbalTransportFactory('dbal'));
+        } else {
+            $extension->addTransportFactory(new MissingTransportFactory('dbal', ['enqueue/dbal']));
         }
 
         if (class_exists(SqsConnectionFactory::class)) {
-            $extension->addTransportFactory(new SqsTransportFactory());
+            $extension->addTransportFactory(new SqsTransportFactory('sqs'));
+        } else {
+            $extension->addTransportFactory(new MissingTransportFactory('sqs', ['enqueue/sqs']));
         }
 
         if (class_exists(GpsConnectionFactory::class)) {
-            $extension->addTransportFactory(new GpsTransportFactory());
+            $extension->addTransportFactory(new GpsTransportFactory('gps'));
+        } else {
+            $extension->addTransportFactory(new MissingTransportFactory('gps', ['enqueue/gps']));
         }
 
         $container->addCompilerPass(new AsyncEventsPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100);

--- a/pkg/enqueue/Symfony/MissingTransportFactory.php
+++ b/pkg/enqueue/Symfony/MissingTransportFactory.php
@@ -47,9 +47,16 @@ class MissingTransportFactory implements TransportFactoryInterface, DriverFactor
 
         $builder
             ->info($message)
-            ->validate()->always(function () use ($message) {
-                throw new \InvalidArgumentException($message);
-            })
+            ->beforeNormalization()
+                ->always(function () {
+                    return [];
+                })
+                ->end()
+            ->validate()
+                ->always(function () use ($message) {
+                    throw new \InvalidArgumentException($message);
+                })
+                ->end()
         ;
     }
 

--- a/pkg/enqueue/Symfony/MissingTransportFactory.php
+++ b/pkg/enqueue/Symfony/MissingTransportFactory.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Enqueue\Symfony;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class MissingTransportFactory implements TransportFactoryInterface, DriverFactoryInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var string[]
+     */
+    private $packages;
+
+    /**
+     * @param string   $name
+     * @param string[] $packages
+     */
+    public function __construct($name, array $packages)
+    {
+        $this->name = $name;
+        $this->packages = $packages;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addConfiguration(ArrayNodeDefinition $builder)
+    {
+        if (1 == count($this->packages)) {
+            $message = sprintf(
+                'In order to use the transport "%s" install a package "%s"',
+                $this->getName(),
+                implode('", "', $this->packages)
+            );
+        } else {
+            $message = sprintf(
+                'In order to use the transport "%s" install one of the packages "%s"',
+                $this->getName(),
+                implode('", "', $this->packages)
+            );
+        }
+
+        $builder
+            ->info($message)
+            ->validate()->always(function () use ($message) {
+                throw new \InvalidArgumentException($message);
+            })
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createConnectionFactory(ContainerBuilder $container, array $config)
+    {
+        throw new \LogicException('Should not be called');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createContext(ContainerBuilder $container, array $config)
+    {
+        throw new \LogicException('Should not be called');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDriver(ContainerBuilder $container, array $config)
+    {
+        throw new \LogicException('Should not be called');
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/pkg/enqueue/Tests/Symfony/MissingTransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/MissingTransportFactoryTest.php
@@ -53,4 +53,21 @@ class MissingTransportFactoryTest extends TestCase
         $this->expectExceptionMessage('Invalid configuration for path "foo": In order to use the transport "aMissingTransportName" install one of the packages "aFooPackage", "aBarPackage"');
         $processor->process($tb->buildTree(), [[]]);
     }
+
+    public function testThrowEvenIfThereAreSomeOptionsPassed()
+    {
+        $transport = new MissingTransportFactory('aMissingTransportName', ['aFooPackage', 'aBarPackage']);
+        $tb = new TreeBuilder();
+        $rootNode = $tb->root('foo');
+
+        $transport->addConfiguration($rootNode);
+        $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('In order to use the transport "aMissingTransportName"');
+        $processor->process($tb->buildTree(), [[
+            'foo' => 'fooVal',
+            'bar' => 'barVal',
+        ]]);
+    }
 }

--- a/pkg/enqueue/Tests/Symfony/MissingTransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/MissingTransportFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Enqueue\Tests\Symfony;
+
+use Enqueue\Symfony\MissingTransportFactory;
+use Enqueue\Symfony\TransportFactoryInterface;
+use Enqueue\Test\ClassExtensionTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+class MissingTransportFactoryTest extends TestCase
+{
+    use ClassExtensionTrait;
+
+    public function testShouldImplementTransportFactoryInterface()
+    {
+        $this->assertClassImplements(TransportFactoryInterface::class, MissingTransportFactory::class);
+    }
+
+    public function testCouldBeConstructedWithNameAndPackages()
+    {
+        $transport = new MissingTransportFactory('aMissingTransportName', ['aPackage', 'anotherPackage']);
+
+        $this->assertEquals('aMissingTransportName', $transport->getName());
+    }
+
+    public function testThrowOnProcessForOnePackageToInstall()
+    {
+        $transport = new MissingTransportFactory('aMissingTransportName', ['aFooPackage']);
+        $tb = new TreeBuilder();
+        $rootNode = $tb->root('foo');
+
+        $transport->addConfiguration($rootNode);
+        $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "foo": In order to use the transport "aMissingTransportName" install a package "aFooPackage"');
+        $processor->process($tb->buildTree(), [[]]);
+    }
+
+    public function testThrowOnProcessForSeveralPackagesToInstall()
+    {
+        $transport = new MissingTransportFactory('aMissingTransportName', ['aFooPackage', 'aBarPackage']);
+        $tb = new TreeBuilder();
+        $rootNode = $tb->root('foo');
+
+        $transport->addConfiguration($rootNode);
+        $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "foo": In order to use the transport "aMissingTransportName" install one of the packages "aFooPackage", "aBarPackage"');
+        $processor->process($tb->buildTree(), [[]]);
+    }
+}


### PR DESCRIPTION

fixes https://github.com/php-enqueue/enqueue-dev/issues/333

The PR improves a message a develoepr sees when a desired package is not installed.

Instead of:

```
[Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]
Unrecognized option "amqp" under "enqueue.transport"
```

He would see:

<img width="1422" alt="screenshot 2018-01-18 13 31 16" src="https://user-images.githubusercontent.com/143206/35096232-158e93e8-fc54-11e7-8de0-181efdb839e3.png">
