### PR TITLE
Issue-455: fix RabbitMqDelayPluginDelayStrategy for RabbitmMQ 3.7.5 version

### DIFF
--- a/pkg/amqp-tools/RabbitMq37XDelayPluginDelayStrategy.php
+++ b/pkg/amqp-tools/RabbitMq37XDelayPluginDelayStrategy.php
@@ -7,7 +7,7 @@ use Interop\Amqp\AmqpMessage;
 
 class RabbitMq37XDelayPluginDelayStrategy extends RabbitMqDelayPluginDelayStrategy
 {
-    protected function buildDelayMessage(AmqpContext $context, AmqpMessage $message, int $delayMsec): AmqpMessage
+    protected function buildDelayMessage(AmqpContext $context, AmqpMessage $message, $delayMsec)
     {
         $delayMessage = $context->createMessage($message->getBody(), $message->getProperties(), $message->getHeaders());
         $delayMessage->setHeader('x-delay', $delayMsec);

--- a/pkg/amqp-tools/RabbitMq37XDelayPluginDelayStrategy.php
+++ b/pkg/amqp-tools/RabbitMq37XDelayPluginDelayStrategy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Enqueue\AmqpTools;
+
+use Interop\Amqp\AmqpContext;
+use Interop\Amqp\AmqpMessage;
+
+class RabbitMq37XDelayPluginDelayStrategy extends RabbitMqDelayPluginDelayStrategy
+{
+    protected function buildDelayMessage(AmqpContext $context, AmqpMessage $message, int $delayMsec): AmqpMessage
+    {
+        $delayMessage = $context->createMessage($message->getBody(), $message->getProperties(), $message->getHeaders());
+        $delayMessage->setHeader('x-delay', $delayMsec);
+        $delayMessage->setRoutingKey($message->getRoutingKey());
+
+        return $delayMessage;
+    }
+}

--- a/pkg/amqp-tools/RabbitMqDelayPluginDelayStrategy.php
+++ b/pkg/amqp-tools/RabbitMqDelayPluginDelayStrategy.php
@@ -18,7 +18,7 @@ class RabbitMqDelayPluginDelayStrategy implements DelayStrategy
     public function delayMessage(AmqpContext $context, AmqpDestination $dest, AmqpMessage $message, $delayMsec)
     {
         $delayMessage = $context->createMessage($message->getBody(), $message->getProperties(), $message->getHeaders());
-        $delayMessage->setProperty('x-delay', (int) $delayMsec);
+        $delayMessage->setHeader('x-delay', (int) $delayMsec);
         $delayMessage->setRoutingKey($message->getRoutingKey());
 
         if ($dest instanceof AmqpTopic) {

--- a/pkg/amqp-tools/RabbitMqDelayPluginDelayStrategy.php
+++ b/pkg/amqp-tools/RabbitMqDelayPluginDelayStrategy.php
@@ -55,7 +55,7 @@ class RabbitMqDelayPluginDelayStrategy implements DelayStrategy
         $producer->send($delayTopic, $delayMessage);
     }
 
-    protected function buildDelayMessage(AmqpContext $context, AmqpMessage $message, int $delayMsec): AmqpMessage
+    protected function buildDelayMessage(AmqpContext $context, AmqpMessage $message, $delayMsec)
     {
         $delayMessage = $context->createMessage($message->getBody(), $message->getProperties(), $message->getHeaders());
         $delayMessage->setProperty('x-delay', $delayMsec);

--- a/pkg/amqp-tools/Tests/RabbitMq37XDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMq37XDelayPluginDelayStrategyTest.php
@@ -4,214 +4,22 @@ namespace Enqueue\AmqpTools\Tests;
 
 use Enqueue\AmqpTools\DelayStrategy;
 use Enqueue\AmqpTools\RabbitMq37XDelayPluginDelayStrategy;
-use Enqueue\Test\ClassExtensionTrait;
-use Interop\Amqp\AmqpBind;
-use Interop\Amqp\AmqpContext;
-use Interop\Amqp\AmqpDestination;
-use Interop\Amqp\AmqpProducer;
 use Interop\Amqp\Impl\AmqpMessage;
-use Interop\Amqp\Impl\AmqpQueue;
-use Interop\Amqp\Impl\AmqpTopic;
-use Interop\Queue\InvalidDestinationException;
-use Interop\Queue\PsrDestination;
-use Interop\Queue\PsrMessage;
-use PHPUnit\Framework\TestCase;
 
-class RabbitMq37XDelayPluginDelayStrategyTest extends TestCase
+class RabbitMq37XDelayPluginDelayStrategyTest extends RabbitMqDelayPluginDelayStrategyTest
 {
-    use ClassExtensionTrait;
-
     public function testShouldImplementDelayStrategyInterface()
     {
         $this->assertClassImplements(DelayStrategy::class, RabbitMq37XDelayPluginDelayStrategy::class);
     }
 
-    public function testShouldSendDelayedMessageToTopic()
+    protected function buildStrategy(): DelayStrategy
     {
-        $delayedTopic = new AmqpTopic('the-topic');
-        $delayedMessage = new AmqpMessage();
-
-        $producer = $this->createProducerMock();
-        $producer
-            ->expects($this->once())
-            ->method('send')
-            ->with($this->identicalTo($delayedTopic), $this->identicalTo($delayedMessage))
-        ;
-
-        $context = $this->createContextMock();
-        $context
-            ->expects($this->once())
-            ->method('createTopic')
-            ->with($this->identicalTo('enqueue.the-topic.delayed'))
-            ->willReturn($delayedTopic)
-        ;
-        $context
-            ->expects($this->once())
-            ->method('declareTopic')
-            ->with($this->identicalTo($delayedTopic))
-        ;
-        $context
-            ->expects($this->once())
-            ->method('createProducer')
-            ->willReturn($producer)
-        ;
-        $context
-            ->expects($this->once())
-            ->method('createMessage')
-            ->with($this->identicalTo('the body'), $this->identicalTo(['key' => 'value']), $this->identicalTo(['hkey' => 'hvalue']))
-            ->willReturn($delayedMessage)
-        ;
-        $context
-            ->expects($this->once())
-            ->method('bind')
-            ->with($this->isInstanceOf(AmqpBind::class))
-        ;
-
-        $message = new AmqpMessage('the body', ['key' => 'value'], ['hkey' => 'hvalue']);
-        $message->setRoutingKey('the-routing-key');
-
-        $dest = new AmqpTopic('the-topic');
-        $dest->setFlags(12345);
-
-        $strategy = new RabbitMq37XDelayPluginDelayStrategy();
-        $strategy->delayMessage($context, $dest, $message, 10000);
-
-        $this->assertSame(12345, $delayedTopic->getFlags());
-        $this->assertSame('x-delayed-message', $delayedTopic->getType());
-        $this->assertSame([
-            'x-delayed-type' => 'direct',
-        ], $delayedTopic->getArguments());
-
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getHeaders());
-        $this->assertSame('the-routing-key', $delayedMessage->getRoutingKey());
+        return new RabbitMq37XDelayPluginDelayStrategy();
     }
 
-    public function testShouldSendDelayedMessageToQueue()
+    protected function assertXDelay(AmqpMessage $delayedMessage, int $xDelay): void
     {
-        $delayedTopic = new AmqpTopic('the-topic');
-        $delayedMessage = new AmqpMessage();
-
-        $producer = $this->createProducerMock();
-        $producer
-            ->expects($this->once())
-            ->method('send')
-            ->with($this->identicalTo($delayedTopic), $this->identicalTo($delayedMessage))
-        ;
-
-        $context = $this->createContextMock();
-        $context
-            ->expects($this->once())
-            ->method('createTopic')
-            ->with($this->identicalTo('enqueue.queue.delayed'))
-            ->willReturn($delayedTopic)
-        ;
-        $context
-            ->expects($this->once())
-            ->method('declareTopic')
-            ->with($this->identicalTo($delayedTopic))
-        ;
-        $context
-            ->expects($this->once())
-            ->method('createProducer')
-            ->willReturn($producer)
-        ;
-        $context
-            ->expects($this->once())
-            ->method('createMessage')
-            ->with($this->identicalTo('the body'), $this->identicalTo(['key' => 'value']), $this->identicalTo(['hkey' => 'hvalue']))
-            ->willReturn($delayedMessage)
-        ;
-        $context
-            ->expects($this->once())
-            ->method('bind')
-            ->with($this->isInstanceOf(AmqpBind::class))
-        ;
-
-        $message = new AmqpMessage('the body', ['key' => 'value'], ['hkey' => 'hvalue']);
-        $message->setRoutingKey('the-routing-key');
-
-        $dest = new AmqpQueue('the-queue');
-
-        $strategy = new RabbitMq37XDelayPluginDelayStrategy();
-        $strategy->delayMessage($context, $dest, $message, 10000);
-
-        $this->assertSame(AmqpQueue::FLAG_DURABLE, $delayedTopic->getFlags());
-        $this->assertSame('x-delayed-message', $delayedTopic->getType());
-        $this->assertSame([
-            'x-delayed-type' => 'direct',
-        ], $delayedTopic->getArguments());
-
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getHeaders());
-        $this->assertSame('the-queue', $delayedMessage->getRoutingKey());
-    }
-
-    public function testShouldThrowExceptionIfInvalidDestination()
-    {
-        $delayedMessage = new AmqpMessage();
-
-        $context = $this->createContextMock();
-        $context
-            ->expects($this->once())
-            ->method('createMessage')
-            ->willReturn($delayedMessage)
-        ;
-
-        $strategy = new RabbitMq37XDelayPluginDelayStrategy();
-
-        $this->expectException(InvalidDestinationException::class);
-        $this->expectExceptionMessage('The destination must be an instance of Interop\Amqp\AmqpTopic|Interop\Amqp\AmqpQueue but got');
-
-        $strategy->delayMessage($context, $this->createMock(AmqpDestination::class), new AmqpMessage(), 10000);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|AmqpContext
-     */
-    private function createContextMock()
-    {
-        return $this->createMock(AmqpContext::class);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|TestProducer
-     */
-    private function createProducerMock()
-    {
-        return $this->createMock(TestProducer::class);
-    }
-}
-
-class TestProducer implements AmqpProducer, DelayStrategy
-{
-    public function delayMessage(AmqpContext $context, AmqpDestination $dest, \Interop\Amqp\AmqpMessage $message, $delayMsec)
-    {
-    }
-
-    public function send(PsrDestination $destination, PsrMessage $message)
-    {
-    }
-
-    public function setDeliveryDelay($deliveryDelay)
-    {
-    }
-
-    public function getDeliveryDelay()
-    {
-    }
-
-    public function setPriority($priority)
-    {
-    }
-
-    public function getPriority()
-    {
-    }
-
-    public function setTimeToLive($timeToLive)
-    {
-    }
-
-    public function getTimeToLive()
-    {
+        $this->assertSame(['x-delay' => $xDelay], $delayedMessage->getHeaders());
     }
 }

--- a/pkg/amqp-tools/Tests/RabbitMq37XDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMq37XDelayPluginDelayStrategyTest.php
@@ -13,12 +13,12 @@ class RabbitMq37XDelayPluginDelayStrategyTest extends RabbitMqDelayPluginDelaySt
         $this->assertClassImplements(DelayStrategy::class, RabbitMq37XDelayPluginDelayStrategy::class);
     }
 
-    protected function buildStrategy(): DelayStrategy
+    protected function buildStrategy()
     {
         return new RabbitMq37XDelayPluginDelayStrategy();
     }
 
-    protected function assertXDelay(AmqpMessage $delayedMessage, int $xDelay): void
+    protected function assertXDelay(AmqpMessage $delayedMessage, $xDelay)
     {
         $this->assertSame(['x-delay' => $xDelay], $delayedMessage->getHeaders());
     }

--- a/pkg/amqp-tools/Tests/RabbitMq37XDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMq37XDelayPluginDelayStrategyTest.php
@@ -3,7 +3,7 @@
 namespace Enqueue\AmqpTools\Tests;
 
 use Enqueue\AmqpTools\DelayStrategy;
-use Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy;
+use Enqueue\AmqpTools\RabbitMq37XDelayPluginDelayStrategy;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Amqp\AmqpBind;
 use Interop\Amqp\AmqpContext;
@@ -17,13 +17,13 @@ use Interop\Queue\PsrDestination;
 use Interop\Queue\PsrMessage;
 use PHPUnit\Framework\TestCase;
 
-class RabbitMqDelayPluginDelayStrategyTest extends TestCase
+class RabbitMq37XDelayPluginDelayStrategyTest extends TestCase
 {
     use ClassExtensionTrait;
 
     public function testShouldImplementDelayStrategyInterface()
     {
-        $this->assertClassImplements(DelayStrategy::class, RabbitMqDelayPluginDelayStrategy::class);
+        $this->assertClassImplements(DelayStrategy::class, RabbitMq37XDelayPluginDelayStrategy::class);
     }
 
     public function testShouldSendDelayedMessageToTopic()
@@ -73,7 +73,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
         $dest = new AmqpTopic('the-topic');
         $dest->setFlags(12345);
 
-        $strategy = new RabbitMqDelayPluginDelayStrategy();
+        $strategy = new RabbitMq37XDelayPluginDelayStrategy();
         $strategy->delayMessage($context, $dest, $message, 10000);
 
         $this->assertSame(12345, $delayedTopic->getFlags());
@@ -82,7 +82,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             'x-delayed-type' => 'direct',
         ], $delayedTopic->getArguments());
 
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getProperties());
+        $this->assertSame(['x-delay' => 10000], $delayedMessage->getHeaders());
         $this->assertSame('the-routing-key', $delayedMessage->getRoutingKey());
     }
 
