### PR TITLE
Do not cast microtime to integer

### DIFF
--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -83,7 +83,7 @@ class DbalProducer implements PsrProducer
 
         $dbalMessage = [
             'id' => $uuid,
-            'published_at' => microtime(true) * 10000,
+            'published_at' => (int) (microtime(true) * 10000),
             'body' => $body,
             'headers' => JSON::encode($message->getHeaders()),
             'properties' => JSON::encode($message->getProperties()),

--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -83,7 +83,7 @@ class DbalProducer implements PsrProducer
 
         $dbalMessage = [
             'id' => $uuid,
-            'published_at' => (int) microtime(true) * 10000,
+            'published_at' => microtime(true) * 10000,
             'body' => $body,
             'headers' => JSON::encode($message->getHeaders()),
             'properties' => JSON::encode($message->getProperties()),


### PR DESCRIPTION
The benefit of precise scheduling using microtime is gone when casting microtime output to integer

var_dump((int) microtime(true) * 10000);
// int(15180039750000)

var_dump(time());
// int(1518003975)

var_dump(microtime(true) * 10000);
// float(15180039759562)