### PR TITLE
[dbal] Use ordered bytes time uuid codec on message id decode.

### DIFF
--- a/pkg/dbal/DbalContext.php
+++ b/pkg/dbal/DbalContext.php
@@ -17,7 +17,9 @@ use Interop\Queue\Producer;
 use Interop\Queue\Queue;
 use Interop\Queue\SubscriptionConsumer;
 use Interop\Queue\Topic;
+use Ramsey\Uuid\Codec\OrderedTimeCodec;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidFactory;
 
 class DbalContext implements Context
 {
@@ -152,7 +154,9 @@ class DbalContext implements Context
         );
 
         if (isset($arrayMessage['id'])) {
-            $message->setMessageId(Uuid::fromBytes($arrayMessage['id'])->toString());
+            $uuidCodec = new OrderedTimeCodec((new UuidFactory())->getUuidBuilder());
+
+            $message->setMessageId($uuidCodec->decodeBytes($arrayMessage['id'])->toString());
         }
         if (isset($arrayMessage['queue'])) {
             $message->setQueue($arrayMessage['queue']);


### PR DESCRIPTION
fixes https://github.com/php-enqueue/enqueue-dev/issues/657


https://travis-ci.org/php-enqueue/enqueue-dev/jobs/458362777

```
1)
Enqueue\Dbal\Tests\Functional\DbalConsumerTest::testShouldOrderMessagesWithSamePriorityByPublishedAtDate
InvalidArgumentException: $bytes string should contain 16 characters.
/mqdev/vendor/ramsey/uuid/src/Codec/StringCodec.php:97
/mqdev/vendor/ramsey/uuid/src/UuidFactory.php:188
/mqdev/vendor/ramsey/uuid/src/Uuid.php:632
/mqdev/pkg/dbal/DbalContext.php:155
/mqdev/pkg/dbal/DbalConsumerHelperTrait.php:82
/mqdev/pkg/dbal/DbalConsumer.php:83
/mqdev/vendor/queue-interop/queue-interop/src/Impl/ConsumerPollingTrait.php:42
/mqdev/pkg/dbal/Tests/Functional/DbalConsumerTest.php:95
```