### PR TITLE
[amqp][lib] Improve heartbeat handling. Introduce heartbeat on tick. Fixes "Invalid frame type 65" and "Broken pipe or closed connection"

### DIFF
--- a/pkg/amqp-lib/AmqpConnectionFactory.php
+++ b/pkg/amqp-lib/AmqpConnectionFactory.php
@@ -47,6 +47,7 @@ class AmqpConnectionFactory implements InteropAmqpConnectionFactory, DelayStrate
             ->addDefaultOption('login_response', null)
             ->addDefaultOption('locale', 'en_US')
             ->addDefaultOption('keepalive', false)
+            ->addDefaultOption('heartbeat_on_tick', true)
             ->parse()
         ;
 

--- a/pkg/amqp-lib/AmqpContext.php
+++ b/pkg/amqp-lib/AmqpContext.php
@@ -110,7 +110,7 @@ class AmqpContext implements InteropAmqpContext, DelayStrategyAware
      */
     public function createSubscriptionConsumer(): SubscriptionConsumer
     {
-        return new AmqpSubscriptionConsumer($this);
+        return new AmqpSubscriptionConsumer($this, (bool) $this->config['heartbeat_on_tick']);
     }
 
     /**

--- a/pkg/amqp-lib/AmqpSubscriptionConsumer.php
+++ b/pkg/amqp-lib/AmqpSubscriptionConsumer.php
@@ -51,7 +51,7 @@ class AmqpSubscriptionConsumer implements InteropAmqpSubscriptionConsumer
             $context->getLibChannel()->getConnection()->getIO()->check_heartbeat();
         };
 
-        $this->heartbeatOnTick && register_tick_function($heartbeatOnTick);
+        $this->heartbeatOnTick && register_tick_function($heartbeatOnTick, $this->context);
 
         try {
             while (true) {

--- a/pkg/amqp-lib/Tests/AmqpContextTest.php
+++ b/pkg/amqp-lib/Tests/AmqpContextTest.php
@@ -344,7 +344,7 @@ class AmqpContextTest extends TestCase
 
     public function testShouldReturnExpectedSubscriptionConsumerInstance()
     {
-        $context = new AmqpContext($this->createConnectionMock(), []);
+        $context = new AmqpContext($this->createConnectionMock(), ['heartbeat_on_tick' => true]);
 
         $this->assertInstanceOf(AmqpSubscriptionConsumer::class, $context->createSubscriptionConsumer());
     }

--- a/pkg/amqp-lib/Tests/AmqpSubscriptionConsumerTest.php
+++ b/pkg/amqp-lib/Tests/AmqpSubscriptionConsumerTest.php
@@ -16,9 +16,9 @@ class AmqpSubscriptionConsumerTest extends TestCase
         $this->assertTrue($rc->implementsInterface(SubscriptionConsumer::class));
     }
 
-    public function testCouldBeConstructedWithAmqpContextAsFirstArgument()
+    public function testCouldBeConstructedWithAmqpContextAndHeartbeatOnTickAsArguments()
     {
-        new AmqpSubscriptionConsumer($this->createAmqpContextMock());
+        new AmqpSubscriptionConsumer($this->createAmqpContextMock(), $heartbeatOnTick = true);
     }
 
     /**

--- a/pkg/amqp-lib/Tests/Functional/AmqpSubscriptionConsumerWithHeartbeatOnTickTest.php
+++ b/pkg/amqp-lib/Tests/Functional/AmqpSubscriptionConsumerWithHeartbeatOnTickTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Enqueue\AmqpLib\Tests\Functional;
+
+use Enqueue\AmqpLib\AmqpConnectionFactory;
+use Enqueue\AmqpLib\AmqpContext;
+use Interop\Amqp\AmqpQueue;
+use Interop\Queue\Consumer;
+use Interop\Queue\Context;
+use Interop\Queue\Message;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group functional
+ */
+class AmqpSubscriptionConsumerWithHeartbeatOnTickTest extends TestCase
+{
+    /**
+     * @var Context
+     */
+    private $context;
+
+    protected function tearDown()
+    {
+        if ($this->context) {
+            $this->context->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function test()
+    {
+        $this->context = $context = $this->createContext();
+
+        $fooQueue = $this->createQueue($context, 'foo_subscription_consumer_consume_from_all_subscribed_queues_spec');
+
+        $expectedFooBody = 'fooBody';
+
+        $context->createProducer()->send($fooQueue, $context->createMessage($expectedFooBody));
+
+        $fooConsumer = $context->createConsumer($fooQueue);
+
+        $actualBodies = [];
+        $actualQueues = [];
+        $callback = function (Message $message, Consumer $consumer) use (&$actualBodies, &$actualQueues) {
+            declare(ticks=1) {
+                $actualBodies[] = $message->getBody();
+                $actualQueues[] = $consumer->getQueue()->getQueueName();
+
+                $consumer->acknowledge($message);
+
+                return true;
+            }
+        };
+
+        $subscriptionConsumer = $context->createSubscriptionConsumer();
+        $subscriptionConsumer->subscribe($fooConsumer, $callback);
+
+        $subscriptionConsumer->consume(1000);
+
+        $this->assertCount(1, $actualBodies);
+    }
+
+    protected function createContext(): AmqpContext
+    {
+        $factory = new AmqpConnectionFactory(getenv('AMQP_DSN'));
+
+        $context = $factory->createContext();
+        $context->setQos(0, 5, false);
+
+        return $context;
+    }
+
+    protected function createQueue(AmqpContext $context, string $queueName): AmqpQueue
+    {
+        $queue = $context->createQueue($queueName);
+        $context->declareQueue($queue);
+        $context->purgeQueue($queue);
+
+        return $queue;
+    }
+}

--- a/pkg/amqp-lib/composer.json
+++ b/pkg/amqp-lib/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
-        "php-amqplib/php-amqplib": "^2.7",
+        "php-amqplib/php-amqplib": "^2.8",
         "queue-interop/amqp-interop": "^0.8",
         "enqueue/amqp-tools": "0.9.x-dev"
     },


### PR DESCRIPTION
php-amqplib comes with a heartbeat feature. It does not work at all, unreliable and broken. More in the post [Keeping RabbitMQ connections alive in PHP](https://blog.mollie.com/keeping-rabbitmq-connections-alive-in-php-b11cb657d5fb).

This PR fixes it. You could wrap your long running code into `decalre(ticks=1) {}`. The number of ticks should be adjusted to your needs. Calling it at every tick is not good. 

Please note that it does not fix heartbeat issue if you spent most of the time on IO operation.

```php
<?php

use Enqueue\AmqpLib\AmqpConnectionFactory;
use Interop\Amqp\AmqpConsumer;
use Interop\Amqp\AmqpMessage;

$context = (new AmqpConnectionFactory('amqp:?heartbeat_on_tick=1'))->createContext();

$queue = $context->createQueue('a_queue');
$consumer = $context->createConsumer($queue);

$subscriptionConsumer = $context->createSubscriptionConsumer();
$subscriptionConsumer->subscribe($consumer, function(AmqpMessage $message, AmqpConsumer $consumer) {
    // ticks number should be adjusted.
    declare(ticks=1) {
        foreach (fetchHugeSet() as $item) {
            // cycle does something for a long time, much longer than amqp heartbeat.
        }
    }

    $consumer->acknowledge($message);

    return true;
});

$subscriptionConsumer->consume(10000);


function fetchHugeSet(): array {};
```

Fixes partly `Invalid frame type 65` issue. 

```
Error: Uncaught PhpAmqpLib\Exception\AMQPRuntimeException: Invalid frame type 65 in /some/path/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Connection/AbstractConnection.php:528
```

Fixes partly `Broken pipe or closed connection` issue.

```
PHP Fatal error: Uncaught exception 'PhpAmqpLib\Exception\AMQPRuntimeException' with message 'Broken pipe or closed connection' in /some/path/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/IO/StreamIO.php:190
```
