### PR TITLE
[dsn] Parse DSN Cluster

### DIFF
--- a/docs/dsn.md
+++ b/docs/dsn.md
@@ -27,7 +27,7 @@ Basic usage:
 
 use Enqueue\Dsn\Dsn;
 
-$dsn = new Dsn('mysql+pdo://user:password@localhost:3306/database?connection_timeout=123');
+$dsn = Dsn::parseFirst('mysql+pdo://user:password@localhost:3306/database?connection_timeout=123');
 
 $dsn->getSchemeProtocol(); // 'mysql'
 $dsn->getScheme(); // 'mysql+pdo'
@@ -39,8 +39,30 @@ $dsn->getPort(); // 3306
 
 $dsn->getQueryString(); // 'connection_timeout=123'
 $dsn->getQuery(); // ['connection_timeout' => '123']
-$dsn->getQueryParameter('connection_timeout'); // '123'
-$dsn->getInt('connection_timeout'); // 123  
+$dsn->getString('connection_timeout'); // '123'
+$dsn->getDecimal('connection_timeout'); // 123  
+```
+
+Parse Cluster DSN:
+
+```php
+<?php
+
+use Enqueue\Dsn\Dsn;
+
+$dsns = Dsn::parse('mysql+pdo://user:password@foo:3306,bar:5678/database?connection_timeout=123');
+
+count($dsns); // 2
+
+$dsns[0]->getUser(); // 'user'
+$dsns[0]->getPassword(); // 'password'
+$dsns[0]->getHost(); // 'foo'
+$dsns[0]->getPort(); // 3306
+
+$dsns[1]->getUser(); // 'user'
+$dsns[1]->getPassword(); // 'password'
+$dsns[1]->getHost(); // 'bar'
+$dsns[1]->getPort(); // 5678  
 ```
 
 Some parts could be omitted:
@@ -49,7 +71,7 @@ Some parts could be omitted:
 <?php
 use Enqueue\Dsn\Dsn;
 
-$dsn = new Dsn('sqs:?key=aKey&secret=aSecret&token=aToken');
+$dsn = Dsn::parseFirst('sqs:?key=aKey&secret=aSecret&token=aToken');
 
 $dsn->getSchemeProtocol(); // 'sqs'
 $dsn->getScheme(); // 'sqs'
@@ -59,8 +81,24 @@ $dsn->getPassword(); // null
 $dsn->getHost(); // null
 $dsn->getPort(); // null
 
-$dsn->getQueryParameter('key'); // 'aKey'
-$dsn->getQueryParameter('secret'); // 'aSecret'
+$dsn->getString('key'); // 'aKey'
+$dsn->getString('secret'); // 'aSecret'
+```
+
+Get typed query params:
+
+```php
+<?php
+use Enqueue\Dsn\Dsn;
+
+$dsn = Dsn::parseFirst('sqs:?decimal=12&octal=0666&float=1.2&bool=1&array[0]=val');
+
+$dsn->getDecimal('decimal'); // 12
+$dsn->getOctal('decimal'); // 0666
+$dsn->getFloat('float'); // 1.2
+$dsn->getBool('bool'); // true
+$dsn->getArray('array')->getString(0); // val
+$dsn->getArray('array')->toArray(); // [val]
 ```
 
 Throws exception if DSN not valid:
@@ -69,7 +107,7 @@ Throws exception if DSN not valid:
 <?php
 use Enqueue\Dsn\Dsn;
 
-$dsn = new Dsn('foo'); // throws exception here
+$dsn = Dsn::parseFirst('foo'); // throws exception here
 ```
 
 Throws exception if cannot cast query parameter:
@@ -78,9 +116,9 @@ Throws exception if cannot cast query parameter:
 <?php
 use Enqueue\Dsn\Dsn;
 
-$dsn = new Dsn('mysql:?connection_timeout=notInt');
+$dsn = Dsn::parseFirst('mysql:?connection_timeout=notInt');
 
-$dsn->getInt('connection_timeout'); // throws exception here
+$dsn->getDecimal('connection_timeout'); // throws exception here
 ```
 
 [back to index](index.md)

--- a/docs/dsn.md
+++ b/docs/dsn.md
@@ -91,13 +91,14 @@ Get typed query params:
 <?php
 use Enqueue\Dsn\Dsn;
 
-$dsn = Dsn::parseFirst('sqs:?decimal=12&octal=0666&float=1.2&bool=1&array[0]=val');
+$dsn = Dsn::parseFirst('sqs:?decimal=12&octal=0666&float=1.2&bool=1&array[0]=val&array[1]=123');
 
 $dsn->getDecimal('decimal'); // 12
 $dsn->getOctal('decimal'); // 0666
 $dsn->getFloat('float'); // 1.2
 $dsn->getBool('bool'); // true
 $dsn->getArray('array')->getString(0); // val
