### PR TITLE
 Add support for using the /topic prefix instead of /exchange.

### DIFF
--- a/docs/transport/stomp.md
+++ b/docs/transport/stomp.md
@@ -36,6 +36,12 @@ $factory = new StompConnectionFactory('stomp:');
 // same as above
 $factory = new StompConnectionFactory([]);
 
+// connect via stomp to RabbitMQ (default) - the topic names are prefixed with /exchange
+$factory = new StompConnectionFactory('stomp+rabbitmq:');
+
+// connect via stomp to ActiveMQ - the topic names are prefixed with /topic
+$factory = new StompConnectionFactory('stomp+activemq:');
+
 // connect to stomp broker at example.com port 1000 using 
 $factory = new StompConnectionFactory([
     'host' => 'example.com',

--- a/pkg/stomp/StompContext.php
+++ b/pkg/stomp/StompContext.php
@@ -35,7 +35,7 @@ class StompContext implements Context
 
     /**
      * @param BufferedStompClient|callable $stomp
-     * @param bool $useExchangePrefix
+     * @param bool                         $useExchangePrefix
      */
     public function __construct($stomp, $useExchangePrefix = true)
     {

--- a/pkg/stomp/StompContext.php
+++ b/pkg/stomp/StompContext.php
@@ -24,14 +24,20 @@ class StompContext implements Context
     private $stomp;
 
     /**
+     * @var bool
+     */
+    private $useExchangePrefix;
+
+    /**
      * @var callable
      */
     private $stompFactory;
 
     /**
      * @param BufferedStompClient|callable $stomp
+     * @param bool $useExchangePrefix
      */
-    public function __construct($stomp)
+    public function __construct($stomp, $useExchangePrefix = true)
     {
         if ($stomp instanceof BufferedStompClient) {
             $this->stomp = $stomp;
@@ -40,6 +46,8 @@ class StompContext implements Context
         } else {
             throw new \InvalidArgumentException('The stomp argument must be either BufferedStompClient or callable that return BufferedStompClient.');
         }
+
+        $this->useExchangePrefix = $useExchangePrefix;
     }
 
     /**
@@ -84,7 +92,7 @@ class StompContext implements Context
     {
         if (0 !== strpos($name, '/')) {
             $destination = new StompDestination();
-            $destination->setType(StompDestination::TYPE_EXCHANGE);
+            $destination->setType($this->useExchangePrefix ? StompDestination::TYPE_EXCHANGE : StompDestination::TYPE_TOPIC);
             $destination->setStompName($name);
 
             return $destination;

--- a/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
+++ b/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
@@ -55,6 +55,7 @@ class StompConnectionFactoryConfigTest extends TestCase
         yield [
             null,
             [
+                'target' => 'rabbitmq',
                 'host' => 'localhost',
                 'port' => 61613,
                 'login' => 'guest',
@@ -71,6 +72,7 @@ class StompConnectionFactoryConfigTest extends TestCase
         yield [
             'stomp:',
             [
+                'target' => 'rabbitmq',
                 'host' => 'localhost',
                 'port' => 61613,
                 'login' => 'guest',
@@ -87,6 +89,7 @@ class StompConnectionFactoryConfigTest extends TestCase
         yield [
             [],
             [
+                'target' => 'rabbitmq',
                 'host' => 'localhost',
                 'port' => 61613,
                 'login' => 'guest',
@@ -103,6 +106,43 @@ class StompConnectionFactoryConfigTest extends TestCase
         yield [
             'stomp://localhost:1234?foo=bar&lazy=0&sync=true',
             [
+                'target' => 'rabbitmq',
+                'host' => 'localhost',
+                'port' => 1234,
+                'login' => 'guest',
+                'password' => 'guest',
+                'vhost' => '/',
+                'buffer_size' => 1000,
+                'connection_timeout' => 1,
+                'sync' => true,
+                'lazy' => false,
+                'foo' => 'bar',
+                'ssl_on' => false,
+            ],
+        ];
+
+        yield [
+            'stomp+activemq://localhost:1234?foo=bar&lazy=0&sync=true',
+            [
+                'target' => 'activemq',
+                'host' => 'localhost',
+                'port' => 1234,
+                'login' => 'guest',
+                'password' => 'guest',
+                'vhost' => '/',
+                'buffer_size' => 1000,
+                'connection_timeout' => 1,
+                'sync' => true,
+                'lazy' => false,
+                'foo' => 'bar',
+                'ssl_on' => false,
+            ],
+        ];
+
+        yield [
+            'stomp+rabbitmq://localhost:1234?foo=bar&lazy=0&sync=true',
+            [
+                'target' => 'rabbitmq',
                 'host' => 'localhost',
                 'port' => 1234,
                 'login' => 'guest',
@@ -120,6 +160,7 @@ class StompConnectionFactoryConfigTest extends TestCase
         yield [
             ['dsn' => 'stomp://localhost:1234/theVhost?foo=bar&lazy=0&sync=true', 'baz' => 'bazVal', 'foo' => 'fooVal'],
             [
+                'target' => 'rabbitmq',
                 'host' => 'localhost',
                 'port' => 1234,
                 'login' => 'guest',
@@ -138,6 +179,7 @@ class StompConnectionFactoryConfigTest extends TestCase
         yield [
             ['dsn' => 'stomp:///%2f'],
             [
+                'target' => 'rabbitmq',
                 'host' => 'localhost',
                 'port' => 61613,
                 'login' => 'guest',
@@ -154,6 +196,7 @@ class StompConnectionFactoryConfigTest extends TestCase
         yield [
             ['host' => 'localhost', 'port' => 1234, 'foo' => 'bar'],
             [
+                'target' => 'rabbitmq',
                 'host' => 'localhost',
                 'port' => 1234,
                 'login' => 'guest',

--- a/pkg/stomp/Tests/StompConnectionFactoryTest.php
+++ b/pkg/stomp/Tests/StompConnectionFactoryTest.php
@@ -25,6 +25,31 @@ class StompConnectionFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(StompContext::class, $context);
 
         $this->assertAttributeEquals(null, 'stomp', $context);
+        $this->assertAttributeEquals(true, 'useExchangePrefix', $context);
         $this->assertInternalType('callable', $this->readAttribute($context, 'stompFactory'));
+    }
+
+    public function testShouldCreateRabbitMQContext()
+    {
+        $factory = new StompConnectionFactory('stomp+rabbitmq://');
+
+        $context = $factory->createContext();
+
+        $this->assertInstanceOf(StompContext::class, $context);
+
+        $this->assertAttributeEquals(null, 'stomp', $context);
+        $this->assertAttributeEquals(true, 'useExchangePrefix', $context);
+    }
+
+    public function testShouldCreateActiveMQContext()
+    {
+        $factory = new StompConnectionFactory('stomp+activemq://');
+
+        $context = $factory->createContext();
+
+        $this->assertInstanceOf(StompContext::class, $context);
+
+        $this->assertAttributeEquals(null, 'stomp', $context);
+        $this->assertAttributeEquals(false, 'useExchangePrefix', $context);
     }
 }

--- a/pkg/stomp/Tests/StompContextTest.php
+++ b/pkg/stomp/Tests/StompContextTest.php
@@ -79,7 +79,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('/amq/queue/name/routing-key', $destination->getQueueName());
     }
 
-    public function testShouldCreateTopicInstance()
+    public function testShouldCreateTopicInstanceWithExchangePrefix()
     {
         $context = new StompContext($this->createStompClientMock());
 
@@ -89,6 +89,18 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('/exchange/the name', $topic->getQueueName());
         $this->assertSame('/exchange/the name', $topic->getTopicName());
         $this->assertSame(StompDestination::TYPE_EXCHANGE, $topic->getType());
+    }
+
+    public function testShouldCreateTopicInstanceWithTopicPrefix()
+    {
+        $context = new StompContext($this->createStompClientMock(), false);
+
+        $topic = $context->createTopic('the name');
+
+        $this->assertInstanceOf(StompDestination::class, $topic);
+        $this->assertSame('/topic/the name', $topic->getQueueName());
+        $this->assertSame('/topic/the name', $topic->getTopicName());
+        $this->assertSame(StompDestination::TYPE_TOPIC, $topic->getType());
     }
 
     public function testCreateTopicShouldCreateDestinationIfNameIsFullDestinationString()


### PR DESCRIPTION
Add support for using the /topic prefix instead of /exchange. RabbitMQ needs the /exchange prefix for publishing on an exchange, while ActiveMQ needs the /topic prefix for publishing on a topic