### PR TITLE
polling_integer type not correctly handled when using DSN

### DIFF
--- a/pkg/mongodb/MongodbConnectionFactory.php
+++ b/pkg/mongodb/MongodbConnectionFactory.php
@@ -98,7 +98,7 @@ class MongodbConnectionFactory implements ConnectionFactory
             parse_str($parsedUrl['query'], $queryParts);
             //get enqueue attributes values
             if (!empty($queryParts['polling_interval'])) {
-                $config['polling_interval'] = $queryParts['polling_interval'];
+                $config['polling_interval'] = (int) $queryParts['polling_interval'];
             }
             if (!empty($queryParts['enqueue_collection'])) {
                 $config['collection_name'] = $queryParts['enqueue_collection'];

--- a/pkg/mongodb/Tests/MongodbConnectionFactoryTest.php
+++ b/pkg/mongodb/Tests/MongodbConnectionFactoryTest.php
@@ -45,6 +45,20 @@ class MongodbConnectionFactoryTest extends TestCase
         $this->assertAttributeEquals($params, 'config', $factory);
     }
 
+    public function testCouldBeConstructedWithCustomConfigurationFromDsn()
+    {
+        $params = [
+            'dsn' => 'mongodb://127.0.0.3/test-db-name?enqueue_collection=collection-name&polling_interval=3000',
+            'dbname' => 'test-db-name',
+            'collection_name' => 'collection-name',
+            'polling_interval' => 3000,
+        ];
+
+        $factory = new MongodbConnectionFactory($params['dsn']);
+
+        $this->assertAttributeEquals($params, 'config', $factory);
+    }
+
     public function testShouldCreateContext()
     {
         $factory = new MongodbConnectionFactory();


### PR DESCRIPTION
Fixes this error:
```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Argument 1 passed to Enqueue\Mongodb\MongodbConsumer::setPollingInterval() must be of the type integer, string given, called in /var/www/api/vendor/enqueue/mongodb/MongodbContext.php on line 97 in /var/www/api/vendor/enqueue/mongodb/MongodbConsumer.php:40
```
when running `bin/console enqueue:consume` with a DSN with a `polling_interval` parameter