### PR TITLE
[consumption] fix wrong niceness extension param

### DIFF
--- a/pkg/enqueue/Symfony/Consumption/LimitsExtensionsCommandTrait.php
+++ b/pkg/enqueue/Symfony/Consumption/LimitsExtensionsCommandTrait.php
@@ -58,8 +58,8 @@ trait LimitsExtensionsCommandTrait
         }
 
         $niceness = $input->getOption('niceness');
-        if ($niceness) {
-            $extensions[] = new NicenessExtension($niceness);
+        if (!empty($niceness) && is_numeric($niceness)) {
+            $extensions[] = new NicenessExtension((int) $niceness);
         }
 
         return $extensions;

--- a/pkg/enqueue/Tests/Symfony/Consumption/LimitsExtensionsCommandTraitTest.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/LimitsExtensionsCommandTraitTest.php
@@ -108,17 +108,37 @@ class LimitsExtensionsCommandTraitTest extends TestCase
         $this->assertInstanceOf(LimitConsumerMemoryExtension::class, $result[2]);
     }
 
-    public function testShouldAddNicenessExtension()
+    /**
+     * @param mixed $inputValue
+     * @param bool  $enabled
+     * @dataProvider provideNicenessValues
+     */
+    public function testShouldAddNicenessExtension($inputValue, bool $enabled)
     {
         $command = new LimitsExtensionsCommand('name');
         $tester = new CommandTester($command);
         $tester->execute([
-            '--niceness' => 1,
+            '--niceness' => $inputValue,
         ]);
 
         $result = $command->getExtensions();
-        $this->assertCount(1, $result);
 
-        $this->assertInstanceOf(NicenessExtension::class, $result[0]);
+        if ($enabled) {
+            $this->assertCount(1, $result);
+            $this->assertInstanceOf(NicenessExtension::class, $result[0]);
+        } else {
+            $this->assertEmpty($result);
+        }
+    }
+
+    public function provideNicenessValues(): \Generator
+    {
+        yield [1, true];
+        yield ['1', true];
+        yield [-1.0, true];
+        yield ['100', true];
+        yield ['', false];
+        yield ['0', false];
+        yield [0.0, false];
     }
 }


### PR DESCRIPTION
Values from CLI comes as strings but extension expects integer, therefore exception is thrown on any value, even correct one.