### PR TITLE
[Redis] message lost prevention

### DIFF
--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -105,7 +105,7 @@ class PRedis implements Redis
         try {
             return $this->redis->renamenx($key, $target);
         } catch (PRedisServerException $e) {
-            throw new ServerException('lrem command has failed', 0, $e);
+            throw new ServerException('renamenx command has failed', 0, $e);
         }
     }
 

--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -104,10 +104,36 @@ class PRedis implements Redis
         }
     }
 
+    public function brpoplpush(string $source, string $dest, int $timeout): ?RedisResult
+    {
+        try {
+            if ($result = $this->redis->brpoplpush($source, $dest, $timeout)) {
+                return new RedisResult($result[0], $result[1]);
+            }
+
+            return null;
+        } catch (PRedisServerException $e) {
+            throw new ServerException('brpop command has failed', 0, $e);
+        }
+    }
+
     public function rpop(string $key): ?RedisResult
     {
         try {
             if ($message = $this->redis->rpop($key)) {
+                return new RedisResult($key, $message);
+            }
+
+            return null;
+        } catch (PRedisServerException $e) {
+            throw new ServerException('rpop command has failed', 0, $e);
+        }
+    }
+
+    public function rpoplpush(string $source, string $dest): ?RedisResult
+    {
+        try {
+            if ($message = $this->redis->rpoplpush($source, $dest)) {
                 return new RedisResult($key, $message);
             }
 

--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -91,6 +91,15 @@ class PRedis implements Redis
         }
     }
 
