### PR TITLE
Fix exception loop in QueueConsumer

### DIFF
--- a/pkg/enqueue/Consumption/QueueConsumer.php
+++ b/pkg/enqueue/Consumption/QueueConsumer.php
@@ -317,18 +317,16 @@ final class QueueConsumer implements QueueConsumerInterface
 
             return $result;
         } catch (\Exception $e) {
-            $wrapper = $e;
-            while ($prev = $wrapper->getPrevious()) {
+            $prev = $e;
+            do {
                 if ($exception === $wrapper = $prev) {
                     throw $e;
                 }
-            }
+            } while ($prev = $wrapper->getPrevious());
 
-            if ($exception !== $wrapper) {
-                $prev = new \ReflectionProperty('Exception', 'previous');
-                $prev->setAccessible(true);
-                $prev->setValue($wrapper, $exception);
-            }
+            $prev = new \ReflectionProperty($wrapper instanceof \Exception ? \Exception::class : \Error::class, 'previous');
+            $prev->setAccessible(true);
+            $prev->setValue($wrapper, $exception);
 
             throw $e;
         }

--- a/pkg/enqueue/Consumption/QueueConsumer.php
+++ b/pkg/enqueue/Consumption/QueueConsumer.php
@@ -299,7 +299,7 @@ final class QueueConsumer implements QueueConsumerInterface
     }
 
     /**
-     * The logic is similar to one in Symfony's ExceptionListener::.
+     * The logic is similar to one in Symfony's ExceptionListener::onKernelException().
      *
      * https://github.com/symfony/symfony/blob/cbe289517470eeea27162fd2d523eb29c95f775f/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php#L77
      */


### PR DESCRIPTION
Closes #774

I finally understand how this happened and how it should be done correctly so here is the fix.

The if from #725 is not necessary. It was actually wrong anyway - the condition was always true.

I also sent the same PR to Symfony. https://github.com/symfony/symfony/pull/30327