### PR TITLE
Allow to change visibility timeout on SQS during requeue message

### DIFF
--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -138,7 +138,7 @@ class SqsConsumer implements Consumer
                 '@region' => $this->queue->getRegion(),
                 'QueueUrl' => $this->context->getQueueUrl($this->queue),
                 'ReceiptHandle' => $message->getReceiptHandle(),
-                'VisibilityTimeout' => 0,
+                'VisibilityTimeout' => $message->getDelaySeconds(),
             ]);
         } else {
             $this->context->getSqsClient()->deleteMessage([


### PR DESCRIPTION
I think, hardcoding "0" during requeue is not the best option. Especially then `SqsMessage` already has method `getDelaySeconds`.