### PR TITLE
[Kafka] Fix consumption errors in kafka against recent versions in librdkafka/phprdkafka

### DIFF
--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -155,6 +155,10 @@ class RdKafkaConsumer implements Consumer
     {
         $kafkaMessage = $this->consumer->consume($timeout);
 
+        if (null === $kafkaMessage) {
+            return null;
+        }
+
         switch ($kafkaMessage->err) {
             case RD_KAFKA_RESP_ERR__PARTITION_EOF:
             case RD_KAFKA_RESP_ERR__TIMED_OUT:


### PR DESCRIPTION
Recent versions may no longer return error message when reaching end of partition
(`RD_KAFKA_RESP_ERR__PARTITION_EOF` - due to change in `enable.partition.eof`).
This is especially true for librdkafka >=1.0.0.
see https://github.com/arnaud-lb/php-rdkafka/issues/220#issuecomment-491162230