### PR TITLE
Github Pages - Match topic order from index.md

### DIFF
--- a/docs/bundle/async_commands.md
+++ b/docs/bundle/async_commands.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Async commands
+nav_order: 7
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/async_events.md
+++ b/docs/bundle/async_events.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Async events
+nav_order: 6
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/cli_commands.md
+++ b/docs/bundle/cli_commands.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: CLI commands
+nav_order: 3
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/config_reference.md
+++ b/docs/bundle/config_reference.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Config reference
+nav_order: 2
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/consumption_extension.md
+++ b/docs/bundle/consumption_extension.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Consumption extension
+nav_order: 9
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/debugging.md
+++ b/docs/bundle/debugging.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Debugging
+nav_order: 11
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/functional_testing.md
+++ b/docs/bundle/functional_testing.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Functional testing
+nav_order: 12
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/index.md
+++ b/docs/bundle/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Symfony bundle"
-nav_order: 8
+nav_order: 6
 has_children: true
 permalink: /symfony
 ---

--- a/docs/bundle/job_queue.md
+++ b/docs/bundle/job_queue.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Job queue
+nav_order: 8
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/message_processor.md
+++ b/docs/bundle/message_processor.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Message processor
+nav_order: 5
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/message_producer.md
+++ b/docs/bundle/message_producer.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Message producer
+nav_order: 4
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/production_settings.md
+++ b/docs/bundle/production_settings.md
@@ -2,6 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Production settings
+nav_order: 10
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/bundle/quick_tour.md
+++ b/docs/bundle/quick_tour.md
@@ -2,7 +2,7 @@
 layout: default
 parent: "Symfony bundle"
 title: Quick tour
-nav_order: -1
+nav_order: 1
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/client/extensions.md
+++ b/docs/client/extensions.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-nav_exclude: true
+parent: Client
+title: Extensions
+nav_order: 6
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Client
+nav_order: 4
+has_children: true
+permalink: /client
+---
+
+{:toc}

--- a/docs/client/message_bus.md
+++ b/docs/client/message_bus.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-nav_exclude: true
+parent: Client
+title: Message bus
+nav_order: 4
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/client/message_examples.md
+++ b/docs/client/message_examples.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-nav_exclude: true
+parent: Client
+title: Message examples
+nav_order: 2
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/client/quick_tour.md
+++ b/docs/client/quick_tour.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-nav_exclude: true
+parent: Client
+title: Quick tour
+nav_order: 1
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/client/rpc_call.md
+++ b/docs/client/rpc_call.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-nav_exclude: true
+parent: Client
+title: RPC call
+nav_order: 5
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/client/supported_brokers.md
+++ b/docs/client/supported_brokers.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-nav_exclude: true
+parent: Client
+title: Supported brokers
+nav_order: 3
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/consumption/index.md
+++ b/docs/consumption/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Consumption
-nav_order: 2
+nav_order: 3
 has_children: true
 permalink: /consumption
 ---

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Contribution
+nav_order: 99
+---
+
 <h2 align="center">Supporting Enqueue</h2>
 
 Enqueue is an MIT-licensed open source project with its ongoing development made possible entirely by the support of community and our customers. If you'd like to join them, please consider:
@@ -9,8 +15,8 @@ Enqueue is an MIT-licensed open source project with its ongoing development made
 
 # Contribution
 
