### PR TITLE
Allow to enable SSL in StompConnectionFactory

### DIFF
--- a/docs/bundle/config_reference.md
+++ b/docs/bundle/config_reference.md
@@ -21,6 +21,9 @@ enqueue:
             connection_timeout:   1
             buffer_size:          1000
             lazy:                 true
+            
+            # Should be true if you want to use secure connections. False by default
+            ssl_on:               false
         rabbitmq_stomp:
             host:                 localhost
             port:                 61613

--- a/pkg/stomp/StompConnectionFactory.php
+++ b/pkg/stomp/StompConnectionFactory.php
@@ -28,6 +28,7 @@ class StompConnectionFactory implements PsrConnectionFactory
      * 'connection_timeout' => 1,
      * 'sync' => false,
      * 'lazy' => true,
+     * 'ssl_on' => false,
      * ].
      *
      * or
@@ -75,7 +76,8 @@ class StompConnectionFactory implements PsrConnectionFactory
         if (false == $this->stomp) {
             $config = $this->config;
 
-            $uri = 'tcp://'.$config['host'].':'.$config['port'];
+            $scheme = ($config['ssl_on'] === true) ? 'ssl' : 'tcp';
+            $uri = $scheme . '://' . $config['host'] . ':' . $config['port'];
             $connection = new Connection($uri, $config['connection_timeout']);
 
             $this->stomp = new BufferedStompClient($connection, $config['buffer_size']);
@@ -134,6 +136,7 @@ class StompConnectionFactory implements PsrConnectionFactory
             'connection_timeout' => 1,
             'sync' => false,
             'lazy' => true,
+            'ssl_on' => false,
         ];
     }
 }

--- a/pkg/stomp/StompConnectionFactory.php
+++ b/pkg/stomp/StompConnectionFactory.php
@@ -76,8 +76,8 @@ class StompConnectionFactory implements PsrConnectionFactory
         if (false == $this->stomp) {
             $config = $this->config;
 
-            $scheme = ($config['ssl_on'] === true) ? 'ssl' : 'tcp';
-            $uri = $scheme . '://' . $config['host'] . ':' . $config['port'];
+            $scheme = (true === $config['ssl_on']) ? 'ssl' : 'tcp';
+            $uri = $scheme.'://'.$config['host'].':'.$config['port'];
             $connection = new Connection($uri, $config['connection_timeout']);
 
             $this->stomp = new BufferedStompClient($connection, $config['buffer_size']);

--- a/pkg/stomp/Symfony/StompTransportFactory.php
+++ b/pkg/stomp/Symfony/StompTransportFactory.php
@@ -43,6 +43,7 @@ class StompTransportFactory implements TransportFactoryInterface, DriverFactoryI
                 ->integerNode('connection_timeout')->min(1)->defaultValue(1)->end()
                 ->integerNode('buffer_size')->min(1)->defaultValue(1000)->end()
                 ->booleanNode('lazy')->defaultTrue()->end()
+                ->booleanNode('ssl_on')->defaultFalse()->end()
         ;
     }
 

--- a/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
+++ b/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
@@ -64,7 +64,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'connection_timeout' => 1,
                 'sync' => false,
                 'lazy' => true,
-                'ssl_on' => false
+                'ssl_on' => false,
             ],
         ];
 
@@ -80,7 +80,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'connection_timeout' => 1,
                 'sync' => false,
                 'lazy' => true,
-                'ssl_on' => false
+                'ssl_on' => false,
             ],
         ];
 
@@ -96,7 +96,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'connection_timeout' => 1,
                 'sync' => false,
                 'lazy' => true,
-                'ssl_on' => false
+                'ssl_on' => false,
             ],
         ];
 
@@ -113,7 +113,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'sync' => true,
                 'lazy' => false,
                 'foo' => 'bar',
-                'ssl_on' => false
+                'ssl_on' => false,
             ],
         ];
 
@@ -130,7 +130,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'sync' => false,
                 'lazy' => true,
                 'foo' => 'bar',
-                'ssl_on' => false
+                'ssl_on' => false,
             ],
         ];
     }

--- a/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
+++ b/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
@@ -64,6 +64,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'connection_timeout' => 1,
                 'sync' => false,
                 'lazy' => true,
+                'ssl_on' => false
             ],
         ];
 
@@ -79,6 +80,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'connection_timeout' => 1,
                 'sync' => false,
                 'lazy' => true,
+                'ssl_on' => false
             ],
         ];
 
@@ -94,6 +96,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'connection_timeout' => 1,
                 'sync' => false,
                 'lazy' => true,
+                'ssl_on' => false
             ],
         ];
 
@@ -110,6 +113,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'sync' => true,
                 'lazy' => false,
                 'foo' => 'bar',
+                'ssl_on' => false
             ],
         ];
 
@@ -126,6 +130,7 @@ class StompConnectionFactoryConfigTest extends TestCase
                 'sync' => false,
                 'lazy' => true,
                 'foo' => 'bar',
+                'ssl_on' => false
             ],
         ];
     }

--- a/pkg/stomp/Tests/Symfony/RabbitMqStompTransportFactoryTest.php
+++ b/pkg/stomp/Tests/Symfony/RabbitMqStompTransportFactoryTest.php
@@ -59,7 +59,7 @@ class RabbitMqStompTransportFactoryTest extends \PHPUnit\Framework\TestCase
             'management_plugin_installed' => false,
             'management_plugin_port' => 15672,
             'lazy' => true,
-            'ssl_on' => false
+            'ssl_on' => false,
         ], $config);
     }
 

--- a/pkg/stomp/Tests/Symfony/RabbitMqStompTransportFactoryTest.php
+++ b/pkg/stomp/Tests/Symfony/RabbitMqStompTransportFactoryTest.php
@@ -59,6 +59,7 @@ class RabbitMqStompTransportFactoryTest extends \PHPUnit\Framework\TestCase
             'management_plugin_installed' => false,
             'management_plugin_port' => 15672,
             'lazy' => true,
+            'ssl_on' => false
         ], $config);
     }
 

--- a/pkg/stomp/Tests/Symfony/StompTransportFactoryTest.php
+++ b/pkg/stomp/Tests/Symfony/StompTransportFactoryTest.php
@@ -55,6 +55,7 @@ class StompTransportFactoryTest extends \PHPUnit\Framework\TestCase
             'connection_timeout' => 1,
             'buffer_size' => 1000,
             'lazy' => true,
+            'ssl_on' => false
         ], $config);
     }
 

--- a/pkg/stomp/Tests/Symfony/StompTransportFactoryTest.php
+++ b/pkg/stomp/Tests/Symfony/StompTransportFactoryTest.php
@@ -55,7 +55,7 @@ class StompTransportFactoryTest extends \PHPUnit\Framework\TestCase
             'connection_timeout' => 1,
             'buffer_size' => 1000,
             'lazy' => true,
-            'ssl_on' => false
+            'ssl_on' => false,
         ], $config);
     }
 


### PR DESCRIPTION
Allow to enable SSL, depend the uri scheme on that. Fully backwards compatible.