### PR TITLE
Bundle multi transport configuration

### DIFF
--- a/pkg/enqueue-bundle/EnqueueBundle.php
+++ b/pkg/enqueue-bundle/EnqueueBundle.php
@@ -23,8 +23,8 @@ class EnqueueBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         //transport passes
-        $container->addCompilerPass(new BuildConsumptionExtensionsPass('default'));
-        $container->addCompilerPass(new BuildProcessorRegistryPass('default'));
+        $container->addCompilerPass(new BuildConsumptionExtensionsPass());
+        $container->addCompilerPass(new BuildProcessorRegistryPass());
 
         //client passes
         $container->addCompilerPass(new BuildClientConsumptionExtensionsPass('default'));

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
@@ -443,6 +443,24 @@ class EnqueueExtensionTest extends TestCase
         $this->assertSame(456, $def->getArgument(4));
     }
 
+    public function testShouldSetPropertyWithAllConfiguredTransports()
+    {
+        $container = $this->getContainerBuilder(true);
+
+        $extension = new EnqueueExtension();
+        $extension->load([[
+            'client' => [],
+            'transport' => [
+                'default' => ['dsn' => 'default:'],
+                'foo' => ['dsn' => 'foo:'],
+                'bar' => ['dsn' => 'foo:'],
+            ],
+        ]], $container);
+
+        $this->assertTrue($container->hasParameter('enqueue.transports'));
+        $this->assertEquals(['default', 'foo', 'bar'], $container->getParameter('enqueue.transports'));
+    }
+
     public function testShouldLoadProcessAutoconfigureChildDefinition()
     {
         $container = $this->getContainerBuilder(true);

--- a/pkg/enqueue/Client/DriverFactory.php
+++ b/pkg/enqueue/Client/DriverFactory.php
@@ -33,7 +33,7 @@ final class DriverFactory implements DriverFactoryInterface
         $dsn = new Dsn($dsn);
 
         if ($driverInfo = $this->findDriverInfo($dsn, Resources::getAvailableDrivers())) {
-            $driverClass = $driverInfo['factoryClass'];
+            $driverClass = $driverInfo['driverClass'];
 
             if (RabbitMqDriver::class === $driverClass) {
                 if (false == $factory instanceof AmqpConnectionFactory) {

--- a/pkg/enqueue/Client/Resources.php
+++ b/pkg/enqueue/Client/Resources.php
@@ -37,7 +37,7 @@ final class Resources
 
         $availableMap = [];
         foreach ($map as $item) {
-            if (class_exists($item['factoryClass'])) {
+            if (class_exists($item['driverClass'])) {
                 $availableMap[] = $item;
             }
         }
@@ -52,67 +52,67 @@ final class Resources
 
             $map[] = [
                 'schemes' => ['amqp', 'amqps'],
-                'factoryClass' => AmqpDriver::class,
+                'driverClass' => AmqpDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/amqp-bunny'],
             ];
             $map[] = [
                 'schemes' => ['amqp', 'amqps'],
-                'factoryClass' => RabbitMqDriver::class,
+                'driverClass' => RabbitMqDriver::class,
                 'requiredSchemeExtensions' => ['rabbitmq'],
                 'packages' => ['enqueue/enqueue', 'enqueue/amqp-bunny'],
             ];
             $map[] = [
                 'schemes' => ['file'],
-                'factoryClass' => FsDriver::class,
+                'driverClass' => FsDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/fs'],
             ];
             $map[] = [
                 'schemes' => ['null'],
-                'factoryClass' => GenericDriver::class,
+                'driverClass' => GenericDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/null'],
             ];
             $map[] = [
                 'schemes' => ['gps'],
-                'factoryClass' => GpsDriver::class,
+                'driverClass' => GpsDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/gps'],
             ];
             $map[] = [
                 'schemes' => ['redis'],
-                'factoryClass' => RedisDriver::class,
+                'driverClass' => RedisDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/redis'],
             ];
             $map[] = [
                 'schemes' => ['sqs'],
-                'factoryClass' => SqsDriver::class,
+                'driverClass' => SqsDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/sqs'],
             ];
             $map[] = [
                 'schemes' => ['stomp'],
-                'factoryClass' => StompDriver::class,
+                'driverClass' => StompDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/stomp'],
             ];
             $map[] = [
                 'schemes' => ['stomp'],
-                'factoryClass' => RabbitMqStompDriver::class,
+                'driverClass' => RabbitMqStompDriver::class,
                 'requiredSchemeExtensions' => ['rabbitmq'],
                 'packages' => ['enqueue/enqueue', 'enqueue/stomp'],
             ];
             $map[] = [
                 'schemes' => ['kafka', 'rdkafka'],
-                'factoryClass' => RdKafkaDriver::class,
+                'driverClass' => RdKafkaDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/rdkafka'],
             ];
             $map[] = [
                 'schemes' => ['mongodb'],
-                'factoryClass' => MongodbDriver::class,
+                'driverClass' => MongodbDriver::class,
                 'requiredSchemeExtensions' => [],
                 'packages' => ['enqueue/enqueue', 'enqueue/mongodb'],
             ];
@@ -132,19 +132,19 @@ final class Resources
                     'sqlite3',
                     'sqlite',
                 ],
-                'factoryClass' => DbalDriver::class,
+                'driverClass' => DbalDriver::class,
                 'requiredSchemeExtensions' => [],
                 'package' => ['enqueue/enqueue', 'enqueue/dbal'],
             ];
             $map[] = [
                 'schemes' => ['gearman'],
-                'factoryClass' => GenericDriver::class,
+                'driverClass' => GenericDriver::class,
                 'requiredSchemeExtensions' => [],
                 'package' => ['enqueue/enqueue', 'enqueue/gearman'],
             ];
             $map[] = [
                 'schemes' => ['beanstalk'],
-                'factoryClass' => GenericDriver::class,
+                'driverClass' => GenericDriver::class,
                 'requiredSchemeExtensions' => [],
                 'package' => ['enqueue/enqueue', 'enqueue/pheanstalk'],
             ];
@@ -173,7 +173,7 @@ final class Resources
         self::getKnownDrivers();
         self::$knownDrivers[] = [
             'schemes' => $schemes,
-            'factoryClass' => $driverClass,
+            'driverClass' => $driverClass,
             'requiredSchemeExtensions' => $requiredExtensions,
             'packages' => $packages,
         ];

--- a/pkg/enqueue/Symfony/Client/DependencyInjection/ClientFactory.php
+++ b/pkg/enqueue/Symfony/Client/DependencyInjection/ClientFactory.php
@@ -21,7 +21,6 @@ use Enqueue\Consumption\ChainExtension as ConsumptionChainExtension;
 use Enqueue\Consumption\QueueConsumer;
 use Enqueue\Rpc\RpcFactory;
 use Enqueue\Symfony\ContainerProcessorRegistry;
-use Enqueue\Symfony\DependencyInjection\FormatClientNameTrait;
 use Interop\Queue\Context;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/pkg/enqueue/Symfony/Client/DependencyInjection/FormatClientNameTrait.php
+++ b/pkg/enqueue/Symfony/Client/DependencyInjection/FormatClientNameTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enqueue\Symfony\DependencyInjection;
+namespace Enqueue\Symfony\Client\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;

--- a/pkg/enqueue/Symfony/DependencyInjection/BuildConsumptionExtensionsPass.php
+++ b/pkg/enqueue/Symfony/DependencyInjection/BuildConsumptionExtensionsPass.php
@@ -8,55 +8,60 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class BuildConsumptionExtensionsPass implements CompilerPassInterface
 {
-    /**
-     * @var string
-     */
-    private $name;
+    use FormatTransportNameTrait;
 
-    public function __construct(string $transportName)
-    {
-        if (empty($transportName)) {
-            throw new \InvalidArgumentException('The name could not be empty.');
-        }
-
-        $this->name = $transportName;
-    }
+    protected $name;
 
     public function process(ContainerBuilder $container): void
     {
-        $extensionsId = sprintf('enqueue.transport.%s.consumption_extensions', $this->name);
-        if (false == $container->hasDefinition($extensionsId)) {
-            return;
+        if (false == $container->hasParameter('enqueue.transports')) {
+            throw new \LogicException('The "enqueue.transports" parameter must be set.');
         }
 
-        $tags = $container->findTaggedServiceIds('enqueue.transport.consumption_extension');
+        $names = $container->getParameter('enqueue.transports');
 
-        $groupByPriority = [];
-        foreach ($tags as $serviceId => $tagAttributes) {
-            foreach ($tagAttributes as $tagAttribute) {
-                $transport = $tagAttribute['transport'] ?? 'default';
+        foreach ($names as $name) {
+            $this->name = $name;
 
-                if ($transport !== $this->name && 'all' !== $transport) {
-                    continue;
-                }
-
-                $priority = (int) ($tagAttribute['priority'] ?? 0);
-
-                $groupByPriority[$priority][] = new Reference($serviceId);
+            $extensionsId = $this->format('consumption_extensions');
+            if (false == $container->hasDefinition($extensionsId)) {
+                throw new \LogicException(sprintf('Service "%s" not found', $extensionsId));
             }
+
+            $tags = $container->findTaggedServiceIds('enqueue.transport.consumption_extension');
+
+            $groupByPriority = [];
+            foreach ($tags as $serviceId => $tagAttributes) {
+                foreach ($tagAttributes as $tagAttribute) {
+                    $transport = $tagAttribute['transport'] ?? 'default';
+
+                    if ($transport !== $this->name && 'all' !== $transport) {
+                        continue;
+                    }
+
+                    $priority = (int) ($tagAttribute['priority'] ?? 0);
+
+                    $groupByPriority[$priority][] = new Reference($serviceId);
+                }
+            }
+
+            krsort($groupByPriority, SORT_NUMERIC);
+
+            $flatExtensions = [];
+            foreach ($groupByPriority as $extension) {
+                $flatExtensions = array_merge($flatExtensions, $extension);
+            }
+
+            $extensionsService = $container->getDefinition($extensionsId);
+            $extensionsService->replaceArgument(0, array_merge(
+                $extensionsService->getArgument(0),
+                $flatExtensions
+            ));
         }
+    }
 
-        krsort($groupByPriority, SORT_NUMERIC);
-
-        $flatExtensions = [];
-        foreach ($groupByPriority as $extension) {
-            $flatExtensions = array_merge($flatExtensions, $extension);
-        }
-
-        $extensionsService = $container->getDefinition($extensionsId);
-        $extensionsService->replaceArgument(0, array_merge(
-            $extensionsService->getArgument(0),
-            $flatExtensions
-        ));
+    protected function getName(): string
+    {
+        return $this->name;
     }
 }

--- a/pkg/enqueue/Symfony/DependencyInjection/FormatTransportNameTrait.php
+++ b/pkg/enqueue/Symfony/DependencyInjection/FormatTransportNameTrait.php
@@ -2,9 +2,24 @@
 
 namespace Enqueue\Symfony\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
 trait FormatTransportNameTrait
 {
     abstract protected function getName(): string;
+
+    private function reference(string $serviceName, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE): Reference
+    {
+        return new Reference($this->format($serviceName), $invalidBehavior);
+    }
+
+    private function parameter(string $serviceName): string
+    {
+        $fullName = $this->format($serviceName, false);
+
+        return "%$fullName%";
+    }
 
     private function format(string $serviceName, $parameter = false): string
     {

--- a/pkg/enqueue/Tests/Client/ResourcesTest.php
+++ b/pkg/enqueue/Tests/Client/ResourcesTest.php
@@ -33,8 +33,8 @@ class ResourcesTest extends TestCase
 
         $driverInfo = $availableDrivers[0];
 
-        $this->assertArrayHasKey('factoryClass', $driverInfo);
-        $this->assertSame(AmqpDriver::class, $driverInfo['factoryClass']);
+        $this->assertArrayHasKey('driverClass', $driverInfo);
+        $this->assertSame(AmqpDriver::class, $driverInfo['driverClass']);
 
         $this->assertArrayHasKey('schemes', $driverInfo);
         $this->assertSame(['amqp', 'amqps'], $driverInfo['schemes']);
@@ -55,8 +55,8 @@ class ResourcesTest extends TestCase
 
         $driverInfo = $availableDrivers[1];
 
-        $this->assertArrayHasKey('factoryClass', $driverInfo);
-        $this->assertSame(RabbitMqDriver::class, $driverInfo['factoryClass']);
+        $this->assertArrayHasKey('driverClass', $driverInfo);
+        $this->assertSame(RabbitMqDriver::class, $driverInfo['driverClass']);
 
         $this->assertArrayHasKey('schemes', $driverInfo);
         $this->assertSame(['amqp', 'amqps'], $driverInfo['schemes']);
@@ -77,8 +77,8 @@ class ResourcesTest extends TestCase
 
         $driverInfo = $knownDrivers[0];
 
-        $this->assertArrayHasKey('factoryClass', $driverInfo);
-        $this->assertSame(AmqpDriver::class, $driverInfo['factoryClass']);
+        $this->assertArrayHasKey('driverClass', $driverInfo);
+        $this->assertSame(AmqpDriver::class, $driverInfo['driverClass']);
 
         $this->assertArrayHasKey('schemes', $driverInfo);
         $this->assertSame(['amqp', 'amqps'], $driverInfo['schemes']);
@@ -126,7 +126,7 @@ class ResourcesTest extends TestCase
 
         $driverInfo = end($availableDrivers);
 
-        $this->assertSame('theDriverClass', $driverInfo['factoryClass']);
+        $this->assertSame('theDriverClass', $driverInfo['driverClass']);
     }
 
     public function testShouldAllowGetPreviouslyRegisteredDriver()
@@ -144,8 +144,8 @@ class ResourcesTest extends TestCase
 
         $driverInfo = end($availableDrivers);
 
-        $this->assertArrayHasKey('factoryClass', $driverInfo);
-        $this->assertSame($driverClass, $driverInfo['factoryClass']);
+        $this->assertArrayHasKey('driverClass', $driverInfo);
+        $this->assertSame($driverClass, $driverInfo['driverClass']);
 
         $this->assertArrayHasKey('schemes', $driverInfo);
         $this->assertSame(['fooscheme', 'barscheme'], $driverInfo['schemes']);

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildConsumptionExtensionsPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildConsumptionExtensionsPassTest.php
@@ -25,28 +25,29 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $this->assertClassFinal(BuildConsumptionExtensionsPass::class);
     }
 
-    public function testCouldBeConstructedWithName()
+    public function testCouldBeConstructedWithoutArguments()
     {
-        $pass = new BuildConsumptionExtensionsPass('aName');
-
-        $this->assertAttributeSame('aName', 'name', $pass);
+        new BuildConsumptionExtensionsPass();
     }
 
-    public function testThrowIfNameEmptyOnConstruct()
+    public function testThrowIfEnqueueTransportsParameterNotSet()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The name could not be empty.');
-        new BuildConsumptionExtensionsPass('');
+        $pass = new BuildConsumptionExtensionsPass();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The "enqueue.transports" parameter must be set.');
+        $pass->process(new ContainerBuilder());
     }
 
-    public function testShouldDoNothingIfExtensionsServiceIsNotRegistered()
+    public function testThrowsIfNoConsumptionExtensionsServiceFoundForConfiguredTransport()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['foo', 'bar']);
 
-        //guard
-        $this->assertFalse($container->hasDefinition('enqueue.transport.aName.consumption_extensions'));
+        $pass = new BuildConsumptionExtensionsPass();
 
-        $pass = new BuildConsumptionExtensionsPass('aName');
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Service "enqueue.transport.foo.consumption_extensions" not found');
         $pass->process($container);
     }
 
@@ -56,6 +57,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $extensions->addArgument([]);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['aName']);
         $container->setDefinition('enqueue.transport.aName.consumption_extensions', $extensions);
 
         $container->register('aFooExtension', ExtensionInterface::class)
@@ -65,7 +67,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
             ->addTag('enqueue.transport.consumption_extension', ['transport' => 'aName'])
         ;
 
-        $pass = new BuildConsumptionExtensionsPass('aName');
+        $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
         $this->assertInternalType('array', $extensions->getArgument(0));
@@ -81,6 +83,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $extensions->addArgument([]);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['aName']);
         $container->setDefinition('enqueue.transport.aName.consumption_extensions', $extensions);
 
         $container->register('aFooExtension', ExtensionInterface::class)
@@ -90,7 +93,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
             ->addTag('enqueue.transport.consumption_extension', ['transport' => 'anotherName'])
         ;
 
-        $pass = new BuildConsumptionExtensionsPass('aName');
+        $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
         $this->assertInternalType('array', $extensions->getArgument(0));
@@ -105,6 +108,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $extensions->addArgument([]);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['aName']);
         $container->setDefinition('enqueue.transport.aName.consumption_extensions', $extensions);
 
         $container->register('aFooExtension', ExtensionInterface::class)
