### PR TITLE
added getQueueLength method to Redis Consumer

### DIFF
--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -139,4 +139,9 @@ class PRedis implements Redis
     {
         $this->redis->del([$key]);
     }
+
+    public function llen(string $key): int
+    {
+        return $this->redis->llen($key);
+    }
 }

--- a/pkg/redis/PhpRedis.php
+++ b/pkg/redis/PhpRedis.php
@@ -141,4 +141,9 @@ class PhpRedis implements Redis
     {
         $this->redis->del($key);
     }
+
+    public function llen(string $key): int
+    {
+        return $this->redis->llen($key);
+    }
 }

--- a/pkg/redis/Redis.php
+++ b/pkg/redis/Redis.php
@@ -80,4 +80,11 @@ interface Redis
      * @throws ServerException
      */
     public function del(string $key): void;
+
+    /**
+     * @param string $key
+     *
+     * @return int
+     */
+    public function llen(string $key): int;
 }

--- a/pkg/redis/RedisConsumer.php
+++ b/pkg/redis/RedisConsumer.php
@@ -115,6 +115,16 @@ class RedisConsumer implements Consumer
         }
     }
 
+    /**
+     * Get number of tasks left.
+     *
+     * @return int
+     */
+    public function getQueueLength(): int
+    {
+        return $this->getRedis()->llen($this->queue->getName());
+    }
+
     private function getContext(): RedisContext
     {
         return $this->context;

--- a/pkg/redis/Tests/RedisConsumerTest.php
+++ b/pkg/redis/Tests/RedisConsumerTest.php
@@ -290,6 +290,30 @@ class RedisConsumerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('aBody', $message->getBody());
     }
 
+    public function testShouldReturnNumberOfMessagesOnGetQueueLength()
+    {
+        $destination = new RedisDestination('aQueue');
+
+        $redisMock = $this->createRedisMock();
+        $redisMock
+            ->expects($this->once())
+            ->method('llen')
+            ->with('aQueue')
+            ->willReturn(1)
+        ;
+
+        $contextMock = $this->createContextMock();
+        $contextMock
+            ->expects($this->atLeastOnce())
+            ->method('getRedis')
+            ->willReturn($redisMock)
+        ;
+
+        $consumer = new RedisConsumer($contextMock, $destination);
+        $length = $consumer->getQueueLength();
+        $this->assertSame(1, $length);
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Redis
      */


### PR DESCRIPTION
Added ability to get count of messages in the queue.
My use case is to log queue size on every message consume.