@@ -132,7 +132,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
 
         $dest = new AmqpQueue('the-queue');
 
-        $strategy = new RabbitMqDelayPluginDelayStrategy();
+        $strategy = new RabbitMq37XDelayPluginDelayStrategy();
         $strategy->delayMessage($context, $dest, $message, 10000);
 
         $this->assertSame(AmqpQueue::FLAG_DURABLE, $delayedTopic->getFlags());
@@ -141,7 +141,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             'x-delayed-type' => 'direct',
         ], $delayedTopic->getArguments());
 
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getProperties());
+        $this->assertSame(['x-delay' => 10000], $delayedMessage->getHeaders());
         $this->assertSame('the-queue', $delayedMessage->getRoutingKey());
     }
 
@@ -156,7 +156,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             ->willReturn($delayedMessage)
         ;
 
-        $strategy = new RabbitMqDelayPluginDelayStrategy();
+        $strategy = new RabbitMq37XDelayPluginDelayStrategy();
 
         $this->expectException(InvalidDestinationException::class);
         $this->expectExceptionMessage('The destination must be an instance of Interop\Amqp\AmqpTopic|Interop\Amqp\AmqpQueue but got');

--- a/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
@@ -82,7 +82,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             'x-delayed-type' => 'direct',
         ], $delayedTopic->getArguments());
 
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getProperties());
+        $this->assertSame(['x-delay' => 10000], $delayedMessage->getHeaders());
         $this->assertSame('the-routing-key', $delayedMessage->getRoutingKey());
     }
 