@@ -114,7 +118,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
             ->addTag('enqueue.transport.consumption_extension', ['transport' => 'anotherName'])
         ;
 
-        $pass = new BuildConsumptionExtensionsPass('aName');
+        $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
         $this->assertInternalType('array', $extensions->getArgument(0));
@@ -129,6 +133,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $extensions->addArgument([]);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['default']);
         $container->setDefinition('enqueue.transport.default.consumption_extensions', $extensions);
 
         $container->register('aFooExtension', ExtensionInterface::class)
@@ -138,7 +143,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
             ->addTag('enqueue.transport.consumption_extension')
         ;
 
-        $pass = new BuildConsumptionExtensionsPass('default');
+        $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
         $this->assertInternalType('array', $extensions->getArgument(0));
@@ -151,6 +156,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
     public function testShouldOrderExtensionsByPriority()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['default']);
 
         $extensions = new Definition();
         $extensions->addArgument([]);
@@ -168,7 +174,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $extension->addTag('enqueue.transport.consumption_extension', ['priority' => 2]);
         $container->setDefinition('baz_extension', $extension);
 
-        $pass = new BuildConsumptionExtensionsPass('default');
+        $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
         $orderedExtensions = $extensions->getArgument(0);
@@ -182,6 +188,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
     public function testShouldAssumePriorityZeroIfPriorityIsNotSet()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['default']);
 
         $extensions = new Definition();
         $extensions->addArgument([]);
