### PR TITLE
[consumption] Add ability to change process exit status from within queue consumer extension

### DIFF
--- a/pkg/enqueue/Consumption/Context/End.php
+++ b/pkg/enqueue/Consumption/Context/End.php
@@ -27,12 +27,23 @@ final class End
      */
     private $logger;
 
-    public function __construct(Context $context, int $startTime, int $endTime, LoggerInterface $logger)
-    {
+    /**
+     * @var int
+     */
+    private $exitStatus;
+
+    public function __construct(
+        Context $context,
+        int $startTime,
+        int $endTime,
+        LoggerInterface $logger,
+        ?int $exitStatus = null
+    ) {
         $this->context = $context;
         $this->logger = $logger;
         $this->startTime = $startTime;
         $this->endTime = $endTime;
+        $this->exitStatus = $exitStatus;
     }
 
     public function getContext(): Context
@@ -59,5 +70,10 @@ final class End
     public function getEndTime(): int
     {
         return $this->startTime;
+    }
+
+    public function getExitStatus(): ?int
+    {
+        return $this->exitStatus;
     }
 }

--- a/pkg/enqueue/Consumption/Context/PostConsume.php
+++ b/pkg/enqueue/Consumption/Context/PostConsume.php
@@ -43,6 +43,11 @@ final class PostConsume
      */
     private $executionInterrupted;
 
+    /**
+     * @var int
+     */
+    private $exitStatus;
+
     public function __construct(Context $context, SubscriptionConsumer $subscriptionConsumer, int $receivedMessagesCount, int $cycle, int $startTime, LoggerInterface $logger)
     {
         $this->context = $context;
@@ -85,13 +90,19 @@ final class PostConsume
         return $this->logger;
     }
 
+    public function getExitStatus(): ?int
+    {
+        return $this->exitStatus;
+    }
+
     public function isExecutionInterrupted(): bool
     {
         return $this->executionInterrupted;
     }
 
-    public function interruptExecution(): void
+    public function interruptExecution(?int $exitStatus = null): void
     {
+        $this->exitStatus = $exitStatus;
         $this->executionInterrupted = true;
     }
 }

--- a/pkg/enqueue/Consumption/Context/PostMessageReceived.php
+++ b/pkg/enqueue/Consumption/Context/PostMessageReceived.php
@@ -94,7 +94,7 @@ final class PostMessageReceived
     }
 
     /**
-     * @return Result|null|object|string
+     * @return Result|object|string|null
      */
     public function getResult()
     {

--- a/pkg/enqueue/Consumption/Context/PostMessageReceived.php
+++ b/pkg/enqueue/Consumption/Context/PostMessageReceived.php
@@ -45,6 +45,11 @@ final class PostMessageReceived
      */
     private $executionInterrupted;
 
+    /**
+     * @var int
+     */
+    private $exitStatus;
+
     public function __construct(
         Context $context,
         Consumer $consumer,
@@ -96,13 +101,19 @@ final class PostMessageReceived
         return $this->result;
     }
 
+    public function getExitStatus(): ?int
+    {
+        return $this->exitStatus;
+    }
+
     public function isExecutionInterrupted(): bool
     {
         return $this->executionInterrupted;
     }
 
-    public function interruptExecution(): void
+    public function interruptExecution(?int $exitStatus = null): void
     {
+        $this->exitStatus = $exitStatus;
         $this->executionInterrupted = true;
     }
 }

--- a/pkg/enqueue/Consumption/Context/PreConsume.php
+++ b/pkg/enqueue/Consumption/Context/PreConsume.php
@@ -43,6 +43,11 @@ final class PreConsume
      */
     private $executionInterrupted;
 
+    /**
+     * @var int
+     */
+    private $exitStatus;
+
     public function __construct(Context $context, SubscriptionConsumer $subscriptionConsumer, LoggerInterface $logger, int $cycle, int $receiveTimeout, int $startTime)
     {
         $this->context = $context;
@@ -85,13 +90,19 @@ final class PreConsume
         return $this->startTime;
     }
 
+    public function getExitStatus(): ?int
+    {
+        return $this->exitStatus;
+    }
+
     public function isExecutionInterrupted(): bool
     {
         return $this->executionInterrupted;
     }
 
-    public function interruptExecution(): void
+    public function interruptExecution(?int $exitStatus = null): void
     {
+        $this->exitStatus = $exitStatus;
         $this->executionInterrupted = true;
     }
 }

