### PR TITLE
[sqs] Multi region support

### DIFF
--- a/docs/transport/sqs.md
+++ b/docs/transport/sqs.md
@@ -142,4 +142,23 @@ $queue = $context->createQueue('foo');
 $queue->setQueueOwnerAWSAccountId('awsAccountId');
 ```
 
+## Multi region examples
+
+Enqueue SQS provides a generic multi-region support. This enables users to specify which AWS Region to send a command to by setting region on SqsDestination.
+You might need it to access SQS FIFO queue because they are not available for all regions. 
+If not specified the default region is used. 
+
+```php
+<?php
+use Enqueue\Sqs\SqsConnectionFactory;
+
+$context = (new SqsConnectionFactory('sqs:?region=eu-west-2'))->createContext();
+
+$queue = $context->createQueue('foo');
+$queue->setRegion('us-west-2');
+
+// the request goes to US West (Oregon) Region
+$context->declareQueue($queue);
+```
+
 [back to index](../index.md)

--- a/pkg/sqs/SqsConnectionFactory.php
+++ b/pkg/sqs/SqsConnectionFactory.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Enqueue\Sqs;
 
-use Aws\MultiRegionClient;
 use Aws\Sdk;
-use Aws\Sqs\SqsClient;
+use Aws\Sqs\SqsClient as AwsSqsClient;
 use Enqueue\Dsn\Dsn;
 use Interop\Queue\ConnectionFactory;
 use Interop\Queue\Context;
@@ -19,7 +18,7 @@ class SqsConnectionFactory implements ConnectionFactory
     private $config;
 
     /**
-     * @var MultiRegionClient
+     * @var SqsClient
      */
     private $client;
 
@@ -45,8 +44,8 @@ class SqsConnectionFactory implements ConnectionFactory
      */
     public function __construct($config = 'sqs:')
     {
-        if ($config instanceof SqsClient) {
-            $this->client = $config;
+        if ($config instanceof AwsSqsClient) {
+            $this->client = new SqsClient($config);
             $this->config = ['lazy' => false] + $this->defaultConfig();
 
             return;
@@ -63,7 +62,7 @@ class SqsConnectionFactory implements ConnectionFactory
                 unset($config['dsn']);
             }
         } else {
-            throw new \LogicException(sprintf('The config must be either an array of options, a DSN string, null or instance of %s', SqsClient::class));
+            throw new \LogicException(sprintf('The config must be either an array of options, a DSN string, null or instance of %s', AwsSqsClient::class));
         }
 
         $this->config = array_replace($this->defaultConfig(), $config);
@@ -74,16 +73,10 @@ class SqsConnectionFactory implements ConnectionFactory
      */
     public function createContext(): Context
     {
-        if ($this->config['lazy']) {
-            return new SqsContext(function () {
-                return $this->establishConnection();
-            }, $this->config);
-        }
-
         return new SqsContext($this->establishConnection(), $this->config);
     }
 
-    private function establishConnection(): MultiRegionClient
+    private function establishConnection(): SqsClient
     {
         if ($this->client) {
             return $this->client;
@@ -110,7 +103,14 @@ class SqsConnectionFactory implements ConnectionFactory
             }
         }
 
-        $this->client = (new Sdk(['Sqs' => $config]))->createMultiRegionSqs();
+        $establishConnection = function () use ($config) {
+            return (new Sdk(['Sqs' => $config]))->createMultiRegionSqs();
+        };
+
+        $this->client = $this->config['lazy'] ?
+            new SqsClient($establishConnection) :
+            new SqsClient($establishConnection())
+        ;
 
         return $this->client;
     }

--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -119,7 +119,7 @@ class SqsConsumer implements Consumer
     {
         InvalidMessageException::assertMessageInstanceOf($message, SqsMessage::class);
 
-        $this->context->getClient()->deleteMessage([
+        $this->context->getSqsClient()->deleteMessage([
             '@region' => $this->queue->getRegion(),
             'QueueUrl' => $this->context->getQueueUrl($this->queue),
             'ReceiptHandle' => $message->getReceiptHandle(),
@@ -133,7 +133,7 @@ class SqsConsumer implements Consumer
     {
         InvalidMessageException::assertMessageInstanceOf($message, SqsMessage::class);
 
-        $this->context->getClient()->deleteMessage([
+        $this->context->getSqsClient()->deleteMessage([
             '@region' => $this->queue->getRegion(),
             'QueueUrl' => $this->context->getQueueUrl($this->queue),
             'ReceiptHandle' => $message->getReceiptHandle(),
@@ -163,7 +163,7 @@ class SqsConsumer implements Consumer
             $arguments['VisibilityTimeout'] = $this->visibilityTimeout;
         }
 
-        $result = $this->context->getClient()->receiveMessage($arguments);
+        $result = $this->context->getSqsClient()->receiveMessage($arguments);
 
         if ($result->hasKey('Messages')) {
             $this->messages = $result->get('Messages');

--- a/pkg/sqs/SqsContext.php
+++ b/pkg/sqs/SqsContext.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Enqueue\Sqs;
 
-use Aws\Sqs\SqsClient;
+use Aws\Sqs\SqsClient as AwsSqsClient;
 use Interop\Queue\Consumer;
 use Interop\Queue\Context;
 use Interop\Queue\Destination;
@@ -25,36 +25,18 @@ class SqsContext implements Context
     private $client;
 
     /**
-     * @var callable
-     */
-    private $clientFactory;
-
-    /**
      * @var array
      */
     private $queueUrls;
 
+    /**
+     * @var array
+     */
     private $config;
 
-    /**
-     * Callable must return instance of SqsClient once called.
-     *
-     * @param SqsClient|callable $client
-     */
-    public function __construct($client, array $config)
+    public function __construct(SqsClient $client, array $config)
     {
-        if ($client instanceof SqsClient) {
-            $this->client = $client;
-        } elseif (is_callable($client)) {
-            $this->clientFactory = $client;
-        } else {
-            throw new \InvalidArgumentException(sprintf(
-                'The $client argument must be either %s or callable that returns %s once called.',
-                SqsClient::class,
-                SqsClient::class
-            ));
-        }
-
+        $this->client = $client;
         $this->config = $config;
     }
 
@@ -118,7 +100,7 @@ class SqsContext implements Context
     {
         InvalidDestinationException::assertDestinationInstanceOf($queue, SqsDestination::class);
 
-        $this->getClient()->purgeQueue([
+        $this->client->purgeQueue([
             '@region' => $queue->getRegion(),
             'QueueUrl' => $this->getQueueUrl($queue),
         ]);
@@ -129,22 +111,24 @@ class SqsContext implements Context
         throw SubscriptionConsumerNotSupportedException::providerDoestNotSupportIt();
     }
 
-    public function getClient(): SqsClient
+    public function getAwsSqsClient(): AwsSqsClient
     {
-        if (false == $this->client) {
-            $client = call_user_func($this->clientFactory);
-            if (false == $client instanceof SqsClient) {
-                throw new \LogicException(sprintf(
-                    'The factory must return instance of "%s". But it returns %s',
-                    SqsClient::class,
-                    is_object($client) ? get_class($client) : gettype($client)
-                ));
-            }
+        return $this->client->getAWSClient();
+    }
 
-            $this->client = $client;
-        }
-
+    public function getSqsClient(): SqsClient
+    {
         return $this->client;
+    }
+
+    /**
+     * @deprecated use getAwsSqsClient method
+     */
+    public function getClient(): AwsSqsClient
+    {
+        @trigger_error('The method is deprecated since 0.9.2. SqsContext::getAwsSqsClient() method should be used.', E_USER_DEPRECATED);
+
+        return $this->getAwsSqsClient();
     }
 
     public function getQueueUrl(SqsDestination $destination): string
@@ -155,7 +139,7 @@ class SqsContext implements Context
 
         $arguments = [
             '@region' => $destination->getRegion(),
-            'QueueName' => $destination->getQueueName()
+            'QueueName' => $destination->getQueueName(),
         ];
 
         if ($destination->getQueueOwnerAWSAccountId()) {
@@ -164,7 +148,7 @@ class SqsContext implements Context
             $arguments['QueueOwnerAWSAccountId'] = $this->config['queue_owner_aws_account_id'];
         }
 
-        $result = $this->getClient()->getQueueUrl($arguments);
+        $result = $this->client->getQueueUrl($arguments);
 
         if (false == $result->hasKey('QueueUrl')) {
             throw new \RuntimeException(sprintf('QueueUrl cannot be resolved. queueName: "%s"', $destination->getQueueName()));
@@ -175,7 +159,7 @@ class SqsContext implements Context
 
     public function declareQueue(SqsDestination $dest): void
     {
-        $result = $this->getClient()->createQueue([
+        $result = $this->client->createQueue([
             '@region' => $dest->getRegion(),
             'Attributes' => $dest->getAttributes(),
             'QueueName' => $dest->getQueueName(),
@@ -190,7 +174,7 @@ class SqsContext implements Context
 
     public function deleteQueue(SqsDestination $dest): void
     {
-        $this->getClient()->deleteQueue([
+        $this->client->deleteQueue([
             'QueueUrl' => $this->getQueueUrl($dest),
         ]);
 

--- a/pkg/sqs/SqsProducer.php
+++ b/pkg/sqs/SqsProducer.php
@@ -71,7 +71,7 @@ class SqsProducer implements Producer
             $arguments['MessageGroupId'] = $message->getMessageGroupId();
         }
 
-        $result = $this->context->getClient()->sendMessage($arguments);
+        $result = $this->context->getSqsClient()->sendMessage($arguments);
 
         if (false == $result->hasKey('MessageId')) {
             throw new \RuntimeException('Message was not sent');

--- a/pkg/sqs/Tests/SqsClientTest.php
+++ b/pkg/sqs/Tests/SqsClientTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Enqueue\Sqs\Tests;
+
+use Aws\MultiRegionClient;
+use Aws\Result;
+use Aws\Sdk;
+use Aws\Sqs\SqsClient as AwsSqsClient;
+use Enqueue\Sqs\SqsClient;
+use PHPUnit\Framework\TestCase;
+
+class SqsClientTest extends TestCase
+{
+    public function testShouldAllowGetAwsClientIfSingleClientProvided()
+    {
+        $awsClient = (new Sdk(['Sqs' => [
+            'key' => '',
+            'secret' => '',
+            'token' => '',
+            'region' => '',
+            'version' => '2012-11-05',
+            'endpoint' => 'http://localhost',
+        ]]))->createSqs();
+
+        $client = new SqsClient($awsClient);
+
+        $this->assertSame($awsClient, $client->getAWSClient());
+    }
+
+    public function testShouldAllowGetAwsClientIfMultipleClientProvided()
+    {
+        $awsClient = (new Sdk(['Sqs' => [
+            'key' => '',
+            'secret' => '',
+            'token' => '',
+            'region' => '',
+            'version' => '2012-11-05',
+            'endpoint' => 'http://localhost',
+        ]]))->createMultiRegionSqs();
+
+        $client = new SqsClient($awsClient);
+
+        $this->assertInstanceOf(AwsSqsClient::class, $client->getAWSClient());
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
+     */
+    public function testApiCall(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($args))
+            ->willReturn(new Result($result));
+
+        $client = new SqsClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
+     */
+    public function testLazyApiCall(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($args))
+            ->willReturn(new Result($result));
+
+        $client = new SqsClient(function () use ($awsClient) {
+            return $awsClient;
+        });
+
+        $actualResult = $client->{$method}($args);
+
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
+     */
+    public function testThrowIfInvalidInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $client = new SqsClient(new \stdClass());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sqs\SqsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
+        $client->{$method}($args);
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
+     */
+    public function testThrowIfInvalidLazyInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $client = new SqsClient(function () { return new \stdClass(); });
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sqs\SqsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
+        $client->{$method}($args);
+    }
+
+    /**
+     * @dataProvider provideApiCallsMultipleClient
+     */
+    public function testApiCallWithMultiClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $args['@region'] = 'theRegion';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($args))
+            ->willReturn(new Result($result));
+
+        $client = new SqsClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithSingleClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $args['@region'] = 'theRegion';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->never())
+            ->method($method)
+        ;
+
+        $client = new SqsClient($awsClient);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot send message to another region because transport is configured with single aws client');
+        $client->{$method}($args);
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithMultiClientAndEmptyCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $expectedArgs = $args;
+        $args['@region'] = '';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($expectedArgs))
+            ->willReturn(new Result($result));
+
+        $client = new SqsClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
+    }
+
+    public function provideApiCallsSingleClient()
+    {
+        yield [
+            'deleteMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'receiveMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'purgeQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'getQueueUrl',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'createQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'deleteQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'sendMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            AwsSqsClient::class,
+        ];
+    }
+
+    public function provideApiCallsMultipleClient()
+    {
+        yield [
+            'deleteMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'receiveMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'purgeQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'getQueueUrl',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'createQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'deleteQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'sendMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+    }
+}

--- a/pkg/sqs/Tests/SqsConnectionFactoryTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryTest.php
@@ -2,7 +2,8 @@
 
 namespace Enqueue\Sqs\Tests;
 
-use Aws\Sqs\SqsClient;
+use Aws\Sqs\SqsClient as AwsSqsClient;
+use Enqueue\Sqs\SqsClient;
 use Enqueue\Sqs\SqsConnectionFactory;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Test\ClassExtensionTrait;
@@ -54,14 +55,17 @@ class SqsConnectionFactoryTest extends TestCase
 
     public function testCouldBeConstructedWithClient()
     {
-        $client = $this->createMock(SqsClient::class);
+        $awsClient = $this->createMock(AwsSqsClient::class);
 
-        $factory = new SqsConnectionFactory($client);
+        $factory = new SqsConnectionFactory($awsClient);
 
         $context = $factory->createContext();
 
         $this->assertInstanceOf(SqsContext::class, $context);
-        $this->assertAttributeSame($client, 'client', $context);
+
+        $client = $this->readAttribute($context, 'client');
+        $this->assertInstanceOf(SqsClient::class, $client);
+        $this->assertAttributeSame($awsClient, 'inputClient', $client);
     }
 
     public function testShouldCreateLazyContext()
@@ -72,7 +76,8 @@ class SqsConnectionFactoryTest extends TestCase
 
         $this->assertInstanceOf(SqsContext::class, $context);
 
-        $this->assertAttributeEquals(null, 'client', $context);
-        $this->assertInternalType('callable', $this->readAttribute($context, 'clientFactory'));
+        $client = $this->readAttribute($context, 'client');
+        $this->assertInstanceOf(SqsClient::class, $client);
+        $this->assertAttributeInstanceOf(\Closure::class, 'inputClient', $client);
     }
 }

--- a/pkg/sqs/Tests/SqsProducerTest.php
+++ b/pkg/sqs/Tests/SqsProducerTest.php
@@ -3,7 +3,7 @@
 namespace Enqueue\Sqs\Tests;
 
 use Aws\Result;
-use Aws\Sqs\SqsClient;
+use Enqueue\Sqs\SqsClient;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
 use Enqueue\Sqs\SqsMessage;
@@ -68,7 +68,7 @@ class SqsProducerTest extends TestCase
         ;
         $context
             ->expects($this->once())
-            ->method('getClient')
+            ->method('getSqsClient')
             ->will($this->returnValue($client))
         ;
 
@@ -85,6 +85,7 @@ class SqsProducerTest extends TestCase
     public function testShouldSendMessage()
     {
         $expectedArguments = [
+            '@region' => null,
             'MessageAttributes' => [
                 'Headers' => [
                     'DataType' => 'String',
@@ -103,7 +104,7 @@ class SqsProducerTest extends TestCase
             ->expects($this->once())
             ->method('sendMessage')
             ->with($this->identicalTo($expectedArguments))
-            ->willReturn(new Result())
+            ->willReturn(new Result(['MessageId' => 'theMessageId']))
         ;
 
         $context = $this->createSqsContextMock();
@@ -114,7 +115,7 @@ class SqsProducerTest extends TestCase
         ;
         $context
             ->expects($this->once())
-            ->method('getClient')
+            ->method('getSqsClient')
             ->will($this->returnValue($client))
         ;
 
@@ -124,8 +125,48 @@ class SqsProducerTest extends TestCase
         $message->setMessageDeduplicationId('theDeduplicationId');
         $message->setMessageGroupId('groupId');
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Message was not sent');
+        $producer = new SqsProducer($context);
+        $producer->send($destination, $message);
+    }
+
+    public function testShouldSendMessageWithCustomRegion()
+    {
+        $expectedArguments = [
+            '@region' => 'theRegion',
+            'MessageAttributes' => [
+                'Headers' => [
+                    'DataType' => 'String',
+                    'StringValue' => '[[],[]]',
+                ],
+            ],
+            'MessageBody' => 'theBody',
+            'QueueUrl' => 'theQueueUrl',
+        ];
+
+        $client = $this->createSqsClientMock();
+        $client
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->identicalTo($expectedArguments))
+            ->willReturn(new Result(['MessageId' => 'theMessageId']))
+        ;
+
+        $context = $this->createSqsContextMock();
+        $context
+            ->expects($this->once())
+            ->method('getQueueUrl')
+            ->willReturn('theQueueUrl')
+        ;
+        $context
+            ->expects($this->once())
+            ->method('getSqsClient')
+            ->will($this->returnValue($client))
+        ;
+
+        $destination = new SqsDestination('queue-name');
+        $destination->setRegion('theRegion');
+
+        $message = new SqsMessage('theBody');
 
         $producer = new SqsProducer($context);
         $producer->send($destination, $message);
@@ -134,6 +175,7 @@ class SqsProducerTest extends TestCase
     public function testShouldSendDelayedMessage()
     {
         $expectedArguments = [
+            '@region' => null,
             'MessageAttributes' => [
                 'Headers' => [
                     'DataType' => 'String',
@@ -152,7 +194,7 @@ class SqsProducerTest extends TestCase
             ->expects($this->once())
             ->method('sendMessage')
             ->with($this->identicalTo($expectedArguments))
-            ->willReturn(new Result())
+            ->willReturn(new Result(['MessageId' => 'theMessageId']))
         ;
 
         $context = $this->createSqsContextMock();
@@ -163,7 +205,7 @@ class SqsProducerTest extends TestCase
         ;
         $context
             ->expects($this->once())
-            ->method('getClient')
+            ->method('getSqsClient')
             ->will($this->returnValue($client))
         ;
 
@@ -172,9 +214,6 @@ class SqsProducerTest extends TestCase
         $message->setDelaySeconds(12345);
         $message->setMessageDeduplicationId('theDeduplicationId');
         $message->setMessageGroupId('groupId');
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Message was not sent');
 
         $producer = new SqsProducer($context);
         $producer->setDeliveryDelay(5000);
@@ -184,7 +223,7 @@ class SqsProducerTest extends TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|SqsContext
      */
-    private function createSqsContextMock()
+    private function createSqsContextMock(): SqsContext
     {
         return $this->createMock(SqsContext::class);
     }
@@ -192,13 +231,8 @@ class SqsProducerTest extends TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|SqsClient
      */
-    private function createSqsClientMock()
+    private function createSqsClientMock(): SqsClient
     {
-        return $this
-            ->getMockBuilder(SqsClient::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['sendMessage'])
-            ->getMock()
-        ;
+        return $this->createMock(SqsClient::class);
     }
 }


### PR DESCRIPTION
ref https://github.com/php-enqueue/enqueue-dev/issues/439

## Multi region examples

Enqueue SQS provides a generic multi-region support. This enables users to specify which AWS Region to send a command to by setting region on SqsDestination.
You might need it to access SQS FIFO queue because they are not available for all regions. 
If not specified the default region is used. 

```php
<?php
use Enqueue\Sqs\SqsConnectionFactory;

$context = (new SqsConnectionFactory('sqs:?region=eu-west-2'))->createContext();

$queue = $context->createQueue('foo');
$queue->setRegion('us-west-2');

// the request goes to US West (Oregon) Region
$context->declareQueue($queue);
```