### PR TITLE
Prefer stable dependencies for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
       "ext-mongodb": "1.3",
       "ext-bcmath": "1",
       "ext-mbstring": "1"
-    }
+    },
+    "prefer-stable": true
   }
 }


### PR DESCRIPTION
See https://getcomposer.org/doc/04-schema.md#prefer-stable

This PR causes development & CI to use stable versions of dependencies. Noticed this when `v4.3.0-BETA2` Symfony dependencies were being installed locally.

Should have no real effect on library use, since `prefer-stable` is root-only setting for composer, while preventing possibly broken build from crashing CI for example.