### PR TITLE
Add composer runnable scripts for PHPStan & PHP-CS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
   "type": "project",
   "minimum-stability": "beta",
   "homepage": "https://enqueue.forma-pro.com/",
+  "scripts": {
+    "cs-fix": "bin/php-cs-fixer fix --config=.php_cs.php",
+    "cs-lint": "bin/php-cs-fixer fix --config=.php_cs.php --no-interaction --dry-run --diff",
+    "phpstan": "bin/phpstan analyse --memory-limit=512M -c phpstan.neon"
+  },
   "require": {
     "php": "^7.1.3",
 

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -21,6 +21,12 @@ composer install
 
 Once you did it you can work on a feature or bug fix.
 
+If you need, you can also use composer scripts to run code linting and static analysis:
+* For code style linting, run `composer run cs-lint`. Optionally add file names: 
+`composer run cs-lint pkg/null/NullTopic.php` for example.
+* You can also fix your code style with `composer run cs-fix`.
+* Static code analysis can be run using `composer run phpstan`. As above, you can pass specific files.
+
 ## Testing
 
 To run tests


### PR DESCRIPTION
This allows for forks in composer requiring whole package (enqueue) to
work properly.

Also add code style commands as composer scripts for ease of use.

This allows calling for example `composer run cs-fix some-file.php`.