+$dsn->getArray('array')->getDecimal(1); // 123
 $dsn->getArray('array')->toArray(); // [val]
 ```
 

--- a/pkg/amqp-tools/ConnectionConfig.php
+++ b/pkg/amqp-tools/ConnectionConfig.php
@@ -379,7 +379,7 @@ class ConnectionConfig
      */
     private function parseDsn($dsn)
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         $supportedSchemes = $this->supportedSchemes;
         if (false == in_array($dsn->getSchemeProtocol(), $supportedSchemes, true)) {
@@ -410,14 +410,14 @@ class ConnectionConfig
             'persisted' => $dsn->getBool('persisted'),
             'lazy' => $dsn->getBool('lazy'),
             'qos_global' => $dsn->getBool('qos_global'),
-            'qos_prefetch_size' => $dsn->getInt('qos_prefetch_size'),
-            'qos_prefetch_count' => $dsn->getInt('qos_prefetch_count'),
+            'qos_prefetch_size' => $dsn->getDecimal('qos_prefetch_size'),
+            'qos_prefetch_count' => $dsn->getDecimal('qos_prefetch_count'),
             'ssl_on' => $sslOn,
             'ssl_verify' => $dsn->getBool('ssl_verify'),
-            'ssl_cacert' => $dsn->getQueryParameter('ssl_cacert'),
-            'ssl_cert' => $dsn->getQueryParameter('ssl_cert'),
-            'ssl_key' => $dsn->getQueryParameter('ssl_key'),
-            'ssl_passphrase' => $dsn->getQueryParameter('ssl_passphrase'),
+            'ssl_cacert' => $dsn->getString('ssl_cacert'),
+            'ssl_cert' => $dsn->getString('ssl_cert'),
+            'ssl_key' => $dsn->getString('ssl_key'),
+            'ssl_passphrase' => $dsn->getString('ssl_passphrase'),
         ]), function ($value) { return null !== $value; });
 
         return array_map(function ($value) {

--- a/pkg/dsn/Dsn.php
+++ b/pkg/dsn/Dsn.php
@@ -250,7 +250,9 @@ class Dsn
             list($hostsPorts) = explode('#', $dsnWithoutUserPassword, 2);
             list($hostsPorts) = explode('?', $hostsPorts, 2);
             list($hostsPorts) = explode('/', $hostsPorts, 2);
-        } else {
+        }
+
+        if (empty($hostsPorts)) {
             return [
                 new self(
                     $scheme,

--- a/pkg/dsn/Dsn.php
+++ b/pkg/dsn/Dsn.php
@@ -9,12 +9,17 @@ class Dsn
     /**
      * @var string
      */
-    private $dsn;
+    private $scheme;
 
     /**
      * @var string
      */
-    private $scheme;
+    private $schemeProtocol;
+
+    /**
+     * @var string[]
+     */
+    private $schemeExtensions;
 
     /**
      * @var string|null
@@ -47,37 +52,43 @@ class Dsn
     private $queryString;
 
     /**
-     * @var array
+     * @var QueryBag
      */
-    private $query;
+    private $queryBag;
 
-    /**
-     * @var string
-     */
-    private $schemeProtocol;
-
-    /**
-     * @var string[]
-     */
-    private $schemeExtensions;
-
-    public function __construct(string $dsn)
-    {
-        $this->dsn = $dsn;
-        $this->query = [];
-
-        $this->parse($dsn);
+    public function __construct(
+        string $scheme,
+        string $schemeProtocol,
+        array $schemeExtensions,
+        ?string $user,
+        ?string $password,
+        ?string $host,
+        ?int $port,
+        ?string $path,
+        ?string $queryString,
+        array $query
+    ) {
+        $this->scheme = $scheme;
+        $this->schemeProtocol = $schemeProtocol;
+        $this->schemeExtensions = $schemeExtensions;
+        $this->user = $user;
+        $this->password = $password;
+        $this->host = $host;
+        $this->port = $port;
+        $this->path = $path;
+        $this->queryString = $queryString;
+        $this->queryBag = new QueryBag($query);
     }
 
-    public function __toString(): string
-    {
-        return $this->dsn;
-    }
-
-    public function getDsn(): string
-    {
-        return $this->dsn;
-    }
+//    public function __toString(): string
+//    {
+//        return $this->dsn;
+//    }
+//
+//    public function getDsn(): string
+//    {
+//        return $this->dsn;
+//    }
 
     public function getScheme(): string
     {
@@ -99,33 +110,21 @@ class Dsn
         return in_array($extension, $this->schemeExtensions, true);
     }
 
-    /**
-     * @return null|string
-     */
     public function getUser(): ?string
     {
         return $this->user;
     }
 
-    /**
-     * @return null|string
-     */
     public function getPassword(): ?string
     {
         return $this->password;
     }
 
-    /**
-     * @return null|string
-     */
     public function getHost(): ?string
     {
         return $this->host;
     }
 
-    /**
-     * @return int|null
-     */
     public function getPort(): ?int
     {
         return $this->port;
@@ -141,74 +140,44 @@ class Dsn
         return $this->queryString;
     }
 
+    public function getQueryBag(): QueryBag
+    {
+        return $this->queryBag;
+    }
+
     public function getQuery(): array
     {
-        return $this->query;
+        return $this->queryBag->toArray();
     }
 
-    public function getQueryParameter(string $name, string $default = null): ?string
+    public function getString(string $name, string $default = null): ?string
     {
-        return array_key_exists($name, $this->query) ? $this->query[$name] : $default;
+        return $this->queryBag->getString($name, $default);
     }
 
-    public function getInt(string $name, int $default = null): ?int
+    public function getDecimal(string $name, int $default = null): ?int
     {
-        $value = $this->getQueryParameter($name);
-        if (null === $value) {
-            return $default;
-        }
-
-        if (false == preg_match('/^[\+\-]?[0-9]*$/', $value)) {
-            throw InvalidQueryParameterTypeException::create($name, 'integer');
-        }
-
-        return (int) $value;
+        return $this->queryBag->getDecimal($name, $default);
     }
 
     public function getOctal(string $name, int $default = null): ?int
     {
-        $value = $this->getQueryParameter($name);
-        if (null === $value) {
-            return $default;
-        }
-
-        if (false == preg_match('/^0[\+\-]?[0-7]*$/', $value)) {
-            throw InvalidQueryParameterTypeException::create($name, 'integer');
-        }
-
-        return intval($value, 8);
+        return $this->queryBag->getOctal($name, $default);
     }
 
     public function getFloat(string $name, float $default = null): ?float
     {
-        $value = $this->getQueryParameter($name);
-        if (null === $value) {
-            return $default;
-        }
-
-        if (false == is_numeric($value)) {
-            throw InvalidQueryParameterTypeException::create($name, 'float');
-        }
-
-        return (float) $value;
+        return $this->queryBag->getFloat($name, $default);
     }
 
     public function getBool(string $name, bool $default = null): ?bool
     {
-        $value = $this->getQueryParameter($name);
-        if (null === $value) {
-            return $default;
-        }
+        return $this->queryBag->getBool($name, $default);
+    }
 
-        if (in_array($value, ['', '0', 'false'], true)) {
-            return false;
-        }
-
-        if (in_array($value, ['1', 'true'], true)) {
-            return true;
-        }
-
-        throw InvalidQueryParameterTypeException::create($name, 'bool');
+    public function getArray(string $name, bool $default = null): QueryBag
+    {
+        return $this->queryBag->getArray($name, $default);
     }
 
     public function toArray()
@@ -223,11 +192,21 @@ class Dsn
             'port' => $this->port,
             'path' => $this->path,
             'queryString' => $this->queryString,
-            'query' => $this->query,
+            'query' => $this->queryBag->toArray(),
         ];
     }
 
-    private function parse(string $dsn): void
+    public static function parseFirst(string $dsn): ?self
+    {
+        return self::parse($dsn)[0];
+    }
+
+    /**
+     * @param string $dsn
+     *
+     * @return Dsn[]
+     */
+    public static function parse(string $dsn): array
     {
         if (false === strpos($dsn, ':')) {
             throw new \LogicException(sprintf('The DSN is invalid. It does not have scheme separator ":".'));
@@ -241,43 +220,87 @@ class Dsn
         }
 
         $schemeParts = explode('+', $scheme);
-        $this->scheme = $scheme;
-        $this->schemeProtocol = $schemeParts[0];
+        $schemeProtocol = $schemeParts[0];
 
         unset($schemeParts[0]);
-        $this->schemeExtensions = array_values($schemeParts);
+        $schemeExtensions = array_values($schemeParts);
 
-        if ($host = parse_url($dsn, PHP_URL_HOST)) {
-            $this->host = $host;
+        $user = parse_url($dsn, PHP_URL_USER) ?: null;
+        $password = parse_url($dsn, PHP_URL_PASS) ?: null;
+
+        $path = parse_url($dsn, PHP_URL_PATH) ?: null;
+        if ($path) {
+            $path = rawurldecode($path);
         }
 
-        if ($port = parse_url($dsn, PHP_URL_PORT)) {
-            $this->port = (int) $port;
+        $query = [];
+        $queryString = parse_url($dsn, PHP_URL_QUERY) ?: null;
+        if (is_string($queryString)) {
+            $query = self::httpParseQuery($queryString, '&', PHP_QUERY_RFC3986);
+        }
+        $hostsPorts = '';
+        if (0 === strpos($dsnWithoutScheme, '//')) {
+            $dsnWithoutScheme = substr($dsnWithoutScheme, 2);
+            $dsnWithoutUserPassword = explode('@', $dsnWithoutScheme, 2);
+            $dsnWithoutUserPassword = 2 === count($dsnWithoutUserPassword) ?
+                $dsnWithoutUserPassword[1] :
+                $dsnWithoutUserPassword[0]
+            ;
+
+            list($hostsPorts) = explode('#', $dsnWithoutUserPassword, 2);
+            list($hostsPorts) = explode('?', $hostsPorts, 2);
+            list($hostsPorts) = explode('/', $hostsPorts, 2);
+        } else {
+            return [
+                new self(
+                    $scheme,
+                    $schemeProtocol,
+                    $schemeExtensions,
+                    null,
+                    null,
+                    null,
+                    null,
+                    $path,
+                    $queryString,
+                    $query
+                ),
+            ];
         }
 
-        if ($user = parse_url($dsn, PHP_URL_USER)) {
-            $this->user = $user;
+        $dsns = [];
+        $hostParts = explode(',', $hostsPorts);
+        foreach ($hostParts as $key => $hostPart) {
+            unset($hostParts[$key]);
+
+            $parts = explode(':', $hostPart, 2);
+            $host = $parts[0];
+
+            $port = null;
+            if (isset($parts[1])) {
+                $port = (int) $parts[1];
+            }
+
+            $dsns[] = new self(
+                $scheme,
+                $schemeProtocol,
+                $schemeExtensions,
+                $user,
+                $password,
+                $host,
+                $port,
+                $path,
+                $queryString,
+                $query
+            );
         }
 
-        if ($password = parse_url($dsn, PHP_URL_PASS)) {
-            $this->password = $password;
-        }
-
-        if ($path = parse_url($dsn, PHP_URL_PATH)) {
-            $this->path = rawurldecode($path);
-        }
-
-        if ($queryString = parse_url($dsn, PHP_URL_QUERY)) {
-            $this->queryString = $queryString;
-
-            $this->query = $this->httpParseQuery($queryString, '&', PHP_QUERY_RFC3986);
-        }
+        return $dsns;
     }
 
     /**
      * based on http://php.net/manual/en/function.parse-str.php#119484 with some slight modifications.
      */
-    private function httpParseQuery(string $queryString, string $argSeparator = '&', int $decType = PHP_QUERY_RFC1738): array
+    private static function httpParseQuery(string $queryString, string $argSeparator = '&', int $decType = PHP_QUERY_RFC1738): array
     {
         $result = [];
         $parts = explode($argSeparator, $queryString);

--- a/pkg/dsn/Dsn.php
+++ b/pkg/dsn/Dsn.php
@@ -175,7 +175,7 @@ class Dsn
         return $this->queryBag->getBool($name, $default);
     }
 
-    public function getArray(string $name, bool $default = null): QueryBag
+    public function getArray(string $name, array $default = []): QueryBag
     {
         return $this->queryBag->getArray($name, $default);
     }

--- a/pkg/dsn/QueryBag.php
+++ b/pkg/dsn/QueryBag.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enqueue\Dsn;
+
+class QueryBag
+{
+    /**
+     * @var array
+     */
+    private $query;
+
+    public function __construct(array $query)
+    {
+        $this->query = $query;
+    }
+
+    public function toArray(): array
+    {
+        return $this->query;
+    }
+
+    public function getString(string $name, string $default = null): ?string
+    {
+        return array_key_exists($name, $this->query) ? $this->query[$name] : $default;
+    }
+
+    public function getDecimal(string $name, int $default = null): ?int
+    {
+        $value = $this->getString($name);
+        if (null === $value) {
+            return $default;
+        }
+
+        if (false == preg_match('/^[\+\-]?[0-9]*$/', $value)) {
+            throw InvalidQueryParameterTypeException::create($name, 'decimal');
+        }
+
+        return (int) $value;
+    }
+
+    public function getOctal(string $name, int $default = null): ?int
+    {
+        $value = $this->getString($name);
+        if (null === $value) {
+            return $default;
+        }
+
+        if (false == preg_match('/^0[\+\-]?[0-7]*$/', $value)) {
+            throw InvalidQueryParameterTypeException::create($name, 'octal');
+        }
+
+        return intval($value, 8);
+    }
+
+    public function getFloat(string $name, float $default = null): ?float
+    {
+        $value = $this->getString($name);
+        if (null === $value) {
+            return $default;
+        }
+
+        if (false == is_numeric($value)) {
+            throw InvalidQueryParameterTypeException::create($name, 'float');
+        }
+
+        return (float) $value;
+    }
+
+    public function getBool(string $name, bool $default = null): ?bool
+    {
+        $value = $this->getString($name);
+        if (null === $value) {
+            return $default;
+        }
+
+        if (in_array($value, ['', '0', 'false'], true)) {
+            return false;
+        }
+
+        if (in_array($value, ['1', 'true'], true)) {
+            return true;
+        }
+
+        throw InvalidQueryParameterTypeException::create($name, 'bool');
+    }
+
+    public function getArray(string $name, bool $default = null): ?self
+    {
+        if (false == array_key_exists($name, $this->query)) {
+            return $default;
+        }
+
+        $value = $this->query[$name];
+
+        if (is_array($value)) {
+            return new self($value);
+        }
+
+        throw InvalidQueryParameterTypeException::create($name, 'array');
+    }
+}

--- a/pkg/dsn/QueryBag.php
+++ b/pkg/dsn/QueryBag.php
@@ -86,10 +86,10 @@ class QueryBag
         throw InvalidQueryParameterTypeException::create($name, 'bool');
     }
 
-    public function getArray(string $name, bool $default = null): ?self
+    public function getArray(string $name, array $default = []): self
     {
         if (false == array_key_exists($name, $this->query)) {
-            return $default;
+            return new self($default);
         }
 
         $value = $this->query[$name];

--- a/pkg/dsn/Tests/DsnTest.php
+++ b/pkg/dsn/Tests/DsnTest.php
@@ -180,6 +180,16 @@ class DsnTest extends TestCase
         $this->assertSame($expected, $dsn->getFloat('aName'));
     }
 
+    public function testShouldParseDSNWithoutAuthorityPart()
+    {
+        $dsn = Dsn::parseFirst('foo:///foo');
+
+        $this->assertNull($dsn->getUser());
+        $this->assertNull($dsn->getPassword());
+        $this->assertNull($dsn->getHost());
+        $this->assertNull($dsn->getPort());
+    }
+
     public function testShouldReturnDefaultFloatIfNotSet()
     {
         $dsn = Dsn::parseFirst('foo:');

--- a/pkg/dsn/Tests/DsnTest.php
+++ b/pkg/dsn/Tests/DsnTest.php
@@ -10,21 +10,21 @@ class DsnTest extends TestCase
 {
     public function testCouldBeConstructedWithDsnAsFirstArgument()
     {
-        new Dsn('foo://localhost:1234');
+        Dsn::parseFirst('foo://localhost:1234');
     }
 
     public function testThrowsIfSchemePartIsMissing()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The DSN is invalid. It does not have scheme separator ":".');
-        new Dsn('foobar');
+        Dsn::parseFirst('foobar');
     }
 
     public function testThrowsIfSchemeContainsIllegalSymbols()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The DSN is invalid. Scheme contains illegal symbols.');
-        new Dsn('foo_&%&^bar://localhost');
+        Dsn::parseFirst('foo_&%&^bar://localhost');
     }
 
     /**
@@ -32,7 +32,7 @@ class DsnTest extends TestCase
      */
     public function testShouldParseSchemeCorrectly(string $dsn, string $expectedScheme, string $expectedSchemeProtocol, array $expectedSchemeExtensions)
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         $this->assertSame($expectedScheme, $dsn->getScheme());
         $this->assertSame($expectedSchemeProtocol, $dsn->getSchemeProtocol());
@@ -41,49 +41,49 @@ class DsnTest extends TestCase
 
     public function testShouldParseUser()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/thePath');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/thePath');
 
         $this->assertSame('theUser', $dsn->getUser());
     }
 
     public function testShouldParsePassword()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/thePath');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/thePath');
 
         $this->assertSame('thePass', $dsn->getPassword());
     }
 
     public function testShouldParseHost()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/thePath');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/thePath');
 
         $this->assertSame('theHost', $dsn->getHost());
     }
 
     public function testShouldParsePort()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/thePath');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/thePath');
 
         $this->assertSame(1267, $dsn->getPort());
     }
 
     public function testShouldParsePath()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/thePath');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/thePath');
 
         $this->assertSame('/thePath', $dsn->getPath());
     }
 
     public function testShouldUrlDecodedPath()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/%2f');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/%2f');
 
         $this->assertSame('//', $dsn->getPath());
     }
 
     public function testShouldParseQuery()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/thePath?foo=fooVal&bar=bar%2fVal');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/thePath?foo=fooVal&bar=bar%2fVal');
 
         $this->assertSame('foo=fooVal&bar=bar%2fVal', $dsn->getQueryString());
         $this->assertSame(['foo' => 'fooVal', 'bar' => 'bar/Val'], $dsn->getQuery());
@@ -91,7 +91,7 @@ class DsnTest extends TestCase
 
     public function testShouldParseQueryShouldPreservePlusSymbol()
     {
-        $dsn = new Dsn('amqp+ext://theUser:thePass@theHost:1267/thePath?foo=fooVal&bar=bar+Val');
+        $dsn = Dsn::parseFirst('amqp+ext://theUser:thePass@theHost:1267/thePath?foo=fooVal&bar=bar+Val');
 
         $this->assertSame('foo=fooVal&bar=bar+Val', $dsn->getQueryString());
         $this->assertSame(['foo' => 'fooVal', 'bar' => 'bar+Val'], $dsn->getQuery());
@@ -102,9 +102,9 @@ class DsnTest extends TestCase
      */
     public function testShouldParseQueryParameterAsInt(string $parameter, int $expected)
     {
-        $dsn = new Dsn('foo:?aName='.$parameter);
+        $dsn = Dsn::parseFirst('foo:?aName='.$parameter);
 
-        $this->assertSame($expected, $dsn->getInt('aName'));
+        $this->assertSame($expected, $dsn->getDecimal('aName'));
     }
 
     /**
@@ -112,53 +112,62 @@ class DsnTest extends TestCase
      */
     public function testShouldParseQueryParameterAsOctalInt(string $parameter, int $expected)
     {
-        $dsn = new Dsn('foo:?aName='.$parameter);
+        $dsn = Dsn::parseFirst('foo:?aName='.$parameter);
 
         $this->assertSame($expected, $dsn->getOctal('aName'));
     }
 
     public function testShouldReturnDefaultIntIfNotSet()
     {
-        $dsn = new Dsn('foo:');
+        $dsn = Dsn::parseFirst('foo:');
 
-        $this->assertNull($dsn->getInt('aName'));
-        $this->assertSame(123, $dsn->getInt('aName', 123));
+        $this->assertNull($dsn->getDecimal('aName'));
+        $this->assertSame(123, $dsn->getDecimal('aName', 123));
     }
 
-    public function testThrowIfQueryParameterNotInt()
+    public function testThrowIfQueryParameterNotDecimal()
     {
-        $dsn = new Dsn('foo:?aName=notInt');
+        $dsn = Dsn::parseFirst('foo:?aName=notInt');
 
         $this->expectException(InvalidQueryParameterTypeException::class);
-        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "integer"');
-        $dsn->getInt('aName');
+        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "decimal"');
+        $dsn->getDecimal('aName');
     }
 
     public function testThrowIfQueryParameterNotOctalButString()
     {
-        $dsn = new Dsn('foo:?aName=notInt');
+        $dsn = Dsn::parseFirst('foo:?aName=notInt');
 
         $this->expectException(InvalidQueryParameterTypeException::class);
-        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "integer"');
+        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "octal"');
         $dsn->getOctal('aName');
     }
 
     public function testThrowIfQueryParameterNotOctalButDecimal()
     {
-        $dsn = new Dsn('foo:?aName=123');
+        $dsn = Dsn::parseFirst('foo:?aName=123');
 
         $this->expectException(InvalidQueryParameterTypeException::class);
-        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "integer"');
+        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "octal"');
         $dsn->getOctal('aName');
     }
 
     public function testThrowIfQueryParameterInvalidOctal()
     {
-        $dsn = new Dsn('foo:?aName=0128');
+        $dsn = Dsn::parseFirst('foo:?aName=0128');
 
         $this->expectException(InvalidQueryParameterTypeException::class);
-        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "integer"');
+        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "octal"');
         $dsn->getOctal('aName');
+    }
+
+    public function testThrowIfQueryParameterInvalidArray()
+    {
+        $dsn = Dsn::parseFirst('foo:?aName=foo');
+
+        $this->expectException(InvalidQueryParameterTypeException::class);
+        $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "array"');
+        $dsn->getArray('aName');
     }
 
     /**
@@ -166,14 +175,14 @@ class DsnTest extends TestCase
      */
     public function testShouldParseQueryParameterAsFloat(string $parameter, float $expected)
     {
-        $dsn = new Dsn('foo:?aName='.$parameter);
+        $dsn = Dsn::parseFirst('foo:?aName='.$parameter);
 
         $this->assertSame($expected, $dsn->getFloat('aName'));
     }
 
     public function testShouldReturnDefaultFloatIfNotSet()
     {
-        $dsn = new Dsn('foo:');
+        $dsn = Dsn::parseFirst('foo:');
 
         $this->assertNull($dsn->getFloat('aName'));
         $this->assertSame(123., $dsn->getFloat('aName', 123.));
@@ -181,7 +190,7 @@ class DsnTest extends TestCase
 
     public function testThrowIfQueryParameterNotFloat()
     {
-        $dsn = new Dsn('foo:?aName=notFloat');
+        $dsn = Dsn::parseFirst('foo:?aName=notFloat');
 
         $this->expectException(InvalidQueryParameterTypeException::class);
         $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "float"');
@@ -193,14 +202,24 @@ class DsnTest extends TestCase
      */
     public function testShouldParseQueryParameterAsBoolean(string $parameter, bool $expected)
     {
-        $dsn = new Dsn('foo:?aName='.$parameter);
+        $dsn = Dsn::parseFirst('foo:?aName='.$parameter);
 
         $this->assertSame($expected, $dsn->getBool('aName'));
     }
 
+    /**
+     * @dataProvider provideArrayQueryParameters
+     */
+    public function testShouldParseQueryParameterAsArray(string $query, array $expected)
+    {
+        $dsn = Dsn::parseFirst('foo:?'.$query);
+
+        $this->assertSame($expected, $dsn->getArray('aName')->toArray());
+    }
+
     public function testShouldReturnDefaultBoolIfNotSet()
     {
-        $dsn = new Dsn('foo:');
+        $dsn = Dsn::parseFirst('foo:');
 
         $this->assertNull($dsn->getBool('aName'));
         $this->assertTrue($dsn->getBool('aName', true));
@@ -208,11 +227,149 @@ class DsnTest extends TestCase
 
     public function testThrowIfQueryParameterNotBool()
     {
-        $dsn = new Dsn('foo:?aName=notBool');
+        $dsn = Dsn::parseFirst('foo:?aName=notBool');
 
         $this->expectException(InvalidQueryParameterTypeException::class);
         $this->expectExceptionMessage('The query parameter "aName" has invalid type. It must be "bool"');
         $dsn->getBool('aName');
+    }
+
+    public function testShouldParseMultipleDsnsWithUsernameAndPassword()
+    {
+        $dsns = Dsn::parse('foo://user:pass@foo,bar');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $this->assertSame('user', $dsns[0]->getUser());
+        $this->assertSame('pass', $dsns[0]->getPassword());
+        $this->assertSame('foo', $dsns[0]->getHost());
+
+        $this->assertSame('user', $dsns[1]->getUser());
+        $this->assertSame('pass', $dsns[1]->getPassword());
+        $this->assertSame('bar', $dsns[1]->getHost());
+    }
+
+    public function testShouldParseMultipleDsnsWithPorts()
+    {
+        $dsns = Dsn::parse('foo://foo:123,bar:567');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $this->assertSame('foo', $dsns[0]->getHost());
+        $this->assertSame(123, $dsns[0]->getPort());
+
+        $this->assertSame('bar', $dsns[1]->getHost());
+        $this->assertSame(567, $dsns[1]->getPort());
+    }
+
+    public function testShouldParseMultipleDsnsWhenFirstHasPort()
+    {
+        $dsns = Dsn::parse('foo://foo:123,bar');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $this->assertSame('foo', $dsns[0]->getHost());
+        $this->assertSame(123, $dsns[0]->getPort());
+
+        $this->assertSame('bar', $dsns[1]->getHost());
+        $this->assertNull($dsns[1]->getPort());
+    }
+
+    public function testShouldParseMultipleDsnsWhenLastHasPort()
+    {
+        $dsns = Dsn::parse('foo://foo,bar:567');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $this->assertSame('foo', $dsns[0]->getHost());
+        $this->assertNull($dsns[0]->getPort());
+
+        $this->assertSame('bar', $dsns[1]->getHost());
+        $this->assertSame(567, $dsns[1]->getPort());
+    }
+
+    public function testShouldParseMultipleDsnsWithPath()
+    {
+        $dsns = Dsn::parse('foo://foo:123,bar:567/foo/bar');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $this->assertSame('foo', $dsns[0]->getHost());
+        $this->assertSame(123, $dsns[0]->getPort());
+
+        $this->assertSame('bar', $dsns[1]->getHost());
+        $this->assertSame(567, $dsns[1]->getPort());
+    }
+
+    public function testShouldParseMultipleDsnsWithQuery()
+    {
+        $dsns = Dsn::parse('foo://foo:123,bar:567?foo=val');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $this->assertSame('foo', $dsns[0]->getHost());
+        $this->assertSame(123, $dsns[0]->getPort());
+
+        $this->assertSame('bar', $dsns[1]->getHost());
+        $this->assertSame(567, $dsns[1]->getPort());
+    }
+
+    public function testShouldParseMultipleDsnsWithQueryAndPath()
+    {
+        $dsns = Dsn::parse('foo://foo:123,bar:567/foo?foo=val');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $this->assertSame('foo', $dsns[0]->getHost());
+        $this->assertSame(123, $dsns[0]->getPort());
+
+        $this->assertSame('bar', $dsns[1]->getHost());
+        $this->assertSame(567, $dsns[1]->getPort());
+    }
+
+    public function testShouldParseMultipleDsnsIfOnlyColonProvided()
+    {
+        $dsns = Dsn::parse(':');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(1, $dsns);
+
+        $this->assertNull($dsns[0]->getHost());
+        $this->assertNull($dsns[0]->getPort());
+    }
+
+    public function testShouldParseMultipleDsnsWithOnlyScheme()
+    {
+        $dsns = Dsn::parse('foo:');
+
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(1, $dsns);
+
+        $this->assertSame('foo', $dsns[0]->getScheme());
+        $this->assertNull($dsns[0]->getHost());
+        $this->assertNull($dsns[0]->getPort());
+    }
+
+    public function testShouldParseExpectedNumberOfMultipleDsns()
+    {
+        $dsns = Dsn::parse('foo://foo');
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(1, $dsns);
+
+        $dsns = Dsn::parse('foo://foo,bar');
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(2, $dsns);
+
+        $dsns = Dsn::parse('foo://foo,bar,baz');
+        $this->assertContainsOnly(Dsn::class, $dsns);
+        $this->assertCount(3, $dsns);
     }
 
     public static function provideSchemes()
@@ -272,5 +429,16 @@ class DsnTest extends TestCase
         yield ['true', true];
 
         yield ['false', false];
+    }
+
+    public static function provideArrayQueryParameters()
+    {
+        yield ['aName[0]=val', ['val']];
+
+        yield ['aName[key]=val', ['key' => 'val']];
+
+        yield ['aName[0]=fooVal&aName[1]=barVal', ['fooVal', 'barVal']];
+
+        yield ['aName[foo]=fooVal&aName[bar]=barVal', ['foo' => 'fooVal', 'bar' => 'barVal']];
     }
 }

--- a/pkg/enqueue/Client/DriverFactory.php
+++ b/pkg/enqueue/Client/DriverFactory.php
@@ -30,7 +30,7 @@ final class DriverFactory implements DriverFactoryInterface
 
     public function create(ConnectionFactory $factory, string $dsn, array $config): DriverInterface
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         if ($driverInfo = $this->findDriverInfo($dsn, Resources::getAvailableDrivers())) {
             $driverClass = $driverInfo['driverClass'];

--- a/pkg/enqueue/ConnectionFactoryFactory.php
+++ b/pkg/enqueue/ConnectionFactoryFactory.php
@@ -21,7 +21,7 @@ final class ConnectionFactoryFactory implements ConnectionFactoryFactoryInterfac
             throw new \InvalidArgumentException('The config must have dsn key set.');
         }
 
-        $dsn = new Dsn($config['dsn']);
+        $dsn = Dsn::parseFirst($config['dsn']);
 
         if ($factoryClass = $this->findFactoryClass($dsn, Resources::getAvailableConnections())) {
             return new $factoryClass(1 === count($config) ? $config['dsn'] : $config);

--- a/pkg/fs/FsConnectionFactory.php
+++ b/pkg/fs/FsConnectionFactory.php
@@ -70,7 +70,7 @@ class FsConnectionFactory implements ConnectionFactory
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         $supportedSchemes = ['file'];
         if (false == in_array($dsn->getSchemeProtocol(), $supportedSchemes, true)) {
@@ -83,9 +83,9 @@ class FsConnectionFactory implements ConnectionFactory
 
         return array_filter(array_replace($dsn->getQuery(), [
             'path' => $dsn->getPath(),
-            'pre_fetch_count' => $dsn->getInt('pre_fetch_count'),
+            'pre_fetch_count' => $dsn->getDecimal('pre_fetch_count'),
             'chmod' => $dsn->getOctal('chmod'),
-            'polling_interval' => $dsn->getInt('polling_interval'),
+            'polling_interval' => $dsn->getDecimal('polling_interval'),
         ]), function ($value) { return null !== $value; });
     }
 

--- a/pkg/gps/GpsConnectionFactory.php
+++ b/pkg/gps/GpsConnectionFactory.php
@@ -85,7 +85,7 @@ class GpsConnectionFactory implements ConnectionFactory
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         if ('gps' !== $dsn->getSchemeProtocol()) {
             throw new \LogicException(sprintf(
@@ -94,14 +94,14 @@ class GpsConnectionFactory implements ConnectionFactory
             ));
         }
 
-        $emulatorHost = $dsn->getQueryParameter('emulatorHost');
+        $emulatorHost = $dsn->getString('emulatorHost');
         $hasEmulator = $emulatorHost ? true : null;
 
         return array_filter(array_replace($dsn->getQuery(), [
-            'projectId' => $dsn->getQueryParameter('projectId'),
-            'keyFilePath' => $dsn->getQueryParameter('keyFilePath'),
-            'retries' => $dsn->getInt('retries'),
-            'scopes' => $dsn->getQueryParameter('scopes'),
+            'projectId' => $dsn->getString('projectId'),
+            'keyFilePath' => $dsn->getString('keyFilePath'),
+            'retries' => $dsn->getDecimal('retries'),
+            'scopes' => $dsn->getString('scopes'),
             'emulatorHost' => $emulatorHost,
             'hasEmulator' => $hasEmulator,
             'lazy' => $dsn->getBool('lazy'),

--- a/pkg/monitoring/GenericStatsStorageFactory.php
+++ b/pkg/monitoring/GenericStatsStorageFactory.php
@@ -22,7 +22,7 @@ class GenericStatsStorageFactory implements StatsStorageFactory
             throw new \InvalidArgumentException('The config must have dsn key set.');
         }
 
-        $dsn = new Dsn($config['dsn']);
+        $dsn = Dsn::parseFirst($config['dsn']);
 
         if ($storageClass = $this->findStorageClass($dsn, Resources::getKnownStorages())) {
             return new $storageClass(1 === count($config) ? $config['dsn'] : $config);

--- a/pkg/monitoring/InfluxDbStorage.php
+++ b/pkg/monitoring/InfluxDbStorage.php
@@ -182,7 +182,7 @@ class InfluxDbStorage implements StatsStorage
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         if (false === in_array($dsn->getSchemeProtocol(), ['influxdb'], true)) {
             throw new \LogicException(sprintf(
@@ -196,10 +196,10 @@ class InfluxDbStorage implements StatsStorage
             'port' => $dsn->getPort(),
             'user' => $dsn->getUser(),
             'password' => $dsn->getPassword(),
-            'db' => $dsn->getQueryParameter('db'),
-            'measurementSentMessages' => $dsn->getQueryParameter('measurementSentMessages'),
-            'measurementConsumedMessages' => $dsn->getQueryParameter('measurementConsumedMessages'),
-            'measurementConsumers' => $dsn->getQueryParameter('measurementConsumers'),
+            'db' => $dsn->getString('db'),
+            'measurementSentMessages' => $dsn->getString('measurementSentMessages'),
+            'measurementConsumedMessages' => $dsn->getString('measurementConsumedMessages'),
+            'measurementConsumers' => $dsn->getString('measurementConsumers'),
         ]), function ($value) { return null !== $value; });
     }
 }

--- a/pkg/monitoring/WampStorage.php
+++ b/pkg/monitoring/WampStorage.php
@@ -192,7 +192,7 @@ class WampStorage implements StatsStorage
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         if (false === in_array($dsn->getSchemeProtocol(), ['wamp', 'ws'], true)) {
             throw new \LogicException(sprintf(
@@ -204,10 +204,10 @@ class WampStorage implements StatsStorage
         return array_filter(array_replace($dsn->getQuery(), [
             'host' => $dsn->getHost(),
             'port' => $dsn->getPort(),
-            'topic' => $dsn->getQueryParameter('topic'),
-            'max_retries' => $dsn->getInt('max_retries'),
+            'topic' => $dsn->getString('topic'),
+            'max_retries' => $dsn->getDecimal('max_retries'),
             'initial_retry_delay' => $dsn->getFloat('initial_retry_delay'),
-            'max_retry_delay' => $dsn->getInt('max_retry_delay'),
+            'max_retry_delay' => $dsn->getDecimal('max_retry_delay'),
             'retry_delay_growth' => $dsn->getFloat('retry_delay_growth'),
         ]), function ($value) { return null !== $value; });
     }

--- a/pkg/redis/RedisConnectionFactory.php
+++ b/pkg/redis/RedisConnectionFactory.php
@@ -110,7 +110,7 @@ class RedisConnectionFactory implements ConnectionFactory
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         $supportedSchemes = ['redis', 'rediss', 'tcp', 'tls', 'unix'];
         if (false == in_array($dsn->getSchemeProtocol(), $supportedSchemes, true)) {
@@ -121,7 +121,7 @@ class RedisConnectionFactory implements ConnectionFactory
             ));
         }
 
-        $database = $dsn->getInt('database');
+        $database = $dsn->getDecimal('database');
 
         // try use path as database name if not set.
         if (null === $database && 'unix' !== $dsn->getSchemeProtocol() && null !== $dsn->getPath()) {

--- a/pkg/sqs/SqsConnectionFactory.php
+++ b/pkg/sqs/SqsConnectionFactory.php
@@ -114,7 +114,7 @@ class SqsConnectionFactory implements ConnectionFactory
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         if ('sqs' !== $dsn->getSchemeProtocol()) {
             throw new \LogicException(sprintf(
@@ -124,14 +124,14 @@ class SqsConnectionFactory implements ConnectionFactory
         }
 
         return array_filter(array_replace($dsn->getQuery(), [
-            'key' => $dsn->getQueryParameter('key'),
-            'secret' => $dsn->getQueryParameter('secret'),
-            'token' => $dsn->getQueryParameter('token'),
-            'region' => $dsn->getQueryParameter('region'),
-            'retries' => $dsn->getInt('retries'),
-            'version' => $dsn->getQueryParameter('version'),
+            'key' => $dsn->getString('key'),
+            'secret' => $dsn->getString('secret'),
+            'token' => $dsn->getString('token'),
+            'region' => $dsn->getString('region'),
+            'retries' => $dsn->getDecimal('retries'),
+            'version' => $dsn->getString('version'),
             'lazy' => $dsn->getBool('lazy'),
-            'endpoint' => $dsn->getQueryParameter('endpoint'),
+            'endpoint' => $dsn->getString('endpoint'),
         ]), function ($value) { return null !== $value; });
     }
 

--- a/pkg/stomp/StompConnectionFactory.php
+++ b/pkg/stomp/StompConnectionFactory.php
@@ -97,7 +97,7 @@ class StompConnectionFactory implements ConnectionFactory
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         if ('stomp' !== $dsn->getSchemeProtocol()) {
             throw new \LogicException(sprintf('The given DSN "%s" is not supported. Must start with "stomp:".', $dsn));
@@ -109,8 +109,8 @@ class StompConnectionFactory implements ConnectionFactory
             'login' => $dsn->getUser(),
             'password' => $dsn->getPassword(),
             'vhost' => null !== $dsn->getPath() ? ltrim($dsn->getPath(), '/') : null,
-            'buffer_size' => $dsn->getInt('buffer_size'),
-            'connection_timeout' => $dsn->getInt('connection_timeout'),
+            'buffer_size' => $dsn->getDecimal('buffer_size'),
+            'connection_timeout' => $dsn->getDecimal('connection_timeout'),
             'sync' => $dsn->getBool('sync'),
             'lazy' => $dsn->getBool('lazy'),
             'ssl_on' => $dsn->getBool('ssl_on'),

--- a/pkg/stomp/StompConnectionFactory.php
+++ b/pkg/stomp/StompConnectionFactory.php
@@ -100,7 +100,7 @@ class StompConnectionFactory implements ConnectionFactory
         $dsn = Dsn::parseFirst($dsn);
 
         if ('stomp' !== $dsn->getSchemeProtocol()) {
-            throw new \LogicException(sprintf('The given DSN "%s" is not supported. Must start with "stomp:".', $dsn));
+            throw new \LogicException(sprintf('The given DSN is not supported. Must start with "stomp:".'));
         }
 
         return array_filter(array_replace($dsn->getQuery(), [

--- a/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
+++ b/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
@@ -24,7 +24,7 @@ class StompConnectionFactoryConfigTest extends TestCase
     public function testThrowIfSchemeIsNotStomp()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The given DSN "http://example.com" is not supported. Must start with "stomp:".');
+        $this->expectExceptionMessage('The given DSN is not supported. Must start with "stomp:".');
 
         new StompConnectionFactory('http://example.com');
     }

--- a/pkg/test/RabbitManagementExtensionTrait.php
+++ b/pkg/test/RabbitManagementExtensionTrait.php
@@ -11,7 +11,7 @@ trait RabbitManagementExtensionTrait
      */
     private function removeQueue($queueName)
     {
-        $dsn = new Dsn(getenv('RABBITMQ_AMQP_DSN'));
+        $dsn = Dsn::parseFirst(getenv('RABBITMQ_AMQP_DSN'));
 
         $url = sprintf(
             'http://%s:15672/api/queues/%s/%s',
@@ -45,7 +45,7 @@ trait RabbitManagementExtensionTrait
      */
     private function removeExchange($exchangeName)
     {
-        $dsn = new Dsn(getenv('RABBITMQ_AMQP_DSN'));
+        $dsn = Dsn::parseFirst(getenv('RABBITMQ_AMQP_DSN'));
 
         $url = sprintf(
             'http://%s:15672/api/exchanges/%s/%s',

--- a/pkg/wamp/WampConnectionFactory.php
+++ b/pkg/wamp/WampConnectionFactory.php
@@ -85,7 +85,7 @@ class WampConnectionFactory implements ConnectionFactory
 
     private function parseDsn(string $dsn): array
     {
-        $dsn = new Dsn($dsn);
+        $dsn = Dsn::parseFirst($dsn);
 
         if (false === in_array($dsn->getSchemeProtocol(), ['wamp', 'ws'], true)) {
             throw new \LogicException(sprintf(
@@ -97,9 +97,9 @@ class WampConnectionFactory implements ConnectionFactory
         return array_filter(array_replace($dsn->getQuery(), [
             'host' => $dsn->getHost(),
             'port' => $dsn->getPort(),
-            'max_retries' => $dsn->getInt('max_retries'),
+            'max_retries' => $dsn->getDecimal('max_retries'),
             'initial_retry_delay' => $dsn->getFloat('initial_retry_delay'),
-            'max_retry_delay' => $dsn->getInt('max_retry_delay'),
+            'max_retry_delay' => $dsn->getDecimal('max_retry_delay'),
             'retry_delay_growth' => $dsn->getFloat('retry_delay_growth'),
         ]), function ($value) { return null !== $value; });
     }


### PR DESCRIPTION
Parse Cluster DSN:

```php
<?php

use Enqueue\Dsn\Dsn;

$dsns = Dsn::parse('mysql+pdo://user:password@foo:3306,bar:5678/database?connection_timeout=123');

count($dsns); // 2

$dsns[0]->getUser(); // 'user'
$dsns[0]->getPassword(); // 'password'
$dsns[0]->getHost(); // 'foo'
$dsns[0]->getPort(); // 3306

$dsns[1]->getUser(); // 'user'
$dsns[1]->getPassword(); // 'password'
$dsns[1]->getHost(); // 'bar'
$dsns[1]->getPort(); // 5678  
```

Get typed query params:

```php
<?php
use Enqueue\Dsn\Dsn;

$dsn = Dsn::parseFirst('sqs:?decimal=12&octal=0666&float=1.2&bool=1&array[0]=val');

$dsn->getDecimal('decimal'); // 12
$dsn->getOctal('decimal'); // 0666
$dsn->getFloat('float'); // 1.2
$dsn->getBool('bool'); // true
$dsn->getArray('array')->getString(0); // val
$dsn->getArray('array')->toArray(); // [val]
```

fixes https://github.com/php-enqueue/enqueue-dev/issues/624