### PR TITLE
[dbal] Fix DBAL Consumer duplicating messages when rejecting with requeue

### DIFF
--- a/pkg/dbal/DbalConsumer.php
+++ b/pkg/dbal/DbalConsumer.php
@@ -100,16 +100,14 @@ class DbalConsumer implements Consumer
     {
         InvalidMessageException::assertMessageInstanceOf($message, DbalMessage::class);
 
+        $this->acknowledge($message);
+
         if ($requeue) {
             $message = clone $message;
             $message->setRedelivered(false);
 
             $this->getContext()->createProducer()->send($this->queue, $message);
-
-            return;
         }
-
-        $this->deleteMessage($message->getDeliveryId());
     }
 
     protected function getContext(): DbalContext

--- a/pkg/dbal/Tests/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/DbalConsumerTest.php
@@ -169,6 +169,7 @@ class DbalConsumerTest extends TestCase
 
         $message = new DbalMessage();
         $message->setBody('theBody');
+        $message->setDeliveryId(__METHOD__);
 
         $producerMock = $this->createProducerMock();
         $producerMock

--- a/pkg/dbal/Tests/Functional/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/Functional/DbalConsumerTest.php
@@ -144,7 +144,7 @@ class DbalConsumerTest extends TestCase
         $this->assertSame(0, $this->getQuerySize());
     }
 
-    public function testShouldRemoveOriginalMessageThatHaveBeenRejectedWithRequeu()
+    public function testShouldRemoveOriginalMessageThatHaveBeenRejectedWithRequeue()
     {
         $context = $this->context;
         $queue = $context->createQueue(__METHOD__);

--- a/pkg/dbal/Tests/Functional/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/Functional/DbalConsumerTest.php
@@ -160,7 +160,7 @@ class DbalConsumerTest extends TestCase
         $message = $context->createMessage(__CLASS__);
         $producer->send($queue, $message);
 
-        $this->assertCount(1, $this->getQuerySize());
+        $this->assertSame(1, $this->getQuerySize());
 
         $message = $consumer->receive(100); // 100ms
 

--- a/pkg/dbal/Tests/Functional/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/Functional/DbalConsumerTest.php
@@ -166,7 +166,7 @@ class DbalConsumerTest extends TestCase
 
         $this->assertInstanceOf(DbalMessage::class, $message);
         $consumer->reject($message, true);
-        $this->assertCount(1, $this->getQuerySize());
+        $this->assertSame(1, $this->getQuerySize());
     }
 
     private function getQuerySize(): int


### PR DESCRIPTION
Fix #814 

I've switched to `acknowledge` first and then proceed with queueing the message again since this seems how other (Redis, RdKafka for example) work. Others seem to assume that message is automatically acknowledged when it's received.

For the same reason I'm using `acknowledge` instead of `deleteMessage` (other packages seem to work this way.