--- a/pkg/enqueue/Consumption/Context/Start.php
+++ b/pkg/enqueue/Consumption/Context/Start.php
@@ -39,6 +39,11 @@ final class Start
     private $executionInterrupted;
 
     /**
+     * @var int
+     */
+    private $exitStatus;
+
+    /**
      * @param BoundProcessor[] $processors
      */
     public function __construct(Context $context, LoggerInterface $logger, array $processors, int $receiveTimeout, int $startTime)
@@ -105,13 +110,19 @@ final class Start
         });
     }
 
+    public function getExitStatus(): ?int
+    {
+        return $this->exitStatus;
+    }
+
     public function isExecutionInterrupted(): bool
     {
         return $this->executionInterrupted;
     }
 
-    public function interruptExecution(): void
+    public function interruptExecution(?int $exitStatus = null): void
     {
+        $this->exitStatus = $exitStatus;
         $this->executionInterrupted = true;
     }
 }

--- a/pkg/enqueue/Consumption/Extension/CaptureExitStatusExtension.php
+++ b/pkg/enqueue/Consumption/Extension/CaptureExitStatusExtension.php
@@ -3,9 +3,9 @@
 namespace Enqueue\Consumption\Extension;
 
 use Enqueue\Consumption\Context\End;
-use Enqueue\Consumption\ExtensionInterface;
+use Enqueue\Consumption\EndExtensionInterface;
 
-class CaptureExitStatusExtension implements ExtensionInterface
+class CaptureExitStatusExtension implements EndExtensionInterface
 {
     /**
      * @var int
@@ -31,41 +31,5 @@ class CaptureExitStatusExtension implements ExtensionInterface
     public function isExitStatusCaptured(): bool
     {
         return $this->isExitStatusCaptured;
-    }
-
-    public function onInitLogger(\Enqueue\Consumption\Context\InitLogger $context): void
-    {
-    }
-
-    public function onMessageReceived(\Enqueue\Consumption\Context\MessageReceived $context): void
-    {
-    }
-
-    public function onPostConsume(\Enqueue\Consumption\Context\PostConsume $context): void
-    {
-    }
-
-    public function onPostMessageReceived(\Enqueue\Consumption\Context\PostMessageReceived $context): void
-    {
-    }
-
-    public function onPreConsume(\Enqueue\Consumption\Context\PreConsume $context): void
-    {
-    }
-
-    public function onPreSubscribe(\Enqueue\Consumption\Context\PreSubscribe $context): void
-    {
-    }
-
-    public function onProcessorException(\Enqueue\Consumption\Context\ProcessorException $context): void
-    {
-    }
-
-    public function onResult(\Enqueue\Consumption\Context\MessageResult $context): void
-    {
-    }
-
-    public function onStart(\Enqueue\Consumption\Context\Start $context): void
-    {
     }
 }

--- a/pkg/enqueue/Consumption/Extension/CaptureExitStatusExtension.php
+++ b/pkg/enqueue/Consumption/Extension/CaptureExitStatusExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Enqueue\Consumption\Extension;
+
+use Enqueue\Consumption\Context\End;
+use Enqueue\Consumption\EndExtensionInterface;
+
+class CaptureExitStatusExtension implements EndExtensionInterface
+{
+    /**
+     * @var int
+     */
+    private $exitStatus;
+
+    /**
+     * @var bool
+     */
+    private $isExitStatusCaptured = false;
+
+    public function onEnd(End $context): void
+    {
+        $this->exitStatus = $context->getExitStatus();
+        $this->isExitStatusCaptured = true;
+    }
+
+    public function getExitStatus(): ?int
+    {
+        return $this->exitStatus;
+    }
+
+    public function isExitStatusCaptured(): bool
+    {
+        return $this->isExitStatusCaptured;
+    }
+}

--- a/pkg/enqueue/Consumption/Extension/CaptureExitStatusExtension.php
+++ b/pkg/enqueue/Consumption/Extension/CaptureExitStatusExtension.php
@@ -3,9 +3,9 @@
 namespace Enqueue\Consumption\Extension;
 
 use Enqueue\Consumption\Context\End;
-use Enqueue\Consumption\EndExtensionInterface;
+use Enqueue\Consumption\ExtensionInterface;
 
