### PR TITLE
Fix amqp-tools dependency

### DIFF
--- a/pkg/amqp-tools/composer.json
+++ b/pkg/amqp-tools/composer.json
@@ -8,13 +8,13 @@
     "require": {
         "php": "^7.1.3",
         "queue-interop/amqp-interop": "^0.8",
-        "queue-interop/queue-interop": "^0.7|^0.8"
+        "queue-interop/queue-interop": "^0.7|^0.8",
+        "enqueue/dsn": "^0.9.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.4.0",
         "enqueue/test": "0.9.x-dev",
-        "enqueue/null": "0.9.x-dev",
-        "enqueue/dsn": "0.9.x-dev"
+        "enqueue/null": "0.9.x-dev"
     },
     "support": {
         "email": "opensource@forma-pro.com",


### PR DESCRIPTION
Fix #783 

The enqueue/dsn must be required and not only for dev because ConnectionConfig
uses it.