### PR TITLE
Update of "back to index" link

### DIFF
--- a/docs/cookbook/symfony/how-to-change-consume-command-logger.md
+++ b/docs/cookbook/symfony/how-to-change-consume-command-logger.md
@@ -22,7 +22,7 @@ services:
 
 The logger extension with the highest priority will set its logger.
 
-[back to index](../index.md)  
+[back to index](../../index.md)  
 
 
 


### PR DESCRIPTION
This pull request updates "back to index" link to https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md Previous link was  linked to 404 page.