### PR TITLE
Better Symfony doc nav

### DIFF
--- a/docs/bundle/async_commands.md
+++ b/docs/bundle/async_commands.md
@@ -70,4 +70,4 @@ if ($replyMessage = $promise->receive(5000)) {
 }
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/async_events.md
+++ b/docs/bundle/async_events.md
@@ -174,4 +174,4 @@ services:
 The `eventName` attribute accepts a regexp. You can do next `eventName: '/foo\..*?/'`. 
 It uses this transformer for all event with the name beginning with `foo.`
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/cli_commands.md
+++ b/docs/bundle/cli_commands.md
@@ -166,4 +166,4 @@ Help:
   A worker that consumes message from a broker. To use this broker you have to explicitly set a queue to consume from and a message processor service
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/config_reference.md
+++ b/docs/bundle/config_reference.md
@@ -74,4 +74,4 @@ enqueue:
             reply_extension:      true
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/consumption_extension.md
+++ b/docs/bundle/consumption_extension.md
@@ -41,4 +41,4 @@ services:
             - { name: 'enqueue.consumption.extension', priority: 10 }
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/debugging.md
+++ b/docs/bundle/debugging.md
@@ -78,4 +78,4 @@ You can add `-vvv` to see more information.
  
 ![Consume command verbosity](../images/consume_command_verbosity.png)
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/functional_testing.md
+++ b/docs/bundle/functional_testing.md
@@ -87,4 +87,4 @@ class FooTest extends WebTestCase
 }
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/index.md
+++ b/docs/bundle/index.md
@@ -1,0 +1,16 @@
+# Symfony Bundle
+
+* [Quick tour](quick_tour.md)
+* [Config reference](config_reference.md)
+* [Cli commands](cli_commands.md)
+* [Message producer](message_producer.md)
+* [Message processor](message_processor.md)
+* [Async events](async_events.md)
+* [Async commands](async_commands.md)
+* [Job queue](job_queue.md)
+* [Consumption extension](consumption_extension.md)
+* [Production settings](production_settings.md)
+* [Debugging](debugging.md)
+* [Functional testing](functional_testing.md) 
+
+[back to index](../index.md)

--- a/docs/bundle/job_queue.md
+++ b/docs/bundle/job_queue.md
@@ -297,4 +297,4 @@ class ReindexProcessor implements Processor
 }
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/message_processor.md
+++ b/docs/bundle/message_processor.md
@@ -181,4 +181,4 @@ Now you can run a command and tell it to consume from a given queue and process 
 $ ./bin/console enqueue:transport:consume say_hello foo_queue -vvv 
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/message_producer.md
+++ b/docs/bundle/message_producer.md
@@ -94,4 +94,4 @@ $spoolProducer->sendCommand('a_processor_name', 'Hello there!');
 $spoolProducer->flush();
 ```
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/production_settings.md
+++ b/docs/bundle/production_settings.md
@@ -36,4 +36,4 @@ redirect_stderr=true
 
 _**Note**: Pay attention to `--time-limit` it tells the command to exit after 5 minutes._
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/bundle/quick_tour.md
+++ b/docs/bundle/quick_tour.md
@@ -125,4 +125,4 @@ $ ./bin/console enqueue:consume --setup-broker -vvv
 _**Note**: Add -vvv to find out what is going while you are consuming messages. There is a lot of valuable debug info there._
 
 
-[back to index](../index.md)
+[back to index](index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Enqueue is an MIT-licensed open source project with its ongoing development made
 * [Job queue](#job-queue)
     - [Run unique job](job_queue/run_unique_job.md)
     - [Run sub job(s)](job_queue/run_sub_job.md)
-* [EnqueueBundle (Symfony)](#enqueue-bundle-symfony).  
+* [EnqueueBundle (Symfony)](bundle/index.md)
     - [Quick tour](bundle/quick_tour.md)
     - [Config reference](bundle/config_reference.md)
     - [Cli commands](bundle/cli_commands.md)

--- a/docs/quick_tour.md
+++ b/docs/quick_tour.md
@@ -15,6 +15,7 @@ Enqueue is an MIT-licensed open source project with its ongoing development made
 * [Client](#client)
 * [Cli commands](#cli-commands)
 * [Monitoring](#monitoring)
+* [Symfony bundle](#symfony)
 
 ## Transport
 
@@ -287,3 +288,7 @@ $ app.php consume
 There is a tool that can track sent\consumed messages as well as consumer performance. Read more [here](monitoring.md)
 
 [back to index](index.md)
+
+## Symfony
+
+Read more [here](bundle/quick_tour.md) about using Enqueue as a Symfony Bundle.


### PR DESCRIPTION
Actually there is a lot of documentation for Symfony but it's not easy to navigate through the pages as the links always get you back to the general doc instead of a Symfony homepage