### PR TITLE
[amqp] fix #696 parsing vhost from amqp dsn

### DIFF
--- a/pkg/amqp-tools/ConnectionConfig.php
+++ b/pkg/amqp-tools/ConnectionConfig.php
@@ -402,7 +402,9 @@ class ConnectionConfig
             'port' => $dsn->getPort(),
             'user' => $dsn->getUser(),
             'pass' => $dsn->getPassword(),
-            'vhost' => null !== $dsn->getPath() ? ltrim($dsn->getPath(), '/') : null,
+            'vhost' => null !== ($path = $dsn->getPath()) ?
+                (0 === strpos($path, '/') ? substr($path, 1) : $path)
+                : null,
             'read_timeout' => $dsn->getFloat('read_timeout'),
             'write_timeout' => $dsn->getFloat('write_timeout'),
             'connection_timeout' => $dsn->getFloat('connection_timeout'),

--- a/pkg/amqp-tools/Tests/ConnectionConfigTest.php
+++ b/pkg/amqp-tools/Tests/ConnectionConfigTest.php
@@ -534,5 +534,31 @@ class ConnectionConfigTest extends TestCase
                 'ssl_passphrase' => '',
             ],
         ];
+
+        yield [
+            'amqp://guest:guest@localhost:5672/%2f',
+            [
+                'host' => 'localhost',
+                'port' => 5672,
+                'vhost' => '/',
+                'user' => 'guest',
+                'pass' => 'guest',
+                'read_timeout' => 3.,
+                'write_timeout' => 3.,
+                'connection_timeout' => 3.,
+                'persisted' => false,
+                'lazy' => true,
+                'qos_prefetch_size' => 0,
+                'qos_prefetch_count' => 1,
+                'qos_global' => false,
+                'heartbeat' => 0.0,
+                'ssl_on' => false,
+                'ssl_verify' => true,
+                'ssl_cacert' => '',
+                'ssl_cert' => '',
+                'ssl_key' => '',
+                'ssl_passphrase' => '',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Fix issue #696 parsing vhost like rabbitMQ default (`%2f`)