@@ -199,7 +206,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $extension->addTag('enqueue.transport.consumption_extension', ['priority' => -1]);
         $container->setDefinition('baz_extension', $extension);
 
-        $pass = new BuildConsumptionExtensionsPass('default');
+        $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
         $orderedExtensions = $extensions->getArgument(0);
@@ -219,6 +226,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         ]);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['aName']);
         $container->setDefinition('enqueue.transport.aName.consumption_extensions', $extensions);
 
         $container->register('aFooExtension', ExtensionInterface::class)
@@ -228,7 +236,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
             ->addTag('enqueue.transport.consumption_extension')
         ;
 
-        $pass = new BuildConsumptionExtensionsPass('aName');
+        $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
         $this->assertInternalType('array', $extensions->getArgument(0));

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildProcessorRegistryPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildProcessorRegistryPassTest.php
@@ -26,24 +26,30 @@ class BuildProcessorRegistryPassTest extends TestCase
         $this->assertClassFinal(BuildProcessorRegistryPass::class);
     }
 
-    public function testCouldBeConstructedWithName()
+    public function testCouldBeConstructedWithoutArguments()
     {
-        $pass = new BuildProcessorRegistryPass('aName');
-
-        $this->assertAttributeSame('aName', 'name', $pass);
+        new BuildProcessorRegistryPass();
     }
 
