### PR TITLE
Use organization repository for doc hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Features:
 ## Resources
 
 * [Site](https://enqueue.forma-pro.com/)
-* [Quick tour](https://php-enqueue.github.io/enqueue-dev/quick_tour/)
-* [Documentation](https://php-enqueue.github.io/enqueue-dev/)
-* [Blog](https://php-enqueue.github.io/enqueue-dev/#blogs)
+* [Quick tour](https://php-enqueue.github.io/quick_tour/)
+* [Documentation](https://php-enqueue.github.io/)
+* [Blog](https://php-enqueue.github.io/#blogs)
 * [Chat\Questions](https://gitter.im/php-enqueue/Lobby)
 * [Issue Tracker](https://github.com/php-enqueue/enqueue-dev/issues)
 

--- a/bin/subtree-split
+++ b/bin/subtree-split
@@ -44,6 +44,7 @@ function remote()
 }
 
 remote enqueue git@github.com:php-enqueue/enqueue.git
+remote php-enqueue git@github.com:php-enqueue/php-enqueue.git
 remote simple-client git@github.com:php-enqueue/simple-client.git
 remote stomp git@github.com:php-enqueue/stomp.git
 remote amqp-ext git@github.com:php-enqueue/amqp-ext.git
@@ -72,6 +73,7 @@ remote wamp git@github.com:php-enqueue/wamp.git
 remote monitoring git@github.com:php-enqueue/monitoring.git
 
 split 'pkg/enqueue' enqueue
+split 'docs' php-enqueue
 split 'pkg/simple-client' simple-client
 split 'pkg/stomp' stomp
 split 'pkg/amqp-ext' amqp-ext

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 title: enqueue-dev
 description: A Jekyll theme for documentation
-baseurl: "/enqueue-dev" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 permalink: pretty


### PR DESCRIPTION
@makasim This should allow hosting github pages under "organization" without enqueue-dev suffix (https://php-enqueue.github.io/).

I didn't do full lookup if repository split works since I have access to organization, but it should work.