### PR TITLE
Allow sending & reading headers via Kafka Message object.

### DIFF
--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -142,8 +142,8 @@ class RdKafkaConsumer implements Consumer
     }
 
     /**
-     * @param Message $message
-     * @param bool    $requeue
+     * @param RdKafkaMessage $message
+     * @param bool           $requeue
      */
     public function reject(Message $message, bool $requeue = false): void
     {

--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -82,6 +82,7 @@ class RdKafkaConsumer implements Consumer
 
     /**
      * @param int $timeout
+     *
      * @return RdKafkaMessage
      */
     public function receive(int $timeout = 0): ?Message

--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -142,7 +142,7 @@ class RdKafkaConsumer implements Consumer
 
     /**
      * @param Message $message
-     * @param bool $requeue
+     * @param bool    $requeue
      */
     public function reject(Message $message, bool $requeue = false): void
     {

--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -56,6 +56,19 @@ class RdKafkaContext implements Context
         $this->setSerializer(new JsonSerializer());
     }
 
+    public static function getLibrdKafkaVersion(): string
+    {
+        if (!defined('RD_KAFKA_VERSION')) {
+            throw new \RuntimeException('RD_KAFKA_VERSION constant is not defined. Phprdkafka is probably not installed');
+        }
+
+        $major = (RD_KAFKA_VERSION & 0xFF000000) >> 24;
+        $minor = (RD_KAFKA_VERSION & 0x00FF0000) >> 16;
+        $patch = (RD_KAFKA_VERSION & 0x0000FF00) >> 8;
+
+        return "$major.$minor.$patch";
+    }
+
     /**
      * @return RdKafkaMessage
      */

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -43,6 +43,7 @@ class RdKafkaProducer implements Producer
 
         $topic = $this->producer->newTopic($destination->getTopicName(), $destination->getConf());
         // Note: Topic::producev method exists in phprdkafka >= 3.1.0
+        // Headers in payload are maintained for backwards compatibility with apps that might run on lower phprdkafka version
         if (method_exists($topic, 'producev')) {
             $topic->producev($partition, 0 /* must be 0 */, $payload, $key, $message->getHeaders());
         } else {

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -46,7 +46,7 @@ class RdKafkaProducer implements Producer
         // Headers in payload are maintained for backwards compatibility with apps that might run on lower phprdkafka version
         if (method_exists($topic, 'producev')) {
 
-            // Phprdkafka < 3.1.0 will fail calling `producev` on librdkafka 1.0.0 causing segfault
+            // Phprdkafka <= 3.1.0 will fail calling `producev` on librdkafka 1.0.0 causing segfault
             if (version_compare($this->getLibrdKafkaVersion(), '1.0.0', '>=')
                 && version_compare(phpversion('rdkafka'), '3.1.0', '<=')) {
                 trigger_error('Phprdkafka < 3.1.0 is incompatible with librdkafka 1.0.0 when calling `producev`', E_USER_WARNING);

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -42,7 +42,12 @@ class RdKafkaProducer implements Producer
         $key = $message->getKey() ?: $destination->getKey() ?: null;
 
         $topic = $this->producer->newTopic($destination->getTopicName(), $destination->getConf());
-        $topic->produce($partition, 0 /* must be 0 */, $payload, $key);
+        // Note: Topic::producev method exists in phprdkafka >= 3.1.0
+        if (method_exists($topic, 'producev')) {
+            $topic->producev($partition, 0 /* must be 0 */, $payload, $key, $message->getHeaders());
+        } else {
+            $topic->produce($partition, 0 /* must be 0 */, $payload, $key);
+        }
     }
 
     /**

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -46,7 +46,7 @@ class RdKafkaProducer implements Producer
         // Headers in payload are maintained for backwards compatibility with apps that might run on lower phprdkafka version
         if (method_exists($topic, 'producev')) {
             // Phprdkafka <= 3.1.0 will fail calling `producev` on librdkafka 1.0.0 causing segfault
-            if (version_compare($this->getLibrdKafkaVersion(), '1.0.0', '>=')
+            if (version_compare(RdKafkaContext::getLibrdKafkaVersion(), '1.0.0', '>=')
                 && version_compare(phpversion('rdkafka'), '3.1.0', '<=')) {
                 trigger_error('Phprdkafka < 3.1.0 is incompatible with librdkafka 1.0.0 when calling `producev`', E_USER_WARNING);
             }
@@ -102,18 +102,5 @@ class RdKafkaProducer implements Producer
     public function getTimeToLive(): ?int
     {
         return null;
-    }
-
-    private function getLibrdKafkaVersion(): string
-    {
-        if (!defined('RD_KAFKA_VERSION')) {
-            throw new \RuntimeException('RD_KAFKA_VERSION constant is not defined. Phprdkafka is probably not installed');
-        }
-
-        $major = (RD_KAFKA_VERSION & 0xFF000000) >> 24;
-        $minor = (RD_KAFKA_VERSION & 0x00FF0000) >> 16;
-        $patch = (RD_KAFKA_VERSION & 0x0000FF00) >> 8;
-
-        return "$major.$minor.$patch";
     }
 }

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -45,7 +45,6 @@ class RdKafkaProducer implements Producer
         // Note: Topic::producev method exists in phprdkafka > 3.1.0
         // Headers in payload are maintained for backwards compatibility with apps that might run on lower phprdkafka version
         if (method_exists($topic, 'producev')) {
-
             // Phprdkafka <= 3.1.0 will fail calling `producev` on librdkafka 1.0.0 causing segfault
             if (version_compare($this->getLibrdKafkaVersion(), '1.0.0', '>=')
                 && version_compare(phpversion('rdkafka'), '3.1.0', '<=')) {
@@ -107,7 +106,7 @@ class RdKafkaProducer implements Producer
 
     private function getLibrdKafkaVersion(): string
     {
-        if (! defined('RD_KAFKA_VERSION')) {
+        if (!defined('RD_KAFKA_VERSION')) {
             throw new \RuntimeException('RD_KAFKA_VERSION constant is not defined. Phprdkafka is probably not installed');
         }
 


### PR DESCRIPTION
Note that `Topic::producev` & `KafkaMessage::headers` exist since
phprdkafka >= 3.1.0.

Resolves #843 

Due to the fact that `php-enqueue/kafka` might be used with different versions of phprdkafka, I opted to maintain serializing of headers into the message.