-To contribute you have to send a pull request to [enqueue-dev](https://github.com/php-enqueue/enqueue-dev) repository. 
-The pull requests to read only subtree split [repositories](https://github.com/php-enqueue/enqueue-dev/blob/master/bin/subtree-split#L46) will be closed. 
+To contribute you have to send a pull request to [enqueue-dev](https://github.com/php-enqueue/enqueue-dev) repository.
+The pull requests to read only subtree split [repositories](https://github.com/php-enqueue/enqueue-dev/blob/master/bin/subtree-split#L46) will be closed.
 
 ## Setup environment
 
@@ -37,10 +43,10 @@ or for a package only:
 ./bin/test.sh pkg/enqueue
 ```
 
-## Commit 
+## Commit
 
 When you try to commit changes `php-cs-fixer` is run. It fixes all coding style issues. Don't forget to stage them and commit everything.
-Once everything is done open a pull request on official repository. 
+Once everything is done open a pull request on official repository.
 
 ## WTF?!
 

--- a/docs/dsn.md
+++ b/docs/dsn.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: DSN
-nav_order: 98
+title: DSN Parser
+nav_order: 92
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/job_queue/index.md
+++ b/docs/job_queue/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Job Queue
-nav_order: 6
+nav_order: 5
 has_children: true
 permalink: /job-queue
 ---

--- a/docs/job_queue/run_sub_job.md
+++ b/docs/job_queue/run_sub_job.md
@@ -2,6 +2,7 @@
 layout: default
 parent: Job Queue
 title: Run sub job
+nav_order: 2
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/job_queue/run_unique_job.md
+++ b/docs/job_queue/run_unique_job.md
@@ -2,6 +2,7 @@
 layout: default
 parent: Job Queue
 title: Run unique job
+nav_order: 1
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/laravel/index.md
+++ b/docs/laravel/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Laravel
+has_children: true
+nav_order: 6
+permalink: /laravel
+---
+
+{:toc}

--- a/docs/laravel/queues.md
+++ b/docs/laravel/queues.md
@@ -2,6 +2,7 @@
 layout: default
 parent: Laravel
 title: Queues
+nav_order: 2
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/laravel/quick_tour.md
+++ b/docs/laravel/quick_tour.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Laravel
-has_children: true
-nav_order: 4
+parent: Laravel
+title: Quick tour
+nav_order: 1
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/magento/cli_commands.md
+++ b/docs/magento/cli_commands.md
@@ -2,6 +2,7 @@
 layout: default
 parent: Magento
 title: CLI commands
+nav_order: 2
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/magento/index.md
+++ b/docs/magento/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Magento
+has_children: true
+nav_order: 7
+permalink: /magento
+---
+
+{:toc}

--- a/docs/magento/quick_tour.md
+++ b/docs/magento/quick_tour.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-has_children: true
-title: Magento
-nav_order: 4
+parent: Magento
+title: Quick tour
+nav_order: 1
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/magento2/cli_commands.md
+++ b/docs/magento2/cli_commands.md
@@ -2,6 +2,7 @@
 layout: default
 parent: Magento 2
 title: CLI commands
+nav_order: 2
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/magento2/index.md
+++ b/docs/magento2/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Magento 2
+has_children: true
+nav_order: 8
+permalink: /magento2
+---
+
+{:toc}

--- a/docs/magento2/quick_tour.md
+++ b/docs/magento2/quick_tour.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Magento 2
-has_children: true
-nav_order: 4
+parent: Magento 2
+title: Quick tour
+nav_order: 1
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Messages
-nav_exclude: true
+nav_order: 90
 ---
 <h2 align="center">Supporting Enqueue</h2>
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Monitoring
+nav_order: 95
+---
+
 <h2 align="center">Supporting Enqueue</h2>
 
 Enqueue is an MIT-licensed open source project with its ongoing development made possible entirely by the support of community and our customers. If you'd like to join them, please consider:

--- a/docs/yii/amqp_driver.md
+++ b/docs/yii/amqp_driver.md
@@ -1,3 +1,9 @@
+---
+layout: default
+parent: Yii
+title: AMQP Interop driver
+nav_order: 1
+---
 <h2 align="center">Supporting Enqueue</h2>
 
 Enqueue is an MIT-licensed open source project with its ongoing development made possible entirely by the support of community and our customers. If you'd like to join them, please consider:
@@ -18,12 +24,12 @@ In order for it to work you should add any [amqp interop](https://github.com/que
 
 Advantages:
 
-* It would work with any amqp interop compatible transports, such as 
+* It would work with any amqp interop compatible transports, such as
 
     * [enqueue/amqp-ext](https://github.com/php-enqueue/amqp-ext) based on [PHP amqp extension](https://github.com/pdezwart/php-amqp)
     * [enqueue/amqp-lib](https://github.com/php-enqueue/amqp-lib) based on [php-amqplib/php-amqplib](https://github.com/php-amqplib/php-amqplib)
     * [enqueue/amqp-bunny](https://github.com/php-enqueue/amqp-bunny) based on [bunny](https://github.com/jakubkulhan/bunny)
-    
+
 * Supports priorities
 * Supports delays
 * Supports ttr
@@ -47,10 +53,10 @@ return [
             'password' => 'guest',
             'queueName' => 'queue',
             'driver' => yii\queue\amqp_interop\Queue::ENQUEUE_AMQP_LIB,
-            
+
             // or
             'dsn' => 'amqp://guest:guest@localhost:5672/%2F',
-            
+
             // or, same as above
             'dsn' => 'amqp:',
         ],

--- a/docs/yii/index.md
+++ b/docs/yii/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Yii
+has_children: true
+nav_order: 9
+permalink: /yii
+---
+
+{:toc}


### PR DESCRIPTION
Recreate most of the navigation structure using the same labels & order as the one present in index.md file.