### PR TITLE
Monitoring - Fixed influxdb write on sentMessageStats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/phpstan
 bin/jp.php
 bin/php-parse
 bin/google-cloud-batch
+bin/thruway
 vendor
 var
 .php_cs

--- a/pkg/monitoring/InfluxDbStorage.php
+++ b/pkg/monitoring/InfluxDbStorage.php
@@ -155,7 +155,7 @@ class InfluxDbStorage implements StatsStorage
         }
 
         $points = [
-            new Point($this->config['measurementSentMessages'], null, $tags, [], $stats->getTimestampMs()),
+            new Point($this->config['measurementSentMessages'], 1, $tags, [], $stats->getTimestampMs()),
         ];
 
         $this->getDb()->writePoints($points, Database::PRECISION_MILLISECONDS);


### PR DESCRIPTION
I deep dive into one bug on monitoring package, I found that message statistics are not accepted by influxdb (even by 1 year old revision), we always receive message
```
{"error":"unable to parse 'sent-messages,destination=example_topic,command=example_command 1546449295702': invalid field format"}
``` 
Which means that it's not passing influxdb [requirements - LINK](https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/). I checked it and yes, we can send empty value, but only if we have some additional fields. In our case we don't have any fields and no value (which is field as well).

### Steps to reproduce: 
1. Try to send request to influxdb with current state:
`curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'sent-messages,destination=example_topic,command=example_command 1546449295702'`
code: 400, response: ` {"error":"unable to parse 'sent-messages,destination=example_topic,command=example_command  1546449295702': invalid field format"}`

2. Try to add field, for example value:
`curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'sent-messages,destination=example_topic,command=example_command value=1 1546449295702'
`
code: 204, no content 👍

Instead of value we can send something else, but we have to send something.

Could you help with this @ASKozienko?