### PR TITLE
Catch signal in Bunny adapter

### DIFF
--- a/pkg/amqp-bunny/AmqpSubscriptionConsumer.php
+++ b/pkg/amqp-bunny/AmqpSubscriptionConsumer.php
@@ -47,7 +47,7 @@ class AmqpSubscriptionConsumer implements InteropAmqpSubscriptionConsumer
         try {
             $this->context->getBunnyChannel()->getClient()->run(0 !== $timeout ? $timeout / 1000 : null);
         } catch (ClientException $e) {
-            if ('stream_select() failed' === substr($e->getMessage(), 0, 22) && $signalHandler->wasThereSignal()) {
+            if (0 === strpos($e->getMessage(), 'stream_select() failed') && $signalHandler->wasThereSignal()) {
                 return;
             }
 

--- a/pkg/amqp-bunny/AmqpSubscriptionConsumer.php
+++ b/pkg/amqp-bunny/AmqpSubscriptionConsumer.php
@@ -47,7 +47,7 @@ class AmqpSubscriptionConsumer implements InteropAmqpSubscriptionConsumer
         try {
             $this->context->getBunnyChannel()->getClient()->run(0 !== $timeout ? $timeout / 1000 : null);
         } catch (ClientException $e) {
-            if ('stream_select() failed.' == $e->getMessage() && $signalHandler->wasThereSignal()) {
+            if ('stream_select() failed' === substr($e->getMessage(), 0, 22) && $signalHandler->wasThereSignal()) {
                 return;
             }
 


### PR DESCRIPTION
Bunny adapter try to catch `ClientException` when signal was triggered and exception's message is `stream_select() failed.`. However message is `stream_select() failed: Unknown error.`.