### PR TITLE
Do not export non source files

### DIFF
--- a/pkg/amqp-bunny/.gitattributes
+++ b/pkg/amqp-bunny/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/amqp-ext/.gitattributes
+++ b/pkg/amqp-ext/.gitattributes
@@ -1,0 +1,6 @@
+/examples export-ignore
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/amqp-lib/.gitattributes
+++ b/pkg/amqp-lib/.gitattributes
@@ -1,0 +1,7 @@
+/examples export-ignore
+/Tests export-ignore
+/tutorial export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/amqp-tools/.gitattributes
+++ b/pkg/amqp-tools/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+.gitattributes export-ignore

--- a/pkg/async-command/.gitattributes
+++ b/pkg/async-command/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore

--- a/pkg/async-event-dispatcher/.gitattributes
+++ b/pkg/async-event-dispatcher/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/dbal/.gitattributes
+++ b/pkg/dbal/.gitattributes
@@ -1,0 +1,6 @@
+/examples export-ignore
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/dsn/.gitattributes
+++ b/pkg/dsn/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/enqueue-bundle/.gitattributes
+++ b/pkg/enqueue-bundle/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/enqueue/.gitattributes
+++ b/pkg/enqueue/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/fs/.gitattributes
+++ b/pkg/fs/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/gearman/.gitattributes
+++ b/pkg/gearman/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/gps/.gitattributes
+++ b/pkg/gps/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/job-queue/.gitattributes
+++ b/pkg/job-queue/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/mongodb/.gitattributes
+++ b/pkg/mongodb/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/null/.gitattributes
+++ b/pkg/null/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/pheanstalk/.gitattributes
+++ b/pkg/pheanstalk/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/rdkafka/.gitattributes
+++ b/pkg/rdkafka/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/redis/.gitattributes
+++ b/pkg/redis/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/simple-client/.gitattributes
+++ b/pkg/simple-client/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/sqs/.gitattributes
+++ b/pkg/sqs/.gitattributes
@@ -1,0 +1,6 @@
+/examples export-ignore
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/stomp/.gitattributes
+++ b/pkg/stomp/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/pkg/wamp/.gitattributes
+++ b/pkg/wamp/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This commit minimizes vendor directory size (so downloading and installing speed slightly increases), and prevents from including non source files