-class CaptureExitStatusExtension implements EndExtensionInterface
+class CaptureExitStatusExtension implements ExtensionInterface
 {
     /**
      * @var int
@@ -31,5 +31,41 @@ class CaptureExitStatusExtension implements EndExtensionInterface
     public function isExitStatusCaptured(): bool
     {
         return $this->isExitStatusCaptured;
+    }
+
+    public function onInitLogger(\Enqueue\Consumption\Context\InitLogger $context): void
+    {
+    }
+
+    public function onMessageReceived(\Enqueue\Consumption\Context\MessageReceived $context): void
+    {
+    }
+
+    public function onPostConsume(\Enqueue\Consumption\Context\PostConsume $context): void
+    {
+    }
+
+    public function onPostMessageReceived(\Enqueue\Consumption\Context\PostMessageReceived $context): void
+    {
+    }
+
+    public function onPreConsume(\Enqueue\Consumption\Context\PreConsume $context): void
+    {
+    }
+
+    public function onPreSubscribe(\Enqueue\Consumption\Context\PreSubscribe $context): void
+    {
+    }
+
+    public function onProcessorException(\Enqueue\Consumption\Context\ProcessorException $context): void
+    {
+    }
+
+    public function onResult(\Enqueue\Consumption\Context\MessageResult $context): void
+    {
+    }
+
+    public function onStart(\Enqueue\Consumption\Context\Start $context): void
+    {
     }
 }

--- a/pkg/enqueue/Consumption/Extension/ExitStatusExtension.php
+++ b/pkg/enqueue/Consumption/Extension/ExitStatusExtension.php
@@ -5,31 +5,20 @@ namespace Enqueue\Consumption\Extension;
 use Enqueue\Consumption\Context\End;
 use Enqueue\Consumption\EndExtensionInterface;
 
-class CaptureExitStatusExtension implements EndExtensionInterface
+class ExitStatusExtension implements EndExtensionInterface
 {
     /**
      * @var int
      */
     private $exitStatus;
 
-    /**
-     * @var bool
-     */
-    private $isExitStatusCaptured = false;
-
     public function onEnd(End $context): void
     {
         $this->exitStatus = $context->getExitStatus();
-        $this->isExitStatusCaptured = true;
     }
 
     public function getExitStatus(): ?int
     {
         return $this->exitStatus;
-    }
-
-    public function isExitStatusCaptured(): bool
-    {
-        return $this->isExitStatusCaptured;
     }
 }

--- a/pkg/enqueue/Consumption/QueueConsumer.php
+++ b/pkg/enqueue/Consumption/QueueConsumer.php
@@ -147,7 +147,7 @@ final class QueueConsumer implements QueueConsumerInterface
         $extension->onStart($start);
 
         if ($start->isExecutionInterrupted()) {
-            $this->onEnd($extension, $startTime);
+            $this->onEnd($extension, $startTime, $start->getExitStatus());
 
             return;
         }
@@ -256,7 +256,7 @@ final class QueueConsumer implements QueueConsumerInterface
             $extension->onPreConsume($preConsume);
 
             if ($preConsume->isExecutionInterrupted()) {
-                $this->onEnd($extension, $startTime, $subscriptionConsumer);
+                $this->onEnd($extension, $startTime, $preConsume->getExitStatus(), $subscriptionConsumer);
 
                 return;
             }
@@ -267,7 +267,7 @@ final class QueueConsumer implements QueueConsumerInterface
             $extension->onPostConsume($postConsume);
 
             if ($interruptExecution || $postConsume->isExecutionInterrupted()) {
-                $this->onEnd($extension, $startTime, $subscriptionConsumer);
+                $this->onEnd($extension, $startTime, $postConsume->getExitStatus(), $subscriptionConsumer);
 
                 return;
             }
@@ -286,11 +286,12 @@ final class QueueConsumer implements QueueConsumerInterface
         $this->fallbackSubscriptionConsumer = $fallbackSubscriptionConsumer;
     }
 
-    private function onEnd(ExtensionInterface $extension, int $startTime, SubscriptionConsumer $subscriptionConsumer = null): void
+    private function onEnd(ExtensionInterface $extension, int $startTime, ?int $exitStatus = null, SubscriptionConsumer $subscriptionConsumer = null): void
     {
         $endTime = (int) (microtime(true) * 1000);
 
-        $extension->onEnd(new End($this->interopContext, $startTime, $endTime, $this->logger));
+        $endContext = new End($this->interopContext, $startTime, $endTime, $this->logger, $exitStatus);
+        $extension->onEnd($endContext);
 
         if ($subscriptionConsumer) {
             $subscriptionConsumer->unsubscribeAll();

--- a/pkg/enqueue/Symfony/Client/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Client/ConsumeCommand.php
@@ -4,6 +4,7 @@ namespace Enqueue\Symfony\Client;
 
 use Enqueue\Client\DriverInterface;
 use Enqueue\Consumption\ChainExtension;
+use Enqueue\Consumption\Extension\ExitStatusExtension;
 use Enqueue\Consumption\Extension\LoggerExtension;
 use Enqueue\Consumption\ExtensionInterface;
 use Enqueue\Consumption\QueueConsumerInterface;
@@ -143,9 +144,12 @@ class ConsumeCommand extends Command
             $consumer->bind($queue, $processor);
         }
 
-        $consumer->consume($this->getRuntimeExtensions($input, $output));
+        $runtimeExtensionChain = $this->getRuntimeExtensions($input, $output);
+        $exitStatusExtension = new ExitStatusExtension();
 
-        return null;
+        $consumer->consume(new ChainExtension([$runtimeExtensionChain, $exitStatusExtension]));
+
+        return $exitStatusExtension->getExitStatus();
     }
 
     protected function getRuntimeExtensions(InputInterface $input, OutputInterface $output): ExtensionInterface

