### PR TITLE
Convert between Message::$expire and DbalMessage::$timeToLive

### DIFF
--- a/pkg/dbal/Client/DbalDriver.php
+++ b/pkg/dbal/Client/DbalDriver.php
@@ -72,6 +72,7 @@ class DbalDriver implements DriverInterface
         $transportMessage->setMessageId($message->getMessageId());
         $transportMessage->setTimestamp($message->getTimestamp());
         $transportMessage->setDeliveryDelay($message->getDelay());
+        $transportMessage->setTimeToLive($message->getExpire());
         $transportMessage->setReplyTo($message->getReplyTo());
         $transportMessage->setCorrelationId($message->getCorrelationId());
         if (array_key_exists($message->getPriority(), self::$priorityMap)) {
@@ -97,6 +98,8 @@ class DbalDriver implements DriverInterface
         $clientMessage->setContentType($message->getHeader('content_type'));
         $clientMessage->setMessageId($message->getMessageId());
         $clientMessage->setTimestamp($message->getTimestamp());
+        $timeToLive = $message->getTimeToLive();
+        $clientMessage->setExpire((null === $timeToLive) ? null : (int) round($timeToLive));
         $clientMessage->setDelay($message->getDeliveryDelay());
         $clientMessage->setReplyTo($message->getReplyTo());
         $clientMessage->setCorrelationId($message->getCorrelationId());


### PR DESCRIPTION
Fixes a condition which results in the "enqueue" table having a null value for "time_to_live" even though it was set on the Message object prior to sending the event/command. Closes #391