### PR TITLE
Add support for publisher confirms to amqp-bunny

### DIFF
--- a/docs/transport/amqp_bunny.md
+++ b/docs/transport/amqp_bunny.md
@@ -25,6 +25,7 @@ Build on top of [bunny lib](https://github.com/jakubkulhan/bunny).
 * [Consume message](#consume-message)
 * [Subscription consumer](#subscription-consumer)
 * [Purge queue messages](#purge-queue-messages)
+* [Enable publisher confirms](#enable-publisher-confirms)
 
 ## Installation
 
@@ -265,6 +266,19 @@ $subscriptionConsumer->consume(2000); // 2 sec
 $queue = $context->createQueue('aQueue');
 
 $context->purgeQueue($queue);
+```
+
+## Enable publisher confirms
+
+If you use RabbitMQ and want to be sure your messages are received and persisted to the disk,
+you can turn on the [publisher confirms](https://www.rabbitmq.com/confirms.html#publisher-confirms).
+
+This way, after each published message, your PHP script will wait up to specified number
+of seconds to get confirmation (ACK frame) from RabbitMQ.
+
+```php
+<?php
+$factory = new AmqpConnectionFactory('amqp:?publisher_confirm_timeout=3');
 ```
 
 [back to index](../index.md)

--- a/pkg/amqp-bunny/AmqpContext.php
+++ b/pkg/amqp-bunny/AmqpContext.php
@@ -131,6 +131,9 @@ class AmqpContext implements InteropAmqpContext, DelayStrategyAware
     {
         $producer = new AmqpProducer($this->getBunnyChannel(), $this);
         $producer->setDelayStrategy($this->delayStrategy);
+        if (isset($this->config['publisher_confirm_timeout'])) {
+            $producer->enableConfirmMode((float) $this->config['publisher_confirm_timeout']);
+        }
 
         return $producer;
     }

--- a/pkg/amqp-bunny/AmqpProducer.php
+++ b/pkg/amqp-bunny/AmqpProducer.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Enqueue\AmqpBunny;
 
 use Bunny\Channel;
+use Bunny\ChannelModeEnum;
+use Bunny\Client;
+use Bunny\Protocol\MethodBasicAckFrame;
+use Bunny\Protocol\MethodBasicNackFrame;
+use Bunny\Protocol\MethodFrame;
 use Enqueue\AmqpTools\DelayStrategyAware;
 use Enqueue\AmqpTools\DelayStrategyAwareTrait;
 use Interop\Amqp\AmqpDestination as InteropAmqpDestination;
@@ -50,10 +55,36 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
      */
     private $context;
 
+    /**
+     * @var bool
+     */
+    private $confirmModeEnabled = false;
+
+    /**
+     * @var float|null
+     */
+    private $timeout;
+
+    /**
+     * @var bool
+     */
+    private $ackCallbackAdded = false;
+
+    /**
+     * @var int|null
+     */
+    private $pendingDeliveryTag;
+
     public function __construct(Channel $channel, AmqpContext $context)
     {
         $this->channel = $channel;
         $this->context = $context;
+    }
+
+    public function enableConfirmMode(float $timeout)
+    {
+        $this->confirmModeEnabled = true;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -70,7 +101,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
         InvalidMessageException::assertMessageInstanceOf($message, InteropAmqpMessage::class);
 
         try {
-            $this->doSend($destination, $message);
+            $this->doSendWithPossibleConfirm($destination, $message);
         } catch (\Exception $e) {
             throw new Exception($e->getMessage(), $e->getCode(), $e);
         }
@@ -125,7 +156,20 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
         return $this->timeToLive;
     }
 
-    private function doSend(InteropAmqpDestination $destination, InteropAmqpMessage $message): void
+    private function doSendWithPossibleConfirm(InteropAmqpDestination $destination, InteropAmqpMessage $message): void
+    {
+        if ($this->confirmModeEnabled) {
+            $this->ensureConfirmMode();
+        }
+
+        $result = $this->doSend($destination, $message);
+
+        if ($this->confirmModeEnabled) {
+            $this->waitForDelivery($result);
+        }
+    }
+
+    private function doSend(InteropAmqpDestination $destination, InteropAmqpMessage $message)
     {
         if (null !== $this->priority && null === $message->getPriority()) {
             $message->setPriority($this->priority);
@@ -148,8 +192,10 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
 
         if ($this->deliveryDelay) {
             $this->delayStrategy->delayMessage($this->context, $destination, $message, $this->deliveryDelay);
+
+            return null;
         } elseif ($destination instanceof InteropAmqpTopic) {
-            $this->channel->publish(
+            return $this->channel->publish(
                 $message->getBody(),
                 $amqpProperties,
                 $destination->getTopicName(),
@@ -157,8 +203,9 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
                 (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_MANDATORY),
                 (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_IMMEDIATE)
             );
-        } else {
-            $this->channel->publish(
+        }
+
+        return $this->channel->publish(
                 $message->getBody(),
                 $amqpProperties,
                 '',
@@ -166,6 +213,54 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
                 (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_MANDATORY),
                 (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_IMMEDIATE)
             );
+    }
+
+    private function ensureConfirmMode()
+    {
+        if (ChannelModeEnum::CONFIRM !== $this->channel->getMode()) {
+            $this->channel->confirmSelect();
         }
+
+        if (!$this->ackCallbackAdded) {
+            $this->channel->addAckListener(function (MethodFrame $frame) {
+                $this->handleMethodFrame($frame);
+            });
+            $this->ackCallbackAdded = true;
+        }
+    }
+
+    private function waitForDelivery(?int $deliveryTag)
+    {
+        if (null === $deliveryTag) {
+            return;
+        }
+
+        $this->pendingDeliveryTag = $deliveryTag;
+        $this->channel->getClient()->run($this->timeout);
+        if (null !== $this->pendingDeliveryTag) {
+            throw new Exception(sprintf('No ACK got in %ss for sent message with confirm mode', $this->timeout));
+        }
+    }
+
+    private function handleMethodFrame(MethodFrame $frame)
+    {
+        if (!$frame instanceof MethodBasicAckFrame && !$frame instanceof MethodBasicNackFrame) {
+            throw new Exception(sprintf('Unexpected frame received: %s', get_class($frame)));
+        }
+
+        if ($this->pendingDeliveryTag !== $frame->deliveryTag) {
+            // probably different listener will handle this frame
+            return;
+        }
+
+        if ($frame instanceof MethodBasicNackFrame) {
+            throw new Exception('NACK was got for sent message');
+        }
+
+        $this->pendingDeliveryTag = null;
+
+        /** @var Client $client */
+        $client = $this->channel->getClient();
+        $client->stop();
     }
 }

--- a/pkg/amqp-bunny/Tests/Spec/AmqpSendToAndReceiveFromQueueWithConfirmModeTest.php
+++ b/pkg/amqp-bunny/Tests/Spec/AmqpSendToAndReceiveFromQueueWithConfirmModeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Enqueue\AmqpBunny\Tests\Spec;
+
+use Enqueue\AmqpBunny\AmqpConnectionFactory;
+use Enqueue\AmqpBunny\AmqpContext;
+use Interop\Queue\Context;
+use Interop\Queue\Spec\SendToAndReceiveFromQueueSpec;
+
+/**
+ * @group functional
+ */
+class AmqpSendToAndReceiveFromQueueWithConfirmModeTest extends SendToAndReceiveFromQueueSpec
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createContext()
+    {
+        $factory = new AmqpConnectionFactory(['dsn' => getenv('AMQP_DSN'), 'publisher_confirm_timeout' => 3]);
+
+        return $factory->createContext();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param AmqpContext $context
+     */
+    protected function createQueue(Context $context, $queueName)
+    {
+        $queue = $context->createQueue($queueName);
+        $context->declareQueue($queue);
+        $context->purgeQueue($queue);
+
+        return $queue;
+    }
+}


### PR DESCRIPTION
RabbitMQ has publisher confirm mechanism available: https://www.rabbitmq.com/confirms.html#publisher-confirms
This guarantees that any message published to RabbitMQ will either get persisted to the disk or exception is thrown.
Without this addition, if RabbitMQ instance crashes or if you have some sort of network errors (like dropped connection), all messages published after connection is established will be lost without any notices.

Newly added mode is optional and configurable via DSN.