--- a/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
@@ -3,6 +3,7 @@
 namespace Enqueue\Symfony\Consumption;
 
 use Enqueue\Consumption\ChainExtension;
+use Enqueue\Consumption\Extension\CaptureExitStatusExtension;
 use Enqueue\Consumption\QueueConsumerInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -75,9 +76,12 @@ class ConsumeCommand extends Command
             array_unshift($extensions, $loggerExtension);
         }
 
+        $captureExitStatusExtension = new CaptureExitStatusExtension();
+        array_unshift($extensions, $captureExitStatusExtension);
+
         $consumer->consume(new ChainExtension($extensions));
 
-        return null;
+        return $captureExitStatusExtension->getExitStatus();
     }
 
     private function getQueueConsumer(string $name): QueueConsumerInterface

--- a/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
@@ -3,7 +3,7 @@
 namespace Enqueue\Symfony\Consumption;
 
 use Enqueue\Consumption\ChainExtension;
-use Enqueue\Consumption\Extension\CaptureExitStatusExtension;
+use Enqueue\Consumption\Extension\ExitStatusExtension;
 use Enqueue\Consumption\QueueConsumerInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -76,12 +76,12 @@ class ConsumeCommand extends Command
             array_unshift($extensions, $loggerExtension);
         }
 
-        $captureExitStatusExtension = new CaptureExitStatusExtension();
-        array_unshift($extensions, $captureExitStatusExtension);
+        $exitStatusExtension = new ExitStatusExtension();
+        array_unshift($extensions, $exitStatusExtension);
 
         $consumer->consume(new ChainExtension($extensions));
 
-        return $captureExitStatusExtension->getExitStatus();
+        return $exitStatusExtension->getExitStatus();
     }
 
     private function getQueueConsumer(string $name): QueueConsumerInterface

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -16,7 +16,7 @@ use Enqueue\Consumption\Context\PreSubscribe;
 use Enqueue\Consumption\Context\ProcessorException;
 use Enqueue\Consumption\Context\Start;
 use Enqueue\Consumption\Exception\InvalidArgumentException;
-use Enqueue\Consumption\Extension\CaptureExitStatusExtension;
+use Enqueue\Consumption\Extension\ExitStatusExtension;
 use Enqueue\Consumption\ExtensionInterface;
 use Enqueue\Consumption\QueueConsumer;
 use Enqueue\Consumption\Result;
@@ -1445,13 +1445,12 @@ class QueueConsumerTest extends TestCase
             })
         ;
 
-        $exitExtension = new CaptureExitStatusExtension();
+        $exitExtension = new ExitStatusExtension();
 
         $consumer = new QueueConsumer($this->createContextStub(), $stubExtension);
         $consumer->consume(new ChainExtension([$exitExtension]));
 
         $this->assertEquals($testExitCode, $exitExtension->getExitStatus());
-        $this->assertTrue($exitExtension->isExitStatusCaptured());
     }
 
     /**

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -1532,7 +1532,7 @@ class QueueConsumerTest extends TestCase
     }
 
     /**
-     * @param null|mixed $queue
+     * @param mixed|null $queue
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|Consumer
      */

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -1448,7 +1448,7 @@ class QueueConsumerTest extends TestCase
         $exitExtension = new CaptureExitStatusExtension();
 
         $consumer = new QueueConsumer($this->createContextStub(), $stubExtension);
-        $consumer->consume($exitExtension);
+        $consumer->consume(new ChainExtension([$exitExtension]));
 
         $this->assertEquals($testExitCode, $exitExtension->getExitStatus());
         $this->assertTrue($exitExtension->isExitStatusCaptured());

