### PR TITLE
fix: Wrong parameters for Exception

### DIFF
--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -139,7 +139,7 @@ class DbalProducer implements Producer
                 'redeliver_after' => Type::BIGINT,
             ]);
         } catch (\Exception $e) {
-            throw new Exception('The transport fails to send the message due to some internal error.', null, $e);
+            throw new Exception('The transport fails to send the message due to some internal error.', 0, $e);
         }
     }
 


### PR DESCRIPTION
int must be passed when strict_types is on