### PR TITLE
[fs] polling_interval config should be milliseconds not microseconds

### DIFF
--- a/pkg/fs/FsConsumer.php
+++ b/pkg/fs/FsConsumer.php
@@ -90,7 +90,7 @@ class FsConsumer implements Consumer
                 return null;
             }
 
-            usleep($this->pollingInterval);
+            usleep($this->pollingInterval * 1000);
 
             if ($timeout && (microtime(true) - $startAt) >= $timeout) {
                 return null;


### PR DESCRIPTION
regression from this commit https://github.com/php-enqueue/fs/commit/c5199ca5bac5c661aed86d6b2f751630af42378d

config should be milliseconds like in docs stated.....$this->pollingInterval is holding milliseconds which is correct.

But usleep is using microseconds. To fix it just convert milliseconds to microseconds
