### PR TITLE
Fix un-initialized property use

### DIFF
--- a/pkg/amqp-lib/AmqpSubscriptionConsumer.php
+++ b/pkg/amqp-lib/AmqpSubscriptionConsumer.php
@@ -34,6 +34,7 @@ class AmqpSubscriptionConsumer implements InteropAmqpSubscriptionConsumer
 
     public function __construct(AmqpContext $context, bool $heartbeatOnTick)
     {
+        $this->subscribers = [];
         $this->context = $context;
         $this->heartbeatOnTick = $heartbeatOnTick;
     }


### PR DESCRIPTION
Resolves #833

Simple and straightforward fix, just initialize private property before it's used in `subscribe` method (or any other, for that matter).