### PR TITLE
[bundle] Don't ping DBAL connection if it wasn't opened

### DIFF
--- a/pkg/enqueue-bundle/Consumption/Extension/DoctrinePingConnectionExtension.php
+++ b/pkg/enqueue-bundle/Consumption/Extension/DoctrinePingConnectionExtension.php
@@ -32,6 +32,10 @@ class DoctrinePingConnectionExtension implements ExtensionInterface
     {
         /** @var Connection $connection */
         foreach ($this->registry->getConnections() as $connection) {
+            if (!$connection->isConnected()) {
+                continue;
+            }
+
             if ($connection->ping()) {
                 return;
             }

--- a/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/DoctrinePingConnectionExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/DoctrinePingConnectionExtensionTest.php
@@ -24,6 +24,11 @@ class DoctrinePingConnectionExtensionTest extends TestCase
         $connection = $this->createConnectionMock();
         $connection
             ->expects($this->once())
+            ->method('isConnected')
+            ->will($this->returnValue(true))
+        ;
+        $connection
+            ->expects($this->once())
             ->method('ping')
             ->will($this->returnValue(true))
         ;
@@ -58,6 +63,11 @@ class DoctrinePingConnectionExtensionTest extends TestCase
         $connection = $this->createConnectionMock();
         $connection
             ->expects($this->once())
+            ->method('isConnected')
+            ->will($this->returnValue(true))
+        ;
+        $connection
+            ->expects($this->once())
             ->method('ping')
             ->will($this->returnValue(false))
         ;
@@ -87,6 +97,49 @@ class DoctrinePingConnectionExtensionTest extends TestCase
             ->expects($this->once())
             ->method('getConnections')
             ->will($this->returnValue([$connection]))
+        ;
+
+        $extension = new DoctrinePingConnectionExtension($registry);
+        $extension->onPreReceived($context);
+    }
+
+    public function testShouldSkipIfConnectionWasNotOpened()
+    {
+        $connection1 = $this->createConnectionMock();
+        $connection1
+            ->expects($this->once())
+            ->method('isConnected')
+            ->will($this->returnValue(false))
+        ;
+        $connection1
+            ->expects($this->never())
+            ->method('ping')
+        ;
+
+        // 2nd connection was opened in the past
+        $connection2 = $this->createConnectionMock();
+        $connection2
+            ->expects($this->once())
+            ->method('isConnected')
+            ->will($this->returnValue(true))
+        ;
+        $connection2
+            ->expects($this->once())
+            ->method('ping')
+            ->will($this->returnValue(true))
+        ;
+
+        $context = $this->createPsrContext();
+        $context->getLogger()
+            ->expects($this->never())
+            ->method('debug')
+        ;
+
+        $registry = $this->createRegistryMock();
+        $registry
+            ->expects($this->once())
+            ->method('getConnections')
+            ->will($this->returnValue([$connection1, $connection2]))
         ;
 
         $extension = new DoctrinePingConnectionExtension($registry);


### PR DESCRIPTION
Issue appears when symfony app has more than one connection defined. $connection->ping() always tries to open connection regardless it was used previously or not.