### PR TITLE
Fix TreeBuilder in Symfony 4.2

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,4 +10,7 @@ parameters:
 		- pkg/job-queue/Test/JobRunner.php
 		- pkg/job-queue/Tests/Functional/app/AppKernel.php
 		- pkg/rdkafka/RdKafkaConsumer.php
-
+		- pkg/async-event-dispatcher/DependencyInjection/Configuration.php
+		- pkg/enqueue-bundle/DependencyInjection/Configuration.php
+		- pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+		- pkg/simple-client/SimpleClient.php

--- a/pkg/async-event-dispatcher/DependencyInjection/Configuration.php
+++ b/pkg/async-event-dispatcher/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('enqueue_async_event_dispatcher');
+        $tb = new TreeBuilder('enqueue_async_event_dispatcher');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->children()
             ->scalarNode('context_service')->isRequired()->cannotBeEmpty()->end()

--- a/pkg/async-event-dispatcher/DependencyInjection/Configuration.php
+++ b/pkg/async-event-dispatcher/DependencyInjection/Configuration.php
@@ -13,7 +13,12 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $tb = new TreeBuilder('enqueue_async_event_dispatcher');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('enqueue_async_event_dispatcher');
+        }
 
         $rootNode->children()
             ->scalarNode('context_service')->isRequired()->cannotBeEmpty()->end()

--- a/pkg/async-event-dispatcher/DependencyInjection/Configuration.php
+++ b/pkg/async-event-dispatcher/DependencyInjection/Configuration.php
@@ -12,11 +12,11 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $tb = new TreeBuilder('enqueue_async_event_dispatcher');
-
-        if (method_exists($tb, 'getRootNode')) {
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $tb = new TreeBuilder('enqueue_async_event_dispatcher');
             $rootNode = $tb->getRootNode();
         } else {
+            $tb = new TreeBuilder();
             $rootNode = $tb->root('enqueue_async_event_dispatcher');
         }
 

--- a/pkg/enqueue-bundle/DependencyInjection/Configuration.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Configuration.php
@@ -24,11 +24,11 @@ final class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $tb = new TreeBuilder('enqueue');
-
-        if (method_exists($tb, 'getRootNode')) {
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $tb = new TreeBuilder('enqueue');
             $rootNode = $tb->getRootNode();
         } else {
+            $tb = new TreeBuilder();
             $rootNode = $tb->root('enqueue');
         }
 

--- a/pkg/enqueue-bundle/DependencyInjection/Configuration.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Configuration.php
@@ -24,8 +24,8 @@ final class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('enqueue');
+        $tb = new TreeBuilder('enqueue');
+        $rootNode = $tb->getRootNode();
 
         $rootNode
             ->requiresAtLeastOneElement()

--- a/pkg/enqueue-bundle/DependencyInjection/Configuration.php
+++ b/pkg/enqueue-bundle/DependencyInjection/Configuration.php
@@ -25,7 +25,12 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $tb = new TreeBuilder('enqueue');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('enqueue');
+        }
 
         $rootNode
             ->requiresAtLeastOneElement()

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
@@ -11,6 +11,7 @@ use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\ConnectionFactory;
 use Interop\Queue\Context;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
@@ -37,13 +38,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowAddConfigurationAsStringDsn()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -64,13 +59,7 @@ class TransportFactoryTest extends TestCase
      */
     public function testShouldAllowAddConfigurationAsDsnWithoutSlashes()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -86,13 +75,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfNullGiven()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -108,13 +91,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfEmptyStringGiven()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -130,13 +107,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfEmptyArrayGiven()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -152,13 +123,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfEmptyDsnGiven()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -170,13 +135,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfFactoryClassAndFactoryServiceSetAtTheSameTime()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -194,13 +153,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfConnectionFactoryClassUsedWithFactoryClassAtTheSameTime()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -218,13 +171,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfConnectionFactoryClassUsedWithFactoryServiceAtTheSameTime()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -241,13 +188,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetFactoryClass()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -264,13 +205,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetFactoryService()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -287,13 +222,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetConnectionFactoryClass()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -310,13 +239,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfExtraOptionGiven()
     {
-        $tb = new TreeBuilder('foo');
-
-        if (method_exists($tb, 'getRootNode')) {
-            $rootNode = $tb->getRootNode();
-        } else {
-            $rootNode = $tb->root('foo');
-        }
+        $rootNode = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -528,5 +451,16 @@ class TransportFactoryTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The service "enqueue.transport.default.context" does not exist.');
         $transport->buildRpcClient($container, []);
+    }
+
+    private function getRootNode(): NodeDefinition
+    {
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $tb = new TreeBuilder('foo');
+            return $tb->getRootNode();
+        }
+
+        $tb = new TreeBuilder();
+        return $tb->root('foo');
     }
 }

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
@@ -38,7 +38,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldAllowAddConfigurationAsStringDsn()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -60,7 +65,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldAllowAddConfigurationAsDsnWithoutSlashes()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -77,7 +87,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldSetNullTransportIfNullGiven()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -94,7 +109,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldSetNullTransportIfEmptyStringGiven()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -111,7 +131,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldSetNullTransportIfEmptyArrayGiven()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -128,7 +153,12 @@ class TransportFactoryTest extends TestCase
     public function testThrowIfEmptyDsnGiven()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -141,7 +171,12 @@ class TransportFactoryTest extends TestCase
     public function testThrowIfFactoryClassAndFactoryServiceSetAtTheSameTime()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -160,7 +195,12 @@ class TransportFactoryTest extends TestCase
     public function testThrowIfConnectionFactoryClassUsedWithFactoryClassAtTheSameTime()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -179,7 +219,12 @@ class TransportFactoryTest extends TestCase
     public function testThrowIfConnectionFactoryClassUsedWithFactoryServiceAtTheSameTime()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -197,7 +242,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldAllowSetFactoryClass()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -215,7 +265,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldAllowSetFactoryService()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -233,7 +288,12 @@ class TransportFactoryTest extends TestCase
     public function testShouldAllowSetConnectionFactoryClass()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -251,7 +311,12 @@ class TransportFactoryTest extends TestCase
     public function testThrowIfExtraOptionGiven()
     {
         $tb = new TreeBuilder('foo');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('foo');
+        }
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
@@ -38,7 +38,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowAddConfigurationAsStringDsn()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -59,7 +59,7 @@ class TransportFactoryTest extends TestCase
      */
     public function testShouldAllowAddConfigurationAsDsnWithoutSlashes()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -75,7 +75,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfNullGiven()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -91,7 +91,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfEmptyStringGiven()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -107,7 +107,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfEmptyArrayGiven()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -123,7 +123,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfEmptyDsnGiven()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -135,7 +135,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfFactoryClassAndFactoryServiceSetAtTheSameTime()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -153,7 +153,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfConnectionFactoryClassUsedWithFactoryClassAtTheSameTime()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -171,7 +171,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfConnectionFactoryClassUsedWithFactoryServiceAtTheSameTime()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -188,7 +188,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetFactoryClass()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -205,7 +205,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetFactoryService()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -222,7 +222,7 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetConnectionFactoryClass()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -239,7 +239,7 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfExtraOptionGiven()
     {
-        $rootNode = $this->getRootNode();
+        list($tb, $rootNode) = $this->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -453,14 +453,19 @@ class TransportFactoryTest extends TestCase
         $transport->buildRpcClient($container, []);
     }
 