+    public function lrem(string $key, int $count, string $value): int
+    {
+        try {
+            return $this->redis->lrem($key, $count, $value);
+        } catch (PRedisServerException $e) {
+            throw new ServerException('lrem command has failed', 0, $e);
+        }
+    }
+
     public function brpop(array $keys, int $timeout): ?RedisResult
     {
         try {

--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -107,8 +107,8 @@ class PRedis implements Redis
     public function brpoplpush(string $source, string $dest, int $timeout): ?RedisResult
     {
         try {
-            if ($result = $this->redis->brpoplpush($source, $dest, $timeout)) {
-                return new RedisResult($result[0], $result[1]);
+            if ($message = $this->redis->brpoplpush($source, $dest, $timeout)) {
+                return new RedisResult($source, $message);
             }
 
             return null;
@@ -117,11 +117,11 @@ class PRedis implements Redis
         }
     }
 
-    public function rpop(string $key): ?RedisResult
+    public function rpoplpush(string $source, string $dest): ?RedisResult
     {
         try {
-            if ($message = $this->redis->rpop($key)) {
-                return new RedisResult($key, $message);
+            if ($message = $this->redis->rpoplpush($source, $dest)) {
+                return new RedisResult($source, $message);
             }
 
             return null;
@@ -130,10 +130,10 @@ class PRedis implements Redis
         }
     }
 
-    public function rpoplpush(string $source, string $dest): ?RedisResult
+    public function rpop(string $key): ?RedisResult
     {
         try {
-            if ($message = $this->redis->rpoplpush($source, $dest)) {
+            if ($message = $this->redis->rpop($key)) {
                 return new RedisResult($key, $message);
             }
 

--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -100,6 +100,15 @@ class PRedis implements Redis
         }
     }
 
+    public function renamenx(string $key, string $target): int
+    {
+        try {
+            return $this->redis->renamenx($key, $target);
+        } catch (PRedisServerException $e) {
+            throw new ServerException('lrem command has failed', 0, $e);
+        }
+    }
+
     public function brpop(array $keys, int $timeout): ?RedisResult
     {
         try {

--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -105,6 +105,9 @@ class PRedis implements Redis
         try {
             return $this->redis->renamenx($key, $target);
         } catch (PRedisServerException $e) {
+            if ($e->getMessage() == 'ERR no such key') {
+                return 0;
+            }
             throw new ServerException('renamenx command has failed', 0, $e);
         }
     }

--- a/pkg/redis/Redis.php
+++ b/pkg/redis/Redis.php
@@ -49,6 +49,17 @@ interface Redis
     public function lpush(string $key, string $value): int;
 
     /**
+     * @param string   $source
+     * @param string   $dest
+     * @param int      $timeout in seconds
+     *
+     * @throws ServerException
+     *
+     * @return RedisResult|null
+     */
+    public function brpoplpush(string $source, string $dest, int $timeout): ?RedisResult;
+
+    /**
      * @param string[] $keys
      * @param int      $timeout in seconds
      *
@@ -57,6 +68,16 @@ interface Redis
      * @return RedisResult|null
      */
     public function brpop(array $keys, int $timeout): ?RedisResult;
+
+    /**
+     * @param string   $source
+     * @param string   $dest
+     *
+     * @throws ServerException
+     *
+     * @return RedisResult|null
+     */
+    public function rpoplpush(string $source, string $dest): ?RedisResult;
 
     /**
      * @param string $key

--- a/pkg/redis/Redis.php
+++ b/pkg/redis/Redis.php
@@ -60,6 +60,16 @@ interface Redis
     public function lrem(string $key, int $count, string $value): int;
 
     /**
+     * @param string $key
+     * @param string $target
+     *
+     * @throws ServerException
+     *
+     * @return int rename key to non-exists target success
+     */
+    public function renamenx(string $key, string $target): int;
+
+    /**
      * @param string   $source
      * @param string   $dest
      * @param int      $timeout in seconds

--- a/pkg/redis/Redis.php
+++ b/pkg/redis/Redis.php
@@ -49,6 +49,17 @@ interface Redis
     public function lpush(string $key, string $value): int;
 
     /**
+     * @param string $key
+     * @param int $count
+     * @param string $value
+     *
+     * @throws ServerException
+     *
+     * @return int number of removed elements
+     */
+    public function lrem(string $key, int $count, string $value): int;
+
+    /**
      * @param string   $source
      * @param string   $dest
      * @param int      $timeout in seconds

--- a/pkg/redis/RedisConsumer.php
+++ b/pkg/redis/RedisConsumer.php
@@ -99,8 +99,6 @@ class RedisConsumer implements Consumer
     {
         InvalidMessageException::assertMessageInstanceOf($message, RedisMessage::class);
 
-        $this->acknowledge($message);
-
         if ($requeue) {
             $message = $this->getContext()->getSerializer()->toMessage($message->getReservedKey());
             $message->setHeader('attempts', 0);
@@ -113,6 +111,8 @@ class RedisConsumer implements Consumer
 
             $this->getRedis()->lpush($this->queue->getName(), $payload);
         }
+
+        $this->acknowledge($message);
     }
 
     private function getContext(): RedisContext

--- a/pkg/redis/RedisConsumer.php
+++ b/pkg/redis/RedisConsumer.php
@@ -73,7 +73,7 @@ class RedisConsumer implements Consumer
             }
         }
 
-        return $this->receiveMessage([$this->queue], $timeout, $this->redeliveryDelay);
+        return $this->receiveMessage($this->queue, $timeout, $this->redeliveryDelay);
     }
 
     /**

--- a/pkg/redis/RedisConsumer.php
+++ b/pkg/redis/RedisConsumer.php
@@ -100,15 +100,14 @@ class RedisConsumer implements Consumer
         InvalidMessageException::assertMessageInstanceOf($message, RedisMessage::class);
 
         if ($requeue) {
-            $message = $this->getContext()->getSerializer()->toMessage($message->getReservedKey());
-            $message->setHeader('attempts', 0);
+            $newMessage = $this->getContext()->getSerializer()->toMessage($message->getReservedKey());
+            $newMessage->setHeader('attempts', 0);
 
             if ($message->getTimeToLive()) {
-                $message->setHeader('expires_at', time() + $message->getTimeToLive());
+                $newMessage->setHeader('expires_at', time() + $message->getTimeToLive());
             }
 
-            $payload = $this->getContext()->getSerializer()->toString($message);
-
+            $payload = $this->getContext()->getSerializer()->toString($newMessage);
             $this->getRedis()->lpush($this->queue->getName(), $payload);
         }
 

--- a/pkg/redis/RedisConsumerHelperTrait.php
+++ b/pkg/redis/RedisConsumerHelperTrait.php
@@ -25,7 +25,7 @@ trait RedisConsumerHelperTrait
             $this->migrateExpiredMessages([$queueName]);
 
             if (false == $result = $this->getContext()->getRedis()->brpoplpush(
-                $queueName, $queueName . ':processing', $thisTimeout
+                $queueName, $queueName.':processing', $thisTimeout
             )) {
                 return null;
             }
@@ -42,9 +42,12 @@ trait RedisConsumerHelperTrait
 
     protected function receiveMessageNoWait(RedisDestination $destination, int $redeliveryDelay): ?RedisMessage
     {
-        $this->migrateExpiredMessages([$destination->getName()]);
+        $queueName = $destination->getName();
+        $this->migrateExpiredMessages([$queueName]);
 
-        if ($result = $this->getContext()->getRedis()->rpop($destination->getName())) {
+        if ($result = $this->getContext()->getRedis()->rpoplpush(
+            $queueName, $queueName.':processing'
+        )) {
             return $this->processResult($result, $redeliveryDelay);
         }
 

--- a/pkg/redis/RedisConsumerHelperTrait.php
+++ b/pkg/redis/RedisConsumerHelperTrait.php
@@ -50,6 +50,8 @@ trait RedisConsumerHelperTrait
             $queueName, $queueName.':processing'
         )) {
             return $this->processResult($result, $redeliveryDelay);
+        } else {
+            $this->migrateProcessingMessages([$queueName]);
         }
 
         return null;

--- a/pkg/redis/RedisConsumerHelperTrait.php
+++ b/pkg/redis/RedisConsumerHelperTrait.php
@@ -9,7 +9,7 @@ trait RedisConsumerHelperTrait
     abstract protected function getContext(): RedisContext;
 
     /**
-     * @param RedisDestination[] $queues
+     * @param RedisDestination   $destination
      * @param int                $timeout
      * @param int                $redeliveryDelay
      *

--- a/pkg/redis/RedisConsumerHelperTrait.php
+++ b/pkg/redis/RedisConsumerHelperTrait.php
@@ -97,7 +97,7 @@ trait RedisConsumerHelperTrait
         }
     }
 
-    protected function migrateProcessingMessages(array $queueNames): int
+    protected function migrateProcessingMessages(array $queueNames): void
     {
         foreach ($queueNames as $queueName) {
             $this->getContext()->getRedis()

--- a/pkg/redis/RedisConsumerHelperTrait.php
+++ b/pkg/redis/RedisConsumerHelperTrait.php
@@ -77,9 +77,7 @@ trait RedisConsumerHelperTrait
 
         $redis = $this->getContext()->getRedis();
         $redis->zadd($reservedQueue, $message->getReservedKey(), $redeliveryAt);
-        // TODO update Redis.php to include lrem
-        $redis->lrem($processingQueue, $result->getMessage());
-
+        $redis->lrem($processingQueue, 0, $result->getMessage());
         return $message;
     }
 

--- a/pkg/redis/RedisContext.php
+++ b/pkg/redis/RedisContext.php
@@ -8,6 +8,7 @@ use Interop\Queue\Consumer;
 use Interop\Queue\Context;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
+use Interop\Queue\Exception\SubscriptionConsumerNotSupportedException;
 use Interop\Queue\Exception\TemporaryQueueNotSupportedException;
 use Interop\Queue\Message;
 use Interop\Queue\Producer;
@@ -135,10 +136,14 @@ class RedisContext implements Context
      */
     public function createSubscriptionConsumer(): SubscriptionConsumer
     {
+        throw SubscriptionConsumerNotSupportedException::providerDoestNotSupportIt();
+        /*
+         * Todo temp disable subscription consumer
         $consumer = new RedisSubscriptionConsumer($this);
         $consumer->setRedeliveryDelay($this->redeliveryDelay);
 
         return $consumer;
+        */
     }
 
     /**


### PR DESCRIPTION
Per #750, the main idea of changes is to swap BRPOP/RPOP into BRPOPLPUSH/RPOPLPUSH and make sure writes happen before deletes:

* On receiveMessage, BRPOPLPUSH/RPOPLPUSH fetches result, also move it into `:processing` list
* At the end processResult after ZADD, LREM to remove `:processing` messages
* If worker crashed/connection drops between receiveMessage and processResult, messages will still left intact under the `:processing` list
* When all jobs clear and queue empty, RENAMENX to migrate `:processing` list into the main queue.

There are still stuffs need to be done. But the current version is running on our production, and seems to be working so far.
With the revised design, tradeoff would be message duplications. If worker jobs are idempotent then this will not be a concern. 
To cope with duplicated issue, can keep a hash set of uuids and check against it. The hash set can be deleted when queue becomes empty. 

Plans/Todo:
- [x] redis interface add methods
  -   brpoplpush
  -   rpoplpush
  -   lrem
  -   renamenx
- [x] predis driver added methods
- [ ] phpredis driver added methods
- [x] disable RedisSubscriptionConsumer, as BRPOPLPUSH does not support multiple queues, not sure how to fix this.
- [x] Refractor receiveMessage:
  -   brpoplpush/rpoplpush from queue to `:processing`
  -   zadd reserved
  -   lrem `queue:processing`
- [x] Refractor requeue:
  - swap LPUSH to be called before ZREM
- [x] on queue empty, renamenx `:processing` back to main queue
- [ ] messages duplicates detection (using hash set of uuids)
- [ ] on queue empty, clear duplication hash set
- [ ] Fix/add test cases