### PR TITLE
[sqs] Add ability to use another aws account per queue.

### DIFF
--- a/docs/transport/sqs.md
+++ b/docs/transport/sqs.md
@@ -19,6 +19,7 @@ It uses internally official [aws sdk library](https://packagist.org/packages/aws
 * [Send delay message](#send-delay-message)
 * [Consume message](#consume-message)
 * [Purge queue messages](#purge-queue-messages)
+* [Queue from another AWS account](#queue-from-another-aws-account)
 
 ## Installation
 
@@ -120,6 +121,25 @@ $consumer->acknowledge($message);
 $fooQueue = $context->createQueue('foo');
 
 $context->purgeQueue($fooQueue);
+```
+
+## Queue from another AWS account
+
+SQS allows to use queues from another account. You could set it globally for all queues via option `queue_owner_aws_account_id` or 
+per queue using `SqsDestination::setQueueOwnerAWSAccountId` method.
+
+```php
+<?php
+use Enqueue\Sqs\SqsConnectionFactory;
+
+// globally for all queues
+$factory = new SqsConnectionFactory('sqs:?queue_owner_aws_account_id=awsAccountId');
+
+$context = (new SqsConnectionFactory('sqs:'))->createContext();
+
+// per queue.
+$queue = $context->createQueue('foo');
+$queue->setQueueOwnerAWSAccountId('awsAccountId');
 ```
 
 [back to index](../index.md)

--- a/pkg/sqs/SqsContext.php
+++ b/pkg/sqs/SqsContext.php
@@ -153,7 +153,10 @@ class SqsContext implements Context
         }
 
         $arguments = ['QueueName' => $destination->getQueueName()];
-        if (false == empty($this->config['queue_owner_aws_account_id'])) {
+
+        if ($destination->getQueueOwnerAWSAccountId()) {
+            $arguments['QueueOwnerAWSAccountId'] = $destination->getQueueOwnerAWSAccountId();
+        } elseif (false == empty($this->config['queue_owner_aws_account_id'])) {
             $arguments['QueueOwnerAWSAccountId'] = $this->config['queue_owner_aws_account_id'];
         }
 

--- a/pkg/sqs/SqsDestination.php
+++ b/pkg/sqs/SqsDestination.php
@@ -20,6 +20,11 @@ class SqsDestination implements Topic, Queue
     private $attributes;
 
     /**
+     * @var string|null
+     */
+    private $queueOwnerAWSAccountId;
+
+    /**
      * The name of the new queue.
      * The following limits apply to this name:
      *   * A queue name can have up to 80 characters.
@@ -186,5 +191,15 @@ class SqsDestination implements Topic, Queue
         } else {
             unset($this->attributes['ContentBasedDeduplication']);
         }
+    }
+
+    public function getQueueOwnerAWSAccountId(): ?string
+    {
+        return $this->queueOwnerAWSAccountId;
+    }
+
+    public function setQueueOwnerAWSAccountId(?string $queueOwnerAWSAccountId): void
+    {
+        $this->queueOwnerAWSAccountId = $queueOwnerAWSAccountId;
     }
 }

--- a/pkg/sqs/Tests/Spec/SqsSendToAndReceiveFromQueueTest.php
+++ b/pkg/sqs/Tests/Spec/SqsSendToAndReceiveFromQueueTest.php
@@ -4,15 +4,18 @@ namespace Enqueue\Sqs\Tests\Spec;
 
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
+use Enqueue\Test\RetryTrait;
 use Enqueue\Test\SqsExtension;
 use Interop\Queue\Context;
 use Interop\Queue\Spec\SendToAndReceiveFromQueueSpec;
 
 /**
  * @group functional
+ * @retry 5
  */
 class SqsSendToAndReceiveFromQueueTest extends SendToAndReceiveFromQueueSpec
 {
+    use RetryTrait;
     use SqsExtension;
     use CreateSqsQueueTrait;
 

--- a/pkg/sqs/Tests/Spec/SqsSendToAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/sqs/Tests/Spec/SqsSendToAndReceiveNoWaitFromQueueTest.php
@@ -4,15 +4,18 @@ namespace Enqueue\Sqs\Tests\Spec;
 
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
+use Enqueue\Test\RetryTrait;
 use Enqueue\Test\SqsExtension;
 use Interop\Queue\Context;
 use Interop\Queue\Spec\SendToAndReceiveNoWaitFromQueueSpec;
 
 /**
  * @group functional
+ * @retry 5
  */
 class SqsSendToAndReceiveNoWaitFromQueueTest extends SendToAndReceiveNoWaitFromQueueSpec
 {
+    use RetryTrait;
     use SqsExtension;
     use CreateSqsQueueTrait;
 

--- a/pkg/sqs/Tests/Spec/SqsSendToAndReceiveNoWaitFromTopicTest.php
+++ b/pkg/sqs/Tests/Spec/SqsSendToAndReceiveNoWaitFromTopicTest.php
@@ -4,15 +4,18 @@ namespace Enqueue\Sqs\Tests\Spec;
 
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
+use Enqueue\Test\RetryTrait;
 use Enqueue\Test\SqsExtension;
 use Interop\Queue\Context;
 use Interop\Queue\Spec\SendToAndReceiveNoWaitFromTopicSpec;
 
 /**
  * @group functional
+ * @retry 5
  */
 class SqsSendToAndReceiveNoWaitFromTopicTest extends SendToAndReceiveNoWaitFromTopicSpec
 {
+    use RetryTrait;
     use SqsExtension;
     use CreateSqsQueueTrait;
 

--- a/pkg/sqs/Tests/Spec/SqsSendToTopicAndReceiveFromQueueTest.php
+++ b/pkg/sqs/Tests/Spec/SqsSendToTopicAndReceiveFromQueueTest.php
@@ -4,15 +4,18 @@ namespace Enqueue\Sqs\Tests\Spec;
 
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
+use Enqueue\Test\RetryTrait;
 use Enqueue\Test\SqsExtension;
 use Interop\Queue\Context;
 use Interop\Queue\Spec\SendToTopicAndReceiveFromQueueSpec;
 
 /**
  * @group functional
+ * @retry 5
  */
 class SqsSendToTopicAndReceiveFromQueueTest extends SendToTopicAndReceiveFromQueueSpec
 {
+    use RetryTrait;
     use SqsExtension;
     use CreateSqsQueueTrait;
 

--- a/pkg/sqs/Tests/Spec/SqsSendToTopicAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/sqs/Tests/Spec/SqsSendToTopicAndReceiveNoWaitFromQueueTest.php
@@ -4,15 +4,18 @@ namespace Enqueue\Sqs\Tests\Spec;
 
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
+use Enqueue\Test\RetryTrait;
 use Enqueue\Test\SqsExtension;
 use Interop\Queue\Context;
 use Interop\Queue\Spec\SendToTopicAndReceiveNoWaitFromQueueSpec;
 
 /**
  * @group functional
+ * @retry 5
  */
 class SqsSendToTopicAndReceiveNoWaitFromQueueTest extends SendToTopicAndReceiveNoWaitFromQueueSpec
 {
+    use RetryTrait;
     use SqsExtension;
     use CreateSqsQueueTrait;
 

--- a/pkg/sqs/Tests/SqsContextTest.php
+++ b/pkg/sqs/Tests/SqsContextTest.php
@@ -220,7 +220,7 @@ class SqsContextTest extends \PHPUnit\Framework\TestCase
         $context->getQueueUrl(new SqsDestination('aQueueName'));
     }
 
-    public function testShouldAllowGetQueueUrlFromAnotherAWSAccount()
+    public function testShouldAllowGetQueueUrlFromAnotherAWSAccountSetGlobally()
     {
         $sqsClient = $this->createSqsClientMock();
         $sqsClient
@@ -238,6 +238,29 @@ class SqsContextTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $context->getQueueUrl(new SqsDestination('aQueueName'));
+    }
+
+    public function testShouldAllowGetQueueUrlFromAnotherAWSAccountSetPerQueue()
+    {
+        $sqsClient = $this->createSqsClientMock();
+        $sqsClient
+            ->expects($this->once())
+            ->method('getQueueUrl')
+            ->with($this->identicalTo([
+                'QueueName' => 'aQueueName',
+                'QueueOwnerAWSAccountId' => 'anotherAWSAccountID',
+            ]))
+            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+        ;
+
+        $context = new SqsContext($sqsClient, [
+            'queue_owner_aws_account_id' => null,
+        ]);
+
+        $queue = new SqsDestination('aQueueName');
+        $queue->setQueueOwnerAWSAccountId('anotherAWSAccountID');
+
+        $context->getQueueUrl($queue);
     }
 
     public function testShouldThrowExceptionIfGetQueueUrlResultHasNoQueueUrlProperty()


### PR DESCRIPTION
## Queue from another AWS account

SQS allows to use queues from another account. You could set it globally for all queues via option `queue_owner_aws_account_id` or 
per queue using `SqsDestination::setQueueOwnerAWSAccountId` method.

```php
<?php
use Enqueue\Sqs\SqsConnectionFactory;

// globally for all queues
$factory = new SqsConnectionFactory('sqs:?queue_owner_aws_account_id=awsAccountId');

$context = (new SqsConnectionFactory('sqs:'))->createContext();

// per queue.
$queue = $context->createQueue('foo');
$queue->setQueueOwnerAWSAccountId('awsAccountId');