@@ -141,7 +141,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             'x-delayed-type' => 'direct',
         ], $delayedTopic->getArguments());
 
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getProperties());
+        $this->assertSame(['x-delay' => 10000], $delayedMessage->getHeaders());
         $this->assertSame('the-queue', $delayedMessage->getRoutingKey());
     }
 

--- a/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
@@ -164,12 +164,12 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
         $strategy->delayMessage($context, $this->createMock(AmqpDestination::class), new AmqpMessage(), 10000);
     }
 
-    protected function buildStrategy(): DelayStrategy
+    protected function buildStrategy()
     {
         return new RabbitMqDelayPluginDelayStrategy();
     }
 
-    protected function assertXDelay(AmqpMessage $delayedMessage, int $xDelay): void
+    protected function assertXDelay(AmqpMessage $delayedMessage, $xDelay)
     {
         $this->assertSame(['x-delay' => $xDelay], $delayedMessage->getProperties());
     }

--- a/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
@@ -73,7 +73,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
         $dest = new AmqpTopic('the-topic');
         $dest->setFlags(12345);
 
-        $strategy = new RabbitMqDelayPluginDelayStrategy();
+        $strategy = $this->buildStrategy();
         $strategy->delayMessage($context, $dest, $message, 10000);
 
         $this->assertSame(12345, $delayedTopic->getFlags());
