### PR TITLE
[fs]: fix: Wrong parameters for Exception

### DIFF
--- a/pkg/fs/FsConsumer.php
+++ b/pkg/fs/FsConsumer.php
@@ -137,7 +137,7 @@ class FsConsumer implements Consumer
 
                         $this->preFetchedMessages[] = $fetchedMessage;
                     } catch (\Exception $e) {
-                        throw new \LogicException(sprintf("Cannot decode json message '%s'", $rawMessage), null, $e);
+                        throw new \LogicException(sprintf("Cannot decode json message '%s'", $rawMessage), 0, $e);
                     }
                 } else {
                     return null;


### PR DESCRIPTION
int must be passed when strict_types is on

same like

https://github.com/php-enqueue/enqueue-dev/commit/fe64cafee453cb5f536ce5dbf2bce069ed14e7cb