### PR TITLE
[fs] Do not throw error in jsonUnserialize on deprecation notice

### DIFF
--- a/pkg/fs/FsContext.php
+++ b/pkg/fs/FsContext.php
@@ -105,7 +105,7 @@ class FsContext implements Context
 
         set_error_handler(function ($severity, $message, $file, $line) {
             throw new \ErrorException($message, 0, $severity, $file, $line);
-        });
+        }, E_ALL & ~E_USER_DEPRECATED);
 
         try {
             $file = fopen((string) $destination->getFileInfo(), $mode);


### PR DESCRIPTION
Caused by queue-interop package

[ErrorException]
  The "Enqueue\Fs\FsMessage" class implements "Interop\Queue\PsrMessage" that is deprecated will be removed in later versions. use one without Psr prefix.
   * The Message interface is the root interface of all transport messages. Most message-oriented middleware (MOM) products treat messages as lightweight entities that consist of a header and a payload. The header contains fields used for message routing an
  d identification; the payload contains the application data being sent.
   * Within this general form, the definition of a message varies significantly across products.

thrown here: https://github.com/ssiergl/enqueue-dev/blob/master/pkg/fs/FsConsumer.php#L131

As discussed in gitter. Without this patch fs transporter is not usable.