### PR TITLE
[Async Event Dispatcher]Add default to php_serializer_event_transformer

### DIFF
--- a/pkg/async-event-dispatcher/DependencyInjection/AsyncTransformersPass.php
+++ b/pkg/async-event-dispatcher/DependencyInjection/AsyncTransformersPass.php
@@ -30,17 +30,21 @@ class AsyncTransformersPass implements CompilerPassInterface
                 $transformerName = isset($tagAttribute['transformerName']) ? $tagAttribute['transformerName'] : $serviceId;
 
                 if (isset($tagAttribute['default']) && $tagAttribute['default']) {
-                    $defaultTransformer = ['id' => $serviceId, 'transformerName' => $transformerName];
+                    $defaultTransformer = [
+                        'id' => $serviceId,
+                        'transformerName' => $transformerName,
+                        'eventName' => $eventName
+                    ];
                 } else {
-                    $eventNamesMap[] = $transformerName;
-                    $transformerIdsMap[] = $serviceId;
+                    $eventNamesMap[$eventName] = $transformerName;
+                    $transformerIdsMap[$transformerName] = $serviceId;
                 }
             }
         }
 
         if ($defaultTransformer) {
-            $eventNamesMap[] = $defaultTransformer['transformerName'];
-            $transformerIdsMap[] = $defaultTransformer['id'];
+            $eventNamesMap[$defaultTransformer['eventName']] = $defaultTransformer['transformerName'];
+            $transformerIdsMap[$defaultTransformer['transformerName']] = $defaultTransformer['id'];
         }
 
         $container->getDefinition('enqueue.events.registry')

--- a/pkg/async-event-dispatcher/DependencyInjection/AsyncTransformersPass.php
+++ b/pkg/async-event-dispatcher/DependencyInjection/AsyncTransformersPass.php
@@ -33,7 +33,7 @@ class AsyncTransformersPass implements CompilerPassInterface
                     $defaultTransformer = [
                         'id' => $serviceId,
                         'transformerName' => $transformerName,
-                        'eventName' => $eventName
+                        'eventName' => $eventName,
                     ];
                 } else {
                     $eventNamesMap[$eventName] = $transformerName;

--- a/pkg/async-event-dispatcher/DependencyInjection/AsyncTransformersPass.php
+++ b/pkg/async-event-dispatcher/DependencyInjection/AsyncTransformersPass.php
@@ -18,6 +18,7 @@ class AsyncTransformersPass implements CompilerPassInterface
 
         $transformerIdsMap = [];
         $eventNamesMap = [];
+        $defaultTransformer = null;
         foreach ($container->findTaggedServiceIds('enqueue.event_transformer') as $serviceId => $tagAttributes) {
             foreach ($tagAttributes as $tagAttribute) {
                 if (false == isset($tagAttribute['eventName'])) {
@@ -28,9 +29,18 @@ class AsyncTransformersPass implements CompilerPassInterface
 
                 $transformerName = isset($tagAttribute['transformerName']) ? $tagAttribute['transformerName'] : $serviceId;
 
-                $eventNamesMap[$eventName] = $transformerName;
-                $transformerIdsMap[$transformerName] = $serviceId;
+                if (isset($tagAttribute['default']) && $tagAttribute['default']) {
+                    $defaultTransformer = ['id' => $serviceId, 'transformerName' => $transformerName];
+                } else {
+                    $eventNamesMap[] = $transformerName;
+                    $transformerIdsMap[] = $serviceId;
+                }
             }
+        }
+
+        if ($defaultTransformer) {
+            $eventNamesMap[] = $defaultTransformer['transformerName'];
+            $transformerIdsMap[] = $defaultTransformer['id'];
         }
 
         $container->getDefinition('enqueue.events.registry')

--- a/pkg/async-event-dispatcher/Resources/config/services.yml
+++ b/pkg/async-event-dispatcher/Resources/config/services.yml
@@ -25,10 +25,10 @@ services:
             - '@event_dispatcher'
             - '@enqueue.events.async_listener'
 
-    enqueue.events.php_serializer_event_transofrmer:
+    enqueue.events.php_serializer_event_transformer:
         class: 'Enqueue\AsyncEventDispatcher\PhpSerializerEventTransformer'
         public: public
         arguments:
             - '@enqueue.events.context'
         tags:
-            - {name: 'enqueue.event_transformer', eventName: '/.*/', transformerName: 'php_serializer' }
+            - {name: 'enqueue.event_transformer', eventName: '/.*/', transformerName: 'php_serializer', default: true }


### PR DESCRIPTION
The default `php_serializer_event_transformer` will be loaded at the end in `AsyncTransformersPass` so custom event transformers can be used 

See https://github.com/php-enqueue/enqueue-dev/issues/747