### PR TITLE
Fix wrong exceptions in transports

### DIFF
--- a/pkg/gearman/GearmanProducer.php
+++ b/pkg/gearman/GearmanProducer.php
@@ -7,6 +7,7 @@ namespace Enqueue\Gearman;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Interop\Queue\Exception\InvalidMessageException;
+use Interop\Queue\Exception\PriorityNotSupportedException;
 use Interop\Queue\Message;
 use Interop\Queue\Producer;
 
@@ -59,7 +60,7 @@ class GearmanProducer implements Producer
             return $this;
         }
 
-        throw new \LogicException('Not implemented');
+        throw PriorityNotSupportedException::providerDoestNotSupportIt();
     }
 
     public function getPriority(): ?int

--- a/pkg/pheanstalk/PheanstalkProducer.php
+++ b/pkg/pheanstalk/PheanstalkProducer.php
@@ -7,6 +7,7 @@ namespace Enqueue\Pheanstalk;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Interop\Queue\Exception\InvalidMessageException;
+use Interop\Queue\Exception\PriorityNotSupportedException;
 use Interop\Queue\Message;
 use Interop\Queue\Producer;
 use Pheanstalk\Pheanstalk;
@@ -75,7 +76,7 @@ class PheanstalkProducer implements Producer
             return $this;
         }
 
-        throw new \LogicException('Not implemented');
+        throw PriorityNotSupportedException::providerDoestNotSupportIt();
     }
 
     public function getPriority(): ?int

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -7,6 +7,7 @@ namespace Enqueue\RdKafka;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Interop\Queue\Exception\InvalidMessageException;
+use Interop\Queue\Exception\PriorityNotSupportedException;
 use Interop\Queue\Message;
 use Interop\Queue\Producer;
 use RdKafka\Producer as VendorProducer;
@@ -70,7 +71,7 @@ class RdKafkaProducer implements Producer
             return $this;
         }
 
-        throw new \LogicException('Not implemented');
+        throw PriorityNotSupportedException::providerDoestNotSupportIt();
     }
 
     public function getPriority(): ?int

--- a/pkg/redis/RedisProducer.php
+++ b/pkg/redis/RedisProducer.php
@@ -7,6 +7,7 @@ namespace Enqueue\Redis;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Interop\Queue\Exception\InvalidMessageException;
+use Interop\Queue\Exception\PriorityNotSupportedException;
 use Interop\Queue\Message;
 use Interop\Queue\Producer;
 use Ramsey\Uuid\Uuid;
@@ -94,7 +95,7 @@ class RedisProducer implements Producer
             return $this;
         }
 
-        throw new \LogicException('Not implemented');
+        throw PriorityNotSupportedException::providerDoestNotSupportIt();
     }
 
     public function getPriority(): ?int

--- a/pkg/stomp/StompProducer.php
+++ b/pkg/stomp/StompProducer.php
@@ -7,6 +7,7 @@ namespace Enqueue\Stomp;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Interop\Queue\Exception\InvalidMessageException;
+use Interop\Queue\Exception\PriorityNotSupportedException;
 use Interop\Queue\Message;
 use Interop\Queue\Producer;
 use Stomp\Client;
@@ -64,7 +65,7 @@ class StompProducer implements Producer
             return $this;
         }
 
-        throw new \LogicException('Not implemented');
+        throw PriorityNotSupportedException::providerDoestNotSupportIt();
     }
 
     public function getPriority(): ?int


### PR DESCRIPTION
The `setPriority` method have to throw a PriorityNotSupportedException
if the feature is not supported.