### PR TITLE
[sqs] Dead Letter Queue Adoption

### DIFF
--- a/pkg/sqs/SqsClient.php
+++ b/pkg/sqs/SqsClient.php
@@ -43,6 +43,11 @@ class SqsClient
         return $this->callApi('receiveMessage', $args);
     }
 
+    public function changeMessageVisibility(array $args): Result
+    {
+        return $this->callApi('changeMessageVisibility', $args);
+    }
+
     public function purgeQueue(array $args): Result
     {
         return $this->callApi('purgeQueue', $args);

--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -133,14 +133,19 @@ class SqsConsumer implements Consumer
     {
         InvalidMessageException::assertMessageInstanceOf($message, SqsMessage::class);
 
-        $this->context->getSqsClient()->deleteMessage([
-            '@region' => $this->queue->getRegion(),
-            'QueueUrl' => $this->context->getQueueUrl($this->queue),
-            'ReceiptHandle' => $message->getReceiptHandle(),
-        ]);
-
         if ($requeue) {
-            $this->context->createProducer()->send($this->queue, $message);
+            $this->context->getAwsSqsClient()->changeMessageVisibility([
+                '@region' => $this->queue->getRegion(),
+                'QueueUrl' => $this->context->getQueueUrl($this->queue),
+                'ReceiptHandle' => $message->getReceiptHandle(),
+                'VisibilityTimeout' => 0,
+            ]);
+        } else {
+            $this->context->getSqsClient()->deleteMessage([
+                '@region' => $this->queue->getRegion(),
+                'QueueUrl' => $this->context->getQueueUrl($this->queue),
+                'ReceiptHandle' => $message->getReceiptHandle(),
+            ]);
         }
     }
 

--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -134,7 +134,7 @@ class SqsConsumer implements Consumer
         InvalidMessageException::assertMessageInstanceOf($message, SqsMessage::class);
 
         if ($requeue) {
-            $this->context->getAwsSqsClient()->changeMessageVisibility([
+            $this->context->getSqsClient()->changeMessageVisibility([
                 '@region' => $this->queue->getRegion(),
                 'QueueUrl' => $this->context->getQueueUrl($this->queue),
                 'ReceiptHandle' => $message->getReceiptHandle(),

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -205,18 +205,11 @@ class SqsConsumerTest extends TestCase
             ->expects($this->once())
             ->method('changeMessageVisibility')
             ->with($this->identicalTo([
-                '@region' => null,
+                '@region' => 'theRegion',
                 'QueueUrl' => 'theQueueUrl',
                 'ReceiptHandle' => 'theReceipt',
                 'VisibilityTimeout' => 0,
             ]))
-        ;
-
-        $producer = $this->createProducerMock();
-        $producer
-            ->expects($this->once())
-            ->method('send')
-            ->with($this->identicalTo($destination), $this->identicalTo($message))
         ;
 
         $context = $this->createContextMock();
@@ -239,6 +232,7 @@ class SqsConsumerTest extends TestCase
         $message->setReceiptHandle('theReceipt');
 
         $destination = new SqsDestination('queue');
+        $destination->setRegion('theRegion');
 
         $consumer = new SqsConsumer($context, $destination);
         $consumer->reject($message, true);

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -203,18 +203,14 @@ class SqsConsumerTest extends TestCase
         $client = $this->createSqsClientMock();
         $client
             ->expects($this->once())
-            ->method('deleteMessage')
+            ->method('changeMessageVisibility')
             ->with($this->identicalTo([
                 '@region' => null,
                 'QueueUrl' => 'theQueueUrl',
                 'ReceiptHandle' => 'theReceipt',
+                'VisibilityTimeout' => 0,
             ]))
         ;
-
-        $message = new SqsMessage();
-        $message->setReceiptHandle('theReceipt');
-
-        $destination = new SqsDestination('queue');
 
         $producer = $this->createProducerMock();
         $producer
@@ -235,10 +231,14 @@ class SqsConsumerTest extends TestCase
             ->willReturn('theQueueUrl')
         ;
         $context
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('createProducer')
-            ->willReturn($producer)
         ;
+
+        $message = new SqsMessage();
+        $message->setReceiptHandle('theReceipt');
+
+        $destination = new SqsDestination('queue');
 
         $consumer = new SqsConsumer($context, $destination);
         $consumer->reject($message, true);


### PR DESCRIPTION
Per #475, current Sqs requeue behaviour deletes the message and create another one.

This is not desirable because SQS lost track of Receive count, hence unable to adopt dead letter queue.

Changes made to terminte visibility timeout instead:
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#terminating-message-visibility-timeout

Todo:
- [x] Fix Tests