### PR TITLE
Send topic and command for consumed messages

### DIFF
--- a/pkg/monitoring/InfluxDbStorage.php
+++ b/pkg/monitoring/InfluxDbStorage.php
@@ -160,6 +160,16 @@ class InfluxDbStorage implements StatsStorage
             'status' => $stats->getStatus(),
         ];
 
+        $properties = $stats->getProperties();
+
+        if (false === empty($properties[Config::TOPIC])) {
+            $tags['topic'] = $properties[Config::TOPIC];
+        }
+
+        if (false === empty($properties[Config::COMMAND])) {
+            $tags['command'] = $properties[Config::COMMAND];
+        }
+
         $values = [
             'receivedAt' => $stats->getReceivedAtMs(),
             'processedAt' => $stats->getTimestampMs(),


### PR DESCRIPTION
`topic` and `command` are important to know what messages exactly are causing any failures, if anything wrong happens. `queue` is the same for all topics with default configuration.
The code is same as with emitted messages.
Tested with real use-case inside symfony project.