### PR TITLE
[pheanstalk] Requeuing a message should not acknowledge it beforehand

### DIFF
--- a/pkg/pheanstalk/PheanstalkConsumer.php
+++ b/pkg/pheanstalk/PheanstalkConsumer.php
@@ -88,11 +88,13 @@ class PheanstalkConsumer implements Consumer
      */
     public function reject(Message $message, bool $requeue = false): void
     {
-        $this->acknowledge($message);
-
         if ($requeue) {
             $this->pheanstalk->release($message->getJob(), $message->getPriority(), $message->getDelay());
+
+            return;
         }
+
+        $this->acknowledge($message);
     }
 
     private function convertJobToMessage(Job $job): PheanstalkMessage


### PR DESCRIPTION
Requeuing a message in Beanstalk means to release a reserved message:
https://github.com/beanstalkd/beanstalkd/blob/b5a6f7a23a368ffb31fbf48cdffe95541166d3fa/doc/protocol.txt#L85-L102
If the message is acknowledged beforehand (i.e. deleted), it can't be released anymore.
If you are OK with the modification, I will add a unit test.