### PR TITLE
Fix resolving DSN from dynamic environment variables

### DIFF
--- a/pkg/enqueue-bundle/DependencyInjection/Compiler/BuildTransportFactoriesPass.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Compiler/BuildTransportFactoriesPass.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Enqueue\Bundle\DependencyInjection\Compiler;
+
+use Enqueue\Bundle\DependencyInjection\EnqueueExtension;
+use Enqueue\Symfony\DriverFactoryInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class BuildTransportFactoriesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        /** @var EnqueueExtension $extension */
+        $extension = $container->getExtension('enqueue');
+        $config = $container->resolveEnvPlaceholders($extension->getProcessedConfig(), true);
+
+        $factories = $extension->getTransportFactories();
+        
+        foreach ($config['transport'] as $name => $transportConfig) {
+            $factories[$name]->createConnectionFactory($container, $transportConfig);
+            $factories[$name]->createContext($container, $transportConfig);
+
+            if ($factories[$name] instanceof DriverFactoryInterface && isset($config['client'])) {
+                $factories[$name]->createDriver($container, $transportConfig);
+            }
+        }
+    }
+}

--- a/pkg/enqueue-bundle/EnqueueBundle.php
+++ b/pkg/enqueue-bundle/EnqueueBundle.php
@@ -9,6 +9,7 @@ use Enqueue\AsyncEventDispatcher\DependencyInjection\AsyncEventsPass;
 use Enqueue\AsyncEventDispatcher\DependencyInjection\AsyncTransformersPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildClientExtensionsPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildClientRoutingPass;
+use Enqueue\Bundle\DependencyInjection\Compiler\BuildTransportFactoriesPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildConsumptionExtensionsPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildExclusiveCommandsExtensionPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildProcessorRegistryPass;
@@ -45,6 +46,7 @@ class EnqueueBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
+        $container->addCompilerPass(new BuildTransportFactoriesPass());
         $container->addCompilerPass(new BuildConsumptionExtensionsPass());
         $container->addCompilerPass(new BuildClientRoutingPass());
         $container->addCompilerPass(new BuildProcessorRegistryPass());

--- a/pkg/enqueue-bundle/Tests/Functional/Client/ProducerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Client/ProducerTest.php
@@ -25,9 +25,9 @@ class ProducerTest extends WebTestCase
 
     public function tearDown()
     {
-        parent::tearDown();
-
         static::$container->get(Producer::class)->clearTraces();
+
+        parent::tearDown();
     }
 
     public function testCouldBeGetFromContainerAsService()

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\Tests\Unit\DependencyInjection;
 
+use Enqueue\Bundle\DependencyInjection\Compiler\BuildTransportFactoriesPass;
 use Enqueue\Bundle\DependencyInjection\Configuration;
 use Enqueue\Bundle\DependencyInjection\EnqueueExtension;
 use Enqueue\Bundle\Tests\Unit\Mocks\FooTransportFactory;
@@ -84,15 +85,20 @@ class EnqueueExtensionTest extends TestCase
     public function testShouldEnabledNullTransportAndSetItAsDefault()
     {
         $container = $this->getContainerBuilder(true);
+        $pass = new BuildTransportFactoriesPass();
 
         $extension = new EnqueueExtension();
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'null',
                 'null' => true,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasAlias('enqueue.transport.default.context'));
         self::assertEquals('enqueue.transport.null.context', (string) $container->getAlias('enqueue.transport.default.context'));
@@ -107,13 +113,17 @@ class EnqueueExtensionTest extends TestCase
         $container = $this->getContainerBuilder(true);
 
         $extension = new EnqueueExtension();
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'null',
                 'null' => true,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertEquals(
             'enqueue.transport.default.context',
@@ -131,13 +141,17 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'foo',
                 'foo' => ['foo_param' => 'aParam'],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition('foo.connection_factory'));
         self::assertTrue($container->hasDefinition('foo.context'));
