### PR TITLE
Clean up when a job triggers an exception

### DIFF
--- a/pkg/job-queue/Tests/JobRunnerTest.php
+++ b/pkg/job-queue/Tests/JobRunnerTest.php
@@ -163,6 +163,38 @@ class JobRunnerTest extends \PHPUnit\Framework\TestCase
         });
     }
 
+    public function testRunUniqueShouldFailJobIfCallbackThrowsException()
+    {
+        $root = new Job();
+        $child = new Job();
+
+        $jobProcessor = $this->createJobProcessorMock();
+        $jobProcessor
+            ->expects($this->once())
+            ->method('findOrCreateRootJob')
+            ->will($this->returnValue($root))
+        ;
+        $jobProcessor
+            ->expects($this->once())
+            ->method('findOrCreateChildJob')
+            ->will($this->returnValue($child))
+        ;
+        $jobProcessor
+            ->expects($this->never())
+            ->method('successChildJob')
+        ;
+        $jobProcessor
+            ->expects($this->once())
+            ->method('failChildJob')
+        ;
+
+        $jobRunner = new JobRunner($jobProcessor);
+        $this->expectException(\Exception::class);
+        $jobRunner->runUnique('owner-id', 'job-name', function () {
+            throw new \Exception();
+        });
+    }
+
     public function testRunUniqueShouldNotSuccessJobIfJobIsAlreadyStopped()
     {
         $root = new Job();


### PR DESCRIPTION
Fixes a condition that occurs when a running job triggers an uncaught exception. The job is left in a “running” state instead of “failed” and future jobs with the same name are not allowed to run.

Fixes issue #385