### PR TITLE
Add autoconfigure for services extending PsrProcess interface

### DIFF
--- a/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
+++ b/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
@@ -3,7 +3,9 @@
 namespace Enqueue\Bundle\DependencyInjection;
 
 use Enqueue\AsyncEventDispatcher\DependencyInjection\AsyncEventDispatcherExtension;
+use Enqueue\Client\CommandSubscriberInterface;
 use Enqueue\Client\Producer;
+use Enqueue\Client\TopicSubscriberInterface;
 use Enqueue\Client\TraceableProducer;
 use Enqueue\Consumption\QueueConsumer;
 use Enqueue\JobQueue\Job;
@@ -71,6 +73,8 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        $this->setupAutowiringForProcessors($container);
 
         foreach ($config['transport'] as $name => $transportConfig) {
             $this->factories[$name]->createConnectionFactory($container, $transportConfig);
@@ -219,5 +223,20 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
                 break;
             }
         }
+    }
+
+    private function setupAutowiringForProcessors(ContainerBuilder $container)
+    {
+        if (!method_exists($container, 'registerForAutoconfiguration')) {
+            return;
+        }
+
+        $container->registerForAutoconfiguration(TopicSubscriberInterface::class)
+            ->setPublic(true)
+            ->addTag('enqueue.client.processor');
+
+        $container->registerForAutoconfiguration(CommandSubscriberInterface::class)
+            ->setPublic(true)
+            ->addTag('enqueue.client.processor');
     }
 }


### PR DESCRIPTION
This will allow to Symfony users that have autoconfigure/autowiring enabled to avoid defining
explicitly the processor service and its tag. Now, the symfony container does it automatically.