@@ -154,13 +168,17 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'foo',
                 'foo' => ['foo_param' => 'aParam'],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertEquals(
             'enqueue.transport.default.context',
@@ -178,7 +196,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'client' => null,
             'transport' => [
@@ -188,6 +206,10 @@ class EnqueueExtensionTest extends TestCase
                 ],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition('foo.driver'));
         self::assertTrue($container->hasDefinition('enqueue.client.config'));
@@ -201,7 +223,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new TransportFactoryWithoutDriverFactory());
-
+        
         $extension->load([[
             'client' => null,
             'transport' => [
@@ -209,6 +231,10 @@ class EnqueueExtensionTest extends TestCase
                 'without_driver' => [],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition('without_driver.context'));
         self::assertTrue($container->hasDefinition('without_driver.connection_factory'));
@@ -221,7 +247,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'client' => null,
             'transport' => [
@@ -231,6 +257,10 @@ class EnqueueExtensionTest extends TestCase
                 ],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $producer = $container->getDefinition(Producer::class);
         self::assertEquals(Producer::class, $producer->getClass());
@@ -242,7 +272,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'client' => [
                 'traceable_producer' => false,
@@ -254,6 +284,10 @@ class EnqueueExtensionTest extends TestCase
                 ],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $producer = $container->getDefinition(Producer::class);
         self::assertEquals(Producer::class, $producer->getClass());
@@ -265,7 +299,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'foo',
@@ -275,6 +309,10 @@ class EnqueueExtensionTest extends TestCase
             ],
             'client' => null,
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $producer = $container->getDefinition(TraceableProducer::class);
         self::assertEquals(TraceableProducer::class, $producer->getClass());
@@ -303,7 +341,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'foo',
@@ -312,6 +350,10 @@ class EnqueueExtensionTest extends TestCase
                 ],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $this->assertFalse($container->hasDefinition(TraceableProducer::class));
     }
@@ -322,7 +364,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'client' => [
                 'traceable_producer' => true,
@@ -334,6 +376,10 @@ class EnqueueExtensionTest extends TestCase
                 ],
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $producer = $container->getDefinition(TraceableProducer::class);
         self::assertEquals(TraceableProducer::class, $producer->getClass());
@@ -362,7 +408,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'foo',
@@ -374,6 +420,10 @@ class EnqueueExtensionTest extends TestCase
                 'redelivered_delay_time' => 12345,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $extension = $container->getDefinition('enqueue.client.delay_redelivered_message_extension');
 
@@ -386,7 +436,7 @@ class EnqueueExtensionTest extends TestCase
 
         $extension = new EnqueueExtension();
         $extension->addTransportFactory(new FooTransportFactory());
-
+        
         $extension->load([[
             'transport' => [
                 'default' => 'foo',
@@ -398,6 +448,10 @@ class EnqueueExtensionTest extends TestCase
                 'redelivered_delay_time' => 0,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $this->assertFalse($container->hasDefinition('enqueue.client.delay_redelivered_message_extension'));
     }
@@ -407,11 +461,15 @@ class EnqueueExtensionTest extends TestCase
         $container = $this->getContainerBuilder(true);
 
         $extension = new EnqueueExtension();
-
+        
         $extension->load([[
             'transport' => [],
             'job' => true,
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition(JobRunner::class));
     }
@@ -421,11 +479,15 @@ class EnqueueExtensionTest extends TestCase
         $container = $this->getContainerBuilder(true);
 
         $extension = new EnqueueExtension();
-
+        
         $extension->load([[
             'transport' => [],
             'job' => false,
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertFalse($container->hasDefinition(JobRunner::class));
     }
@@ -451,6 +513,10 @@ class EnqueueExtensionTest extends TestCase
                 'doctrine_ping_connection_extension' => true,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition('enqueue.consumption.doctrine_ping_connection_extension'));
     }
@@ -467,6 +533,10 @@ class EnqueueExtensionTest extends TestCase
                 'doctrine_ping_connection_extension' => false,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertFalse($container->hasDefinition('enqueue.consumption.doctrine_ping_connection_extension'));
     }
@@ -483,6 +553,10 @@ class EnqueueExtensionTest extends TestCase
                 'doctrine_clear_identity_map_extension' => true,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition('enqueue.consumption.doctrine_clear_identity_map_extension'));
     }
@@ -499,6 +573,10 @@ class EnqueueExtensionTest extends TestCase
                 'doctrine_clear_identity_map_extension' => false,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertFalse($container->hasDefinition('enqueue.consumption.doctrine_clear_identity_map_extension'));
     }