-    public function testThrowIfNameEmptyOnConstruct()
+    public function testThrowIfEnqueueTransportsParameterNotSet()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The name could not be empty.');
-        new BuildProcessorRegistryPass('');
-    }
+        $pass = new BuildProcessorRegistryPass();
 
-    public function testShouldDoNothingIfProcessorRegistryServiceIsNotRegistered()
-    {
-        $pass = new BuildProcessorRegistryPass('aName');
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The "enqueue.transports" parameter must be set.');
         $pass->process(new ContainerBuilder());
+    }
+
+    public function testThrowsIfNoRegistryServiceFoundForConfiguredTransport()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['foo', 'bar']);
+
+        $pass = new BuildProcessorRegistryPass();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Service "enqueue.transport.foo.processor_registry" not found');
+        $pass->process($container);
     }
 
     public function testShouldRegisterProcessorWithMatchedName()
@@ -52,6 +58,7 @@ class BuildProcessorRegistryPassTest extends TestCase
         $registry->addArgument([]);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['foo']);
         $container->setDefinition('enqueue.transport.foo.processor_registry', $registry);
         $container->register('aFooProcessor', 'aProcessorClass')
             ->addTag('enqueue.transport.processor', ['transport' => 'foo'])
@@ -60,7 +67,7 @@ class BuildProcessorRegistryPassTest extends TestCase
             ->addTag('enqueue.transport.processor', ['transport' => 'bar'])
         ;
 