@@ -82,7 +82,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             'x-delayed-type' => 'direct',
         ], $delayedTopic->getArguments());
 
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getProperties());
+        $this->assertXDelay($delayedMessage, 10000);
         $this->assertSame('the-routing-key', $delayedMessage->getRoutingKey());
     }
 
@@ -132,7 +132,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
 
         $dest = new AmqpQueue('the-queue');
 
-        $strategy = new RabbitMqDelayPluginDelayStrategy();
+        $strategy = $this->buildStrategy();
         $strategy->delayMessage($context, $dest, $message, 10000);
 
         $this->assertSame(AmqpQueue::FLAG_DURABLE, $delayedTopic->getFlags());
@@ -141,7 +141,7 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             'x-delayed-type' => 'direct',
         ], $delayedTopic->getArguments());
 
-        $this->assertSame(['x-delay' => 10000], $delayedMessage->getProperties());
+        $this->assertXDelay($delayedMessage, 10000);
         $this->assertSame('the-queue', $delayedMessage->getRoutingKey());
     }
 
@@ -156,12 +156,22 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
             ->willReturn($delayedMessage)
         ;
 
-        $strategy = new RabbitMqDelayPluginDelayStrategy();
+        $strategy = $this->buildStrategy();
 
         $this->expectException(InvalidDestinationException::class);
         $this->expectExceptionMessage('The destination must be an instance of Interop\Amqp\AmqpTopic|Interop\Amqp\AmqpQueue but got');
 
         $strategy->delayMessage($context, $this->createMock(AmqpDestination::class), new AmqpMessage(), 10000);
+    }
+
+    protected function buildStrategy(): DelayStrategy
+    {
+        return new RabbitMqDelayPluginDelayStrategy();
+    }
+
+    protected function assertXDelay(AmqpMessage $delayedMessage, int $xDelay): void
+    {
+        $this->assertSame(['x-delay' => $xDelay], $delayedMessage->getProperties());
     }
 
     /**


### PR DESCRIPTION
`RabbitMqDelayPluginDelayStrategy`: options x-delay must be header, not the property

https://github.com/php-enqueue/enqueue-dev/issues/455