@@ -515,6 +593,10 @@ class EnqueueExtensionTest extends TestCase
                 'signal_extension' => true,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition('enqueue.consumption.signal_extension'));
     }
@@ -531,6 +613,10 @@ class EnqueueExtensionTest extends TestCase
                 'signal_extension' => false,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertFalse($container->hasDefinition('enqueue.consumption.signal_extension'));
     }
@@ -547,6 +633,10 @@ class EnqueueExtensionTest extends TestCase
                 'reply_extension' => true,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertTrue($container->hasDefinition('enqueue.consumption.reply_extension'));
     }
@@ -563,6 +653,10 @@ class EnqueueExtensionTest extends TestCase
                 'reply_extension' => false,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         self::assertFalse($container->hasDefinition('enqueue.consumption.reply_extension'));
     }
@@ -609,6 +703,10 @@ class EnqueueExtensionTest extends TestCase
                 'receive_timeout' => 456,
             ],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $def = $container->getDefinition(QueueConsumer::class);
         $this->assertSame(123, $def->getArgument(2));
@@ -648,6 +746,10 @@ class EnqueueExtensionTest extends TestCase
             'client' => [],
             'transport' => [],
         ]], $container);
+        $container->registerExtension($extension);
+        
+        $pass = new BuildTransportFactoriesPass();
+        $pass->process($container);
 
         $autoconfigured = $container->getAutoconfiguredInstanceof();
 

--- a/pkg/enqueue-bundle/Tests/Unit/EnqueueBundleTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/EnqueueBundleTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Bundle\Tests\Unit;
 
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildClientExtensionsPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildClientRoutingPass;
+use Enqueue\Bundle\DependencyInjection\Compiler\BuildTransportFactoriesPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildConsumptionExtensionsPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildExclusiveCommandsExtensionPass;
 use Enqueue\Bundle\DependencyInjection\Compiler\BuildProcessorRegistryPass;
@@ -47,40 +48,45 @@ class EnqueueBundleTest extends TestCase
         $container
             ->expects($this->at(0))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(BuildConsumptionExtensionsPass::class))
+            ->with($this->isInstanceOf(BuildTransportFactoriesPass::class))
         ;
         $container
             ->expects($this->at(1))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(BuildClientRoutingPass::class))
+            ->with($this->isInstanceOf(BuildConsumptionExtensionsPass::class))
         ;
         $container
             ->expects($this->at(2))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(BuildProcessorRegistryPass::class))
+            ->with($this->isInstanceOf(BuildClientRoutingPass::class))
         ;
         $container
             ->expects($this->at(3))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(BuildTopicMetaSubscribersPass::class))
+            ->with($this->isInstanceOf(BuildProcessorRegistryPass::class))
         ;
         $container
             ->expects($this->at(4))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(BuildQueueMetaRegistryPass::class))
+            ->with($this->isInstanceOf(BuildTopicMetaSubscribersPass::class))
         ;
         $container
             ->expects($this->at(5))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(BuildClientExtensionsPass::class))
+            ->with($this->isInstanceOf(BuildQueueMetaRegistryPass::class))
         ;
         $container
             ->expects($this->at(6))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(BuildExclusiveCommandsExtensionPass::class))
+            ->with($this->isInstanceOf(BuildClientExtensionsPass::class))
         ;
         $container
             ->expects($this->at(7))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf(BuildExclusiveCommandsExtensionPass::class))
+        ;
+        $container
+            ->expects($this->at(8))
             ->method('getExtension')
             ->willReturn($extensionMock)
         ;

