### PR TITLE
Avoid OutOfMemoryException

### DIFF
--- a/pkg/enqueue/Consumption/QueueConsumer.php
+++ b/pkg/enqueue/Consumption/QueueConsumer.php
@@ -323,9 +323,11 @@ final class QueueConsumer implements QueueConsumerInterface
                 }
             }
 
-            $prev = new \ReflectionProperty('Exception', 'previous');
-            $prev->setAccessible(true);
-            $prev->setValue($wrapper, $exception);
+            if ($exception !== $wrapper) {
+                $prev = new \ReflectionProperty('Exception', 'previous');
+                $prev->setAccessible(true);
+                $prev->setValue($wrapper, $exception);
+            }
 
             throw $e;
         }


### PR DESCRIPTION
We're currently using enqueue 0.9.4 and monolog 1.24.0 in a symfony 4.2.2 project.

We're getting `OutOfMemoryException` when an exception is thrown from a processor. After digging a little bit in the code base, we found that monolog [loops indefinitely trying to reach every previous exception](https://github.com/Seldaek/monolog/blob/bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266/src/Monolog/Formatter/LineFormatter.php#L141).

It looks like that the previous attribute should be set only if the original exception (coming from a processor) is strictly different than the one re-thrown by the `QueueConsumer` at [L314](https://github.com/php-enqueue/enqueue-dev/blob/35b15fcfb5e3b34160964062e560051d7a325e17/pkg/enqueue/Consumption/QueueConsumer.php#L314))