### PR TITLE
Fix async command/event pkgs

### DIFF
--- a/pkg/async-command/DependencyInjection/AsyncCommandExtension.php
+++ b/pkg/async-command/DependencyInjection/AsyncCommandExtension.php
@@ -19,7 +19,7 @@ class AsyncCommandExtension extends Extension
                     'client' => $client,
                     'command' => Commands::RUN_COMMAND,
                     'queue' => Commands::RUN_COMMAND,
-                    'queue_prefixed' => false,
+                    'prefix_queue' => false,
                     'exclusive' => true,
                 ])
                 ->addTag('enqueue.transport.processor')

--- a/pkg/async-event-dispatcher/DependencyInjection/AsyncEventDispatcherExtension.php
+++ b/pkg/async-event-dispatcher/DependencyInjection/AsyncEventDispatcherExtension.php
@@ -28,7 +28,7 @@ class AsyncEventDispatcherExtension extends Extension
             ->addTag('enqueue.processor', [
                 'command' => Commands::DISPATCH_ASYNC_EVENTS,
                 'queue' => '%enqueue_events_queue%',
-                'queue_prefixed' => false,
+                'prefix_queue' => false,
                 'exclusive' => true,
             ])
             ->addTag('enqueue.transport.processor')


### PR DESCRIPTION
I replaced `queue_prefixed` by `prefix_queue`in command and event DI extension. See https://github.com/php-enqueue/enqueue-dev/issues/690