--- a/pkg/enqueue/Symfony/DefaultTransportFactory.php
+++ b/pkg/enqueue/Symfony/DefaultTransportFactory.php
@@ -81,9 +81,7 @@ class DefaultTransportFactory implements TransportFactoryInterface, DriverFactor
         if (isset($config['alias'])) {
             $aliasId = sprintf('enqueue.transport.%s.connection_factory', $config['alias']);
         } else {
-            $dsn = $this->resolveDSN($container, $config['dsn']);
-
-            $aliasId = $this->findFactory($dsn)->createConnectionFactory($container, $config);
+            $aliasId = $this->findFactory($config['dsn'])->createConnectionFactory($container, $config);
         }
 
         $factoryId = sprintf('enqueue.transport.%s.connection_factory', $this->getName());
@@ -102,13 +100,11 @@ class DefaultTransportFactory implements TransportFactoryInterface, DriverFactor
         if (isset($config['alias'])) {
             $aliasId = sprintf('enqueue.transport.%s.context', $config['alias']);
         } else {
-            $dsn = $this->resolveDSN($container, $config['dsn']);
-
-            $aliasId = $this->findFactory($dsn)->createContext($container, $config);
+            $aliasId = $this->findFactory($config['dsn'])->createContext($container, $config);
         }
-
+        
         $contextId = sprintf('enqueue.transport.%s.context', $this->getName());
-
+                
         $container->setAlias($contextId, new Alias($aliasId, true));
         $container->setAlias('enqueue.transport.context', new Alias($contextId, true));
 
@@ -123,9 +119,7 @@ class DefaultTransportFactory implements TransportFactoryInterface, DriverFactor
         if (isset($config['alias'])) {
             $aliasId = sprintf('enqueue.client.%s.driver', $config['alias']);
         } else {
-            $dsn = $this->resolveDSN($container, $config['dsn']);
-
-            $aliasId = $this->findFactory($dsn)->createDriver($container, $config);
+            $aliasId = $this->findFactory($config['dsn'])->createDriver($container, $config);
         }
 
         $driverId = sprintf('enqueue.client.%s.driver', $this->getName());
@@ -142,33 +136,6 @@ class DefaultTransportFactory implements TransportFactoryInterface, DriverFactor
     public function getName()
     {
         return $this->name;
-    }
-
-    /**
-     * This is a quick fix to the exception "Incompatible use of dynamic environment variables "ENQUEUE_DSN" found in parameters."
-     * TODO: We'll have to come up with a better solution.
-     *
-     * @param ContainerBuilder $container
-     * @param $dsn
-     *
-     * @return array|false|string
-     */
-    private function resolveDSN(ContainerBuilder $container, $dsn)
-    {
-        if (method_exists($container, 'resolveEnvPlaceholders')) {
-            $dsn = $container->resolveEnvPlaceholders($dsn);
-
-            $matches = [];
-            if (preg_match('/%env\((.*?)\)/', $dsn, $matches)) {
-                if (false === $realDsn = getenv($matches[1])) {
-                    throw new \LogicException(sprintf('The env "%s" var is not defined', $matches[1]));
-                }
-
-                return $realDsn;
-            }
-        }
-
-        return $dsn;
     }
 
     /**


### PR DESCRIPTION
There was a hack in the `DefaultTransportFactory ` class named `resolveDSN` which allowed for basic environment variable resolving but not for dynamic resolving.

E.g. this would work:
```
ENQUEUE_DSN=file:///tmp

enqueue:
  transport:
    default: '%env(ENQUEUE_DSN)%'
  client: ~
```

But this wouldn't:
```
ENQUEUE_DSN=file:///%kernel.cache_dir%/enqueue

enqueue:
  transport:
    default: '%env(resolve:ENQUEUE_DSN)%'
  client: ~
```

With this fix this now works like it should.

I fixed it by moving the logic of creating connection factories, contexts and drivers to a compiler pass which allows for dynamic resolving of environment placeholders.

Because this was normally done in the extension itself, some tests had to be altered to run the compiler pass after registering the extension.