### PR TITLE
allow tls as scheme in DSN string for predis library

### DIFF
--- a/pkg/redis/RedisConnectionFactory.php
+++ b/pkg/redis/RedisConnectionFactory.php
@@ -50,11 +50,7 @@ class RedisConnectionFactory implements PsrConnectionFactory
         }
 
         $this->config = array_replace($this->defaultConfig(), $config);
-        if (isset($this->config['vendor'])) {
-            $vendor = $this->config['vendor'];
-        } else {
-            $vendor = "";
-        }
+        $vendor = $this->config['vendor'];
 
         $supportedVendors = ['predis', 'phpredis', 'custom'];
         if (false == in_array($vendor, $supportedVendors, true)) {

--- a/pkg/redis/RedisConnectionFactory.php
+++ b/pkg/redis/RedisConnectionFactory.php
@@ -118,7 +118,7 @@ class RedisConnectionFactory implements PsrConnectionFactory
     {
         $unsupportedError = 'The given DSN "%s" is not supported. Must start with "redis:".';
 
-        if ((false === strpos($dsn, 'redis:')) and (false === strpos($dsn, 'tls:'))) {
+        if ((false === strpos($dsn, 'redis:')) and (false === strpos($dsn, 'rediss:'))) {
             throw new \LogicException(sprintf($unsupportedError, $dsn));
         }
 

--- a/pkg/redis/RedisConnectionFactory.php
+++ b/pkg/redis/RedisConnectionFactory.php
@@ -50,13 +50,18 @@ class RedisConnectionFactory implements PsrConnectionFactory
         }
 
         $this->config = array_replace($this->defaultConfig(), $config);
+        if (isset($this->config['vendor'])) {
+            $vendor = $this->config['vendor'];
+        } else {
+            $vendor = "";
+        }
 
         $supportedVendors = ['predis', 'phpredis', 'custom'];
-        if (false == in_array($this->config['vendor'], $supportedVendors, true)) {
+        if (false == in_array($vendor, $supportedVendors, true)) {
             throw new \LogicException(sprintf(
                 'Unsupported redis vendor given. It must be either "%s". Got "%s"',
                 implode('", "', $supportedVendors),
-                $this->config['vendor']
+                $vendor
             ));
         }
     }
@@ -133,8 +138,15 @@ class RedisConnectionFactory implements PsrConnectionFactory
             $config = array_replace($queryConfig, $config);
         }
 
+        if (isset($config['vendor'])) {
+            $vendor = $config['vendor'];
+        } else {
+            $vendor = "";
+        }
+
+
         //predis additionaly supports tls as scheme, but it must remain in the $config array
-        if ($config['vendor']!='predis') {
+        if ($vendor!='predis') {
             if ($config['scheme']!='redis') throw new \LogicException(sprintf($unsupportedError, $dsn));
             unset($config['scheme']);
         }

--- a/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
+++ b/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
@@ -125,6 +125,46 @@ class RedisConnectionFactoryConfigTest extends TestCase
             ],
         ];
 
+        //check normal redis connection for predis library
+        yield [
+            'redis://localhost:1234?foo=bar&lazy=0&vendor=predis',
+            [
+                'host' => 'localhost',
+                'port' => 1234,
+                'timeout' => null,
+                'reserved' => null,
+                'retry_interval' => null,
+                'vendor' => 'predis',
+                'persisted' => false,
+                'lazy' => false,
+                'foo' => 'bar',
+                'database' => 0,
+                'scheme' => 'redis',
+                'redis' => null,
+            ],
+        ];
+
+        //check tls connection for predis library
+        yield [
+            'rediss://localhost:1234?foo=bar&lazy=0&vendor=predis',
+            [
+                'host' => 'localhost',
+                'port' => 1234,
+                'timeout' => null,
+                'reserved' => null,
+                'retry_interval' => null,
+                'vendor' => 'predis',
+                'persisted' => false,
+                'lazy' => false,
+                'foo' => 'bar',
+                'database' => 0,
+                'scheme' => 'rediss',
+                'redis' => null,
+            ],
+        ];
+
+
+
         yield [
             ['host' => 'localhost', 'port' => 1234, 'foo' => 'bar'],
             [


### PR DESCRIPTION
Predis allows connecting to TLS encrypted endpoints by using scheme=tls which is not allowed by current enqueue library. This is needed to connect to major cloud provider's redis services. I added the posibility to specify tls:// endpoints in DSN string for each configuration.

See predis docs for more info on TLS: https://github.com/nrk/predis

My DSN string looks as following:

    ENQUEUE_DSN=tls://xxx.redis.cache.windows.net:6380?password=yyyy&ssl[verify_peer]=1&persistent=1&vendor=predis
