### PR TITLE
Fixed rabbitmq plugin delay strategy by applying correct header

### DIFF
--- a/pkg/amqp-tools/RabbitMqDelayPluginDelayStrategy.php
+++ b/pkg/amqp-tools/RabbitMqDelayPluginDelayStrategy.php
@@ -17,7 +17,8 @@ class RabbitMqDelayPluginDelayStrategy implements DelayStrategy
     public function delayMessage(AmqpContext $context, AmqpDestination $dest, AmqpMessage $message, int $delay): void
     {
         $delayMessage = $context->createMessage($message->getBody(), $message->getProperties(), $message->getHeaders());
-        $delayMessage->setProperty('x-delay', (int) $delay);
+        $delayMessage->setProperty('x-delay', $delay);
+        $delayMessage->setHeader('x-delay', $delay);
         $delayMessage->setRoutingKey($message->getRoutingKey());
 
         if ($dest instanceof AmqpTopic) {

--- a/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
@@ -84,6 +84,8 @@ class RabbitMqDelayPluginDelayStrategyTest extends TestCase
         ], $delayedTopic->getArguments());
 
         $this->assertSame(['x-delay' => 10000], $delayedMessage->getProperties());
+        $this->assertArrayHasKey('x-delay', $delayedMessage->getHeaders());
+        $this->assertSame(10000, $delayedMessage->getHeaders()['x-delay']);
         $this->assertSame('the-routing-key', $delayedMessage->getRoutingKey());
     }
 


### PR DESCRIPTION
The delay strategy creates a header array of application_headers which contained the x-delay instead of having the x-delay header directly. Screenshot of the message in the queue https://i.imgur.com/Qk4jyc4.png

The result was that the message was not correctly delayed. I've added the correct header to the message and then the delay started working. I've left the original property unchanged other than removing unnecessary type casting.