-    private function getRootNode(): NodeDefinition
+    /**
+     * @return [TreeBuilder, NodeDefinition]
+     */
+    private function getRootNode(): array
     {
         if (method_exists(TreeBuilder::class, 'getRootNode')) {
             $tb = new TreeBuilder('foo');
-            return $tb->getRootNode();
+
+            return [$tb, $tb->getRootNode()];
         }
 
         $tb = new TreeBuilder();
-        return $tb->root('foo');
+
+        return [$tb, $tb->root('foo')];
     }
 }

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
@@ -37,8 +37,8 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowAddConfigurationAsStringDsn()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -59,8 +59,8 @@ class TransportFactoryTest extends TestCase
      */
     public function testShouldAllowAddConfigurationAsDsnWithoutSlashes()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -76,8 +76,8 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfNullGiven()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -93,8 +93,8 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfEmptyStringGiven()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -110,8 +110,8 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldSetNullTransportIfEmptyArrayGiven()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -127,8 +127,8 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfEmptyDsnGiven()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -140,8 +140,8 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfFactoryClassAndFactoryServiceSetAtTheSameTime()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -159,8 +159,8 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfConnectionFactoryClassUsedWithFactoryClassAtTheSameTime()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
 
@@ -178,8 +178,8 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfConnectionFactoryClassUsedWithFactoryServiceAtTheSameTime()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -196,8 +196,8 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetFactoryClass()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -214,8 +214,8 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetFactoryService()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -232,8 +232,8 @@ class TransportFactoryTest extends TestCase
 
     public function testShouldAllowSetConnectionFactoryClass()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();
@@ -250,8 +250,8 @@ class TransportFactoryTest extends TestCase
 
     public function testThrowIfExtraOptionGiven()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('foo');
+        $tb = new TreeBuilder('foo');
+        $rootNode = $tb->getRootNode();
 
         $rootNode->append(TransportFactory::getConfiguration());
         $processor = new Processor();

--- a/pkg/simple-client/SimpleClient.php
+++ b/pkg/simple-client/SimpleClient.php
@@ -306,11 +306,11 @@ final class SimpleClient
 
     private function createConfiguration(): NodeInterface
     {
-        $tb = new TreeBuilder('enqueue');
-
-        if (method_exists($tb, 'getRootNode')) {
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $tb = new TreeBuilder('enqueue');
             $rootNode = $tb->getRootNode();
         } else {
+            $tb = new TreeBuilder();
             $rootNode = $tb->root('enqueue');
         }
 

--- a/pkg/simple-client/SimpleClient.php
+++ b/pkg/simple-client/SimpleClient.php
@@ -306,8 +306,8 @@ final class SimpleClient
 
     private function createConfiguration(): NodeInterface
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('enqueue');
+        $tb = new TreeBuilder('enqueue');
+        $rootNode = $tb->getRootNode();
 
         $rootNode
             ->beforeNormalization()

--- a/pkg/simple-client/SimpleClient.php
+++ b/pkg/simple-client/SimpleClient.php
@@ -307,7 +307,12 @@ final class SimpleClient
     private function createConfiguration(): NodeInterface
     {
         $tb = new TreeBuilder('enqueue');
-        $rootNode = $tb->getRootNode();
+
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            $rootNode = $tb->root('enqueue');
+        }
 
         $rootNode
             ->beforeNormalization()


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.