### PR TITLE
Monitoring - Add support for minimum stability - stable

### DIFF
--- a/pkg/monitoring/composer.json
+++ b/pkg/monitoring/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1.3",
         "enqueue/enqueue": "^0.9",
         "ramsey/uuid": "^3",
-        "enqueue/dsn": "0.9.x-dev"
+        "enqueue/dsn": "^0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.4.0",


### PR DESCRIPTION
I removed dev dependency from requirements. Should help for `minimum-stability: stable`  projects.

Composer log:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for enqueue/monitoring ^0.9.1 -> satisfiable by enqueue/monitoring[0.9.1].
    - enqueue/monitoring 0.9.1 requires enqueue/dsn 0.9.x-dev -> satisfiable by enqueue/dsn[0.9.x-dev] but these conflict with your requirements or minimum-stability.
```