### PR TITLE
Add support for the 'ciphers' ssl option

### DIFF
--- a/pkg/amqp-lib/AmqpConnectionFactory.php
+++ b/pkg/amqp-lib/AmqpConnectionFactory.php
@@ -94,6 +94,7 @@ class AmqpConnectionFactory implements InteropAmqpConnectionFactory, DelayStrate
                         'verify_peer' => $this->config->isSslVerify(),
                         'verify_peer_name' => $this->config->isSslVerify(),
                         'passphrase' => $this->getConfig()->getSslPassPhrase(),
+                        'ciphers' => $this->config->getOption('ciphers', ''),
                     ], function ($value) { return '' !== $value; });
 
                     $con = new AMQPSSLConnection(


### PR DESCRIPTION
In order to be able to use the 'ciphers' option (http://php.net/manual/en/context.ssl.php), it needs to be declared in the $sslOptions array, so it can be passed to AMQPSSLConnection.

It will read the value from the 'driver_options' as such:
```
enqueue:
  transport:
    default: rabbitmq_amqp
    rabbitmq_amqp:
    ...
    driver_options:
      ciphers: "RSA,DHE,..."
```