--- a/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
@@ -671,7 +671,7 @@ class ConsumeCommandTest extends TestCase
     }
 
     /**
-     * @param null|mixed $queue
+     * @param mixed|null $queue
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|Consumer
      */

--- a/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
@@ -3,10 +3,18 @@
 namespace Enqueue\Tests\Symfony\Consumption;
 
 use Enqueue\Consumption\ChainExtension;
+use Enqueue\Consumption\Context\Start;
+use Enqueue\Consumption\ExtensionInterface;
+use Enqueue\Consumption\QueueConsumer;
 use Enqueue\Consumption\QueueConsumerInterface;
 use Enqueue\Container\Container;
+use Enqueue\Null\NullQueue;
 use Enqueue\Symfony\Consumption\ConsumeCommand;
 use Enqueue\Test\ClassExtensionTrait;
+use Interop\Queue\Consumer;
+use Interop\Queue\Context as InteropContext;
+use Interop\Queue\Exception\SubscriptionConsumerNotSupportedException;
+use Interop\Queue\Queue;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -123,11 +131,107 @@ class ConsumeCommandTest extends TestCase
         $tester->execute(['--transport' => 'not-defined']);
     }
 
+    public function testShouldReturnExitStatusIfSet()
+    {
+        $testExitCode = 678;
+
+        $stubExtension = $this->createExtension();
+
+        $stubExtension
+            ->expects($this->once())
+            ->method('onStart')
+            ->with($this->isInstanceOf(Start::class))
+            ->willReturnCallback(function (Start $context) use ($testExitCode) {
+                $context->interruptExecution($testExitCode);
+            })
+        ;
+
+        $consumer = new QueueConsumer($this->createContextStub(), $stubExtension);
+
+        $command = new ConsumeCommand(new Container([
+            'enqueue.transport.default.queue_consumer' => $consumer,
+        ]), 'default');
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertEquals($testExitCode, $tester->getStatusCode());
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|QueueConsumerInterface
      */
     private function createQueueConsumerMock()
     {
         return $this->createMock(QueueConsumerInterface::class);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createContextWithoutSubscriptionConsumerMock(): InteropContext
+    {
+        $contextMock = $this->createMock(InteropContext::class);
+        $contextMock
+            ->expects($this->any())
+            ->method('createSubscriptionConsumer')
+            ->willThrowException(SubscriptionConsumerNotSupportedException::providerDoestNotSupportIt())
+        ;
+
+        return $contextMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|InteropContext
+     */
+    private function createContextStub(Consumer $consumer = null): InteropContext
+    {
+        $context = $this->createContextWithoutSubscriptionConsumerMock();
+        $context
+            ->expects($this->any())
+            ->method('createQueue')
+            ->willReturnCallback(function (string $queueName) {
+                return new NullQueue($queueName);
+            })
+        ;
+        $context
+            ->expects($this->any())
+            ->method('createConsumer')
+            ->willReturnCallback(function (Queue $queue) use ($consumer) {
+                return $consumer ?: $this->createConsumerStub($queue);
+            })
+        ;
+
+        return $context;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ExtensionInterface
+     */
+    private function createExtension()
+    {
+        return $this->createMock(ExtensionInterface::class);
+    }
+
+    /**
+     * @param null|mixed $queue
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Consumer
+     */
+    private function createConsumerStub($queue = null): Consumer
+    {
+        if (is_string($queue)) {
+            $queue = new NullQueue($queue);
+        }
+
+        $consumerMock = $this->createMock(Consumer::class);
+        $consumerMock
+            ->expects($this->any())
+            ->method('getQueue')
+            ->willReturn($queue)
+        ;
+
+        return $consumerMock;
     }
 }

--- a/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
@@ -215,7 +215,7 @@ class ConsumeCommandTest extends TestCase
     }
 
     /**
-     * @param null|mixed $queue
+     * @param mixed|null $queue
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|Consumer
      */


### PR DESCRIPTION
```php
<?php
use Enqueue\Consumption\QueueConsumer;
use Enqueue\Consumption\Extension\ExitStatusExtension;

$exitStatusExtension = new ExitStatusExtension();

$fooExtension = new class implements StartExtensionInterface {
    public function onStart(Start $context) 
    {
        $context->interruptExecution(1); // set custom exit code
    }
}

/** @var QueueConsumer $consumer **/
$consumer->consume(new ChainExtension([
    $fooExtension
    $exitStatusExtension
]));

exit($exitStatusExtension->getExitStatus());

```