### PR TITLE
[dbal]: make dbal connection config usable again

### DIFF
--- a/pkg/dbal/Tests/DbalConnectionFactoryConfigTest.php
+++ b/pkg/dbal/Tests/DbalConnectionFactoryConfigTest.php
@@ -102,6 +102,72 @@ class DbalConnectionFactoryConfigTest extends TestCase
         ];
 
         yield [
+            [
+                'dsn' => 'mysql+pdo:',
+                'connection' => [
+                    'dbname' => 'customDbName',
+                ],
+            ],
+            [
+                'connection' => [
+                    'dbname' => 'customDbName',
+                    'driver' => 'pdo_mysql',
+                    'host' => 'localhost',
+                    'port' => '3306',
+                    'user' => 'root',
+                    'password' => '',
+                ],
+                'table_name' => 'enqueue',
+                'polling_interval' => 1000,
+                'lazy' => true,
+            ],
+        ];
+
+        yield [
+            [
+                'dsn' => 'mysql+pdo:',
+                'connection' => [
+                    'dbname' => 'customDbName',
+                    'host' => 'host',
+                    'port' => '10000',
+                    'user' => 'user',
+                    'password' => 'pass',
+                ],
+            ],
+            [
+                'connection' => [
+                    'dbname' => 'customDbName',
+                    'host' => 'host',
+                    'port' => '10000',
+                    'user' => 'user',
+                    'password' => 'pass',
+                    'driver' => 'pdo_mysql',
+                ],
+                'table_name' => 'enqueue',
+                'polling_interval' => 1000,
+                'lazy' => true,
+            ],
+        ];
+
+        yield [
+            [
+                'dsn' => 'mysql+pdo://user:pass@host:10000/db',
+                'connection' => [
+                    'foo' => 'fooValue',
+                ],
+            ],
+            [
+                'connection' => [
+                    'foo' => 'fooValue',
+                    'url' => 'pdo_mysql://user:pass@host:10000/db',
+                ],
+                'table_name' => 'enqueue',
+                'polling_interval' => 1000,
+                'lazy' => true,
+            ],
+        ];
+
+        yield [
             'mysql://user:pass@host:10000/db',
             [
                 'connection' => [


### PR DESCRIPTION
right now user cannot declare connection options.

Reason is that always 'connection' => 'url' was set which dbal always prefers over other
connection settings. With this fix connection can be defined dbal compliant like this:

      connection:
        host: 'localhost'
        port: '3306'
        dbname: 'app'
        user: 'app'
        password: ''

'dsn only' works like before.

@makasim what do you think?