-        $pass = new BuildProcessorRegistryPass('foo');
+        $pass = new BuildProcessorRegistryPass();
 
         $pass->process($container);
 
@@ -71,12 +78,47 @@ class BuildProcessorRegistryPassTest extends TestCase
         ]);
     }
 
+    public function testShouldRegisterProcessorWithMatchedNameToCorrespondingRegistries()
+    {
+        $fooRegistry = new Definition(ProcessorRegistryInterface::class);
+        $fooRegistry->addArgument([]);
+
+        $barRegistry = new Definition(ProcessorRegistryInterface::class);
+        $barRegistry->addArgument([]);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['foo', 'bar']);
+        $container->setDefinition('enqueue.transport.foo.processor_registry', $fooRegistry);
+        $container->setDefinition('enqueue.transport.bar.processor_registry', $barRegistry);
+        $container->register('aFooProcessor', 'aProcessorClass')
+            ->addTag('enqueue.transport.processor', ['transport' => 'foo'])
+        ;
+        $container->register('aBarProcessor', 'aProcessorClass')
+            ->addTag('enqueue.transport.processor', ['transport' => 'bar'])
+        ;
+
+        $pass = new BuildProcessorRegistryPass();
+
+        $pass->process($container);
+
+        $this->assertInstanceOf(Reference::class, $fooRegistry->getArgument(0));
+        $this->assertLocatorServices($container, $fooRegistry->getArgument(0), [
+            'aFooProcessor' => 'aFooProcessor',
+        ]);
+
+        $this->assertInstanceOf(Reference::class, $barRegistry->getArgument(0));
+        $this->assertLocatorServices($container, $barRegistry->getArgument(0), [
+            'aBarProcessor' => 'aBarProcessor',
+        ]);
+    }
+
     public function testShouldRegisterProcessorWithoutNameToDefaultTransport()
     {
         $registry = new Definition(ProcessorRegistryInterface::class);
         $registry->addArgument(null);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['default']);
         $container->setDefinition('enqueue.transport.default.processor_registry', $registry);
         $container->register('aFooProcessor', 'aProcessorClass')
             ->addTag('enqueue.transport.processor', [])
