### PR TITLE
[simple-client] Fix Logger Initialisation

### DIFF
--- a/pkg/simple-client/README.md
+++ b/pkg/simple-client/README.md
@@ -14,7 +14,7 @@ Enqueue is an MIT-licensed open source project with its ongoing development made
 [![Total Downloads](https://poser.pugx.org/enqueue/simple-client/d/total.png)](https://packagist.org/packages/enqueue/simple-client)
 [![Latest Stable Version](https://poser.pugx.org/enqueue/simple-client/version.png)](https://packagist.org/packages/enqueue/simple-client)
  
-The simple client takes Enqueue client classes and Symfony components and combines it to easy to use facade called `SimpleCLient`.   
+The simple client takes Enqueue client classes and Symfony components and combines it to easy to use facade called `SimpleClient`.   
 
 ## Resources
 

--- a/pkg/simple-client/SimpleClient.php
+++ b/pkg/simple-client/SimpleClient.php
@@ -126,9 +126,9 @@ final class SimpleClient
             ];
         }
 
-        $this->build(['enqueue' => $config]);
-
         $this->logger = $logger ?: new NullLogger();
+
+        $this->build(['enqueue' => $config]);
     }
 
     /**


### PR DESCRIPTION
When instantiating a SimpleClient, the internal dependencies are initialised before the LoggerInterface passed into SimpleClient is assigned. The effect of this is that dependent objects receive a NullLogger instead.