### PR TITLE
Order by publish_date within priorities

### DIFF
--- a/pkg/dbal/DbalConsumer.php
+++ b/pkg/dbal/DbalConsumer.php
@@ -213,6 +213,7 @@ class DbalConsumer implements PsrConsumer
             ->andWhere('priority IS NOT NULL')
             ->andWhere('(delayed_until IS NULL OR delayed_until <= :delayedUntil)')
             ->addOrderBy('priority', 'desc')
+            ->addOrderBy('published_at', 'asc')
             ->setMaxResults(1)
         ;
 


### PR DESCRIPTION
When multiple messages got the same priority they should nevertheless be ordered by publish date