### PR TITLE
Fixed docs

### DIFF
--- a/pkg/enqueue/Symfony/DependencyInjection/TransportFactory.php
+++ b/pkg/enqueue/Symfony/DependencyInjection/TransportFactory.php
@@ -117,7 +117,7 @@ final class TransportFactory
                 ->integerNode('receive_timeout')
                     ->min(0)
                     ->defaultValue(10000)
-                    ->info('the time in milliseconds queue consumer waits for a message (100 ms by default)')
+                    ->info('the time in milliseconds queue consumer waits for a message (10000 ms by default)')
                 ->end()
         ;
 


### PR DESCRIPTION
The command docs say the default is `100 ms` but that's not true, it's `10000 ms` by default.
I also wonder what is correct, I mean, in what world do you want a worker to wait 10 seconds between jobs? Maybe 100 ms should've been the right value?