### PR TITLE
Fix heartbeat configuration in bunny with 0 (off) value

### DIFF
--- a/pkg/amqp-bunny/AmqpConnectionFactory.php
+++ b/pkg/amqp-bunny/AmqpConnectionFactory.php
@@ -87,16 +87,13 @@ class AmqpConnectionFactory implements InteropAmqpConnectionFactory, DelayStrate
             $bunnyConfig['password'] = $this->config->getPass();
             $bunnyConfig['read_write_timeout'] = min($this->config->getReadTimeout(), $this->config->getWriteTimeout());
             $bunnyConfig['timeout'] = $this->config->getConnectionTimeout();
+            $bunnyConfig['heartbeat'] = $this->config->getHeartbeat();
 
             // @see https://github.com/php-enqueue/enqueue-dev/issues/229
 //            $bunnyConfig['persistent'] = $this->config->isPersisted();
 //            if ($this->config->isPersisted()) {
 //                $bunnyConfig['path'] = 'enqueue';//$this->config->getOption('path', $this->config->getOption('vhost'));
 //            }
-
-            if ($this->config->getHeartbeat()) {
-                $bunnyConfig['heartbeat'] = $this->config->getHeartbeat();
-            }
 
             if (null !== $this->config->getOption('tcp_nodelay')) {
                 $bunnyConfig['tcp_nodelay'] = $this->config->getOption('tcp_nodelay');


### PR DESCRIPTION
When bunny doesn't see heartbeat key in bunnyConfig it set default value to 60 seconds.
So when one set hearbeat to zero, code ignore setting this key to bunnyConfig. We should remove this check.