@@ -85,7 +127,7 @@ class BuildProcessorRegistryPassTest extends TestCase
             ->addTag('enqueue.transport.processor', ['transport' => 'bar'])
         ;
 
-        $pass = new BuildProcessorRegistryPass('default');
+        $pass = new BuildProcessorRegistryPass();
 
         $pass->process($container);
 
@@ -102,6 +144,7 @@ class BuildProcessorRegistryPassTest extends TestCase
         $registry->addArgument(null);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['default']);
         $container->setDefinition('enqueue.transport.default.processor_registry', $registry);
         $container->register('aFooProcessor', 'aProcessorClass')
             ->addTag('enqueue.transport.processor', ['transport' => 'all'])
@@ -110,7 +153,7 @@ class BuildProcessorRegistryPassTest extends TestCase
             ->addTag('enqueue.transport.processor', ['transport' => 'bar'])
         ;
 
-        $pass = new BuildProcessorRegistryPass('default');
+        $pass = new BuildProcessorRegistryPass();
 
         $pass->process($container);
 
@@ -127,12 +170,13 @@ class BuildProcessorRegistryPassTest extends TestCase
         $registry->addArgument(null);
 
         $container = new ContainerBuilder();
+        $container->setParameter('enqueue.transports', ['default']);
         $container->setDefinition('enqueue.transport.default.processor_registry', $registry);
         $container->register('aFooProcessor', 'aProcessorClass')
             ->addTag('enqueue.transport.processor', ['processor' => 'customProcessorName'])
         ;
 
-        $pass = new BuildProcessorRegistryPass('default');
+        $pass = new BuildProcessorRegistryPass();
 
         $pass->process($container);
 


### PR DESCRIPTION
These configuration are possible:

* one default transport

```yaml
enqueue: '%env(ENQUEUE_DSN)%'
```

* one default transport

```yaml
enqueue: 
  transport: '%env(ENQUEUE_DSN)%'
```

* one default transport

```yaml
enqueue: 
  transport: 
    default: '%env(ENQUEUE_DSN)%'
```

* several transports

```yaml
enqueue: 
  transport: 
    foo: '%env(AMQP_DSN)%'
    bar: 
       dsn: '%env(SQS_DSN)%'
    baz: '%env(SQS_DSN)%'
```
