### PR TITLE
Allow either subscribe or assign in RdKafkaConsumer

### DIFF
--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -55,8 +55,7 @@ class RdKafkaConsumer implements PsrConsumer
         $this->topic = $topic;
         $this->subscribed = false;
         $this->commitAsync = false;
-        $this->offset = null;
-
+        
         $this->setSerializer($serializer);
     }
 
@@ -99,12 +98,15 @@ class RdKafkaConsumer implements PsrConsumer
     public function receive($timeout = 0)
     {
         if (false == $this->subscribed) {
-            $this->consumer->assign([new TopicPartition(
-                $this->getQueue()->getQueueName(),
-                $this->getQueue()->getPartition(),
-                $this->offset
-            )]);
-
+            if ($this->offset === null) {
+                $this->consumer->subscribe([$this->getQueue()->getQueueName()]);
+            } else {
+                $this->consumer->assign([new TopicPartition(
+                    $this->getQueue()->getQueueName(),
+                    $this->getQueue()->getPartition(),
+                    $this->offset
+                ), ]);
+            }
             $this->subscribed = true;
         }
 

--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -55,7 +55,7 @@ class RdKafkaConsumer implements PsrConsumer
         $this->topic = $topic;
         $this->subscribed = false;
         $this->commitAsync = false;
-        
+
         $this->setSerializer($serializer);
     }
 
@@ -97,15 +97,15 @@ class RdKafkaConsumer implements PsrConsumer
      */
     public function receive($timeout = 0)
     {
-        if (false == $this->subscribed) {
-            if ($this->offset === null) {
+        if (false === $this->subscribed) {
+            if (null === $this->offset) {
                 $this->consumer->subscribe([$this->getQueue()->getQueueName()]);
             } else {
                 $this->consumer->assign([new TopicPartition(
                     $this->getQueue()->getQueueName(),
                     $this->getQueue()->getPartition(),
                     $this->offset
-                ), ]);
+                )]);
             }
             $this->subscribed = true;
         }

--- a/pkg/rdkafka/Tests/RdKafkaConsumerTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaConsumerTest.php
@@ -50,7 +50,7 @@ class RdKafkaConsumerTest extends TestCase
         $kafkaConsumer = $this->createKafkaConsumerMock();
         $kafkaConsumer
             ->expects($this->once())
-            ->method('assign')
+            ->method('subscribe')
         ;
         $kafkaConsumer
             ->expects($this->once())
@@ -79,7 +79,7 @@ class RdKafkaConsumerTest extends TestCase
         $kafkaConsumer = $this->createKafkaConsumerMock();
         $kafkaConsumer
             ->expects($this->once())
-            ->method('assign')
+            ->method('subscribe')
         ;
         $kafkaConsumer
             ->expects($this->any())
@@ -109,7 +109,7 @@ class RdKafkaConsumerTest extends TestCase
         $kafkaConsumer = $this->createKafkaConsumerMock();
         $kafkaConsumer
             ->expects($this->once())
-            ->method('assign')
+            ->method('subscribe')
         ;
         $kafkaConsumer
             ->expects($this->any())
@@ -129,7 +129,7 @@ class RdKafkaConsumerTest extends TestCase
         $consumer->receive(1000);
     }
 
-    public function testThrowOnOffsetChangeAfterSubscribing()
+    public function testShouldAssignWhenOffsetIsSet()
     {
         $destination = new RdKafkaTopic('dest');
 
@@ -140,6 +140,38 @@ class RdKafkaConsumerTest extends TestCase
         $kafkaConsumer
             ->expects($this->once())
             ->method('assign')
+        ;
+        $kafkaConsumer
+            ->expects($this->any())
+            ->method('consume')
+            ->willReturn($kafkaMessage)
+        ;
+
+        $consumer = new RdKafkaConsumer(
+            $kafkaConsumer,
+            $this->createContextMock(),
+            $destination,
+            $this->createSerializerMock()
+        );
+
+        $consumer->setOffset(123);
+
+        $consumer->receive(1000);
+        $consumer->receive(1000);
+        $consumer->receive(1000);
+    }
+
+    public function testThrowOnOffsetChangeAfterSubscribing()
+    {
+        $destination = new RdKafkaTopic('dest');
+
+        $kafkaMessage = new Message();
+        $kafkaMessage->err = RD_KAFKA_RESP_ERR__TIMED_OUT;
+
+        $kafkaConsumer = $this->createKafkaConsumerMock();
+        $kafkaConsumer
+            ->expects($this->once())
+            ->method('subscribe')
         ;
         $kafkaConsumer
             ->expects($this->any())
@@ -174,7 +206,7 @@ class RdKafkaConsumerTest extends TestCase
         $kafkaConsumer = $this->createKafkaConsumerMock();
         $kafkaConsumer
             ->expects($this->once())
-            ->method('assign')
+            ->method('subscribe')
         ;
         $kafkaConsumer
             ->expects($this->once())


### PR DESCRIPTION
With `assign` it is not possible to use the rebalancing from Kafka. So if no offset is set we use `subscribe` and rebalancing is possible and otherwise if a offset is set we are using assign.