### PR TITLE
Fix PHPStan error from Symfony 4.3 Event Dispatcher

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -131,7 +131,7 @@ function runPhpstan()
     $returnCode = null;
 
     exec(sprintf(
-        'docker run --workdir="/mqdev" -v "`pwd`:/mqdev" --rm enqueue/dev:latest php -d memory_limit=1024M bin/phpstan analyse -l 1 -c phpstan.neon %s',
+        'docker run --workdir="/mqdev" -v "`pwd`:/mqdev" --rm enqueue/dev:latest php -d memory_limit=1024M bin/phpstan analyse -c phpstan.neon %s',
         implode(' ', getFilesToFix())
     ), $output, $returnCode);
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,16 +1,19 @@
 parameters:
-	excludes_analyse:
-		- docs
-		- bin
-		- docker
-		- var
-		- pkg/amqp-lib/tutorial
-		- pkg/enqueue-bundle/Tests/Functional/App/AsyncListener.php
-		- pkg/enqueue/Util/UUID.php
-		- pkg/job-queue/Test/JobRunner.php
-		- pkg/job-queue/Tests/Functional/app/AppKernel.php
-		- pkg/rdkafka/RdKafkaConsumer.php
-		- pkg/async-event-dispatcher/DependencyInjection/Configuration.php
-		- pkg/enqueue-bundle/DependencyInjection/Configuration.php
-		- pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
-		- pkg/simple-client/SimpleClient.php
+    level: 1
+    paths:
+        - pkg
+    excludes_analyse:
+        - docs
+        - bin
+        - docker
+        - var
+        - pkg/amqp-lib/tutorial
+        - pkg/enqueue-bundle/Tests/Functional/App/AsyncListener.php
+        - pkg/enqueue/Util/UUID.php
+        - pkg/job-queue/Test/JobRunner.php
+        - pkg/job-queue/Tests/Functional/app/AppKernel.php
+        - pkg/rdkafka/RdKafkaConsumer.php
+        - pkg/async-event-dispatcher/DependencyInjection/Configuration.php
+        - pkg/enqueue-bundle/DependencyInjection/Configuration.php
+        - pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+        - pkg/simple-client/SimpleClient.php

--- a/pkg/async-event-dispatcher/AsyncEventDispatcher.php
+++ b/pkg/async-event-dispatcher/AsyncEventDispatcher.php
@@ -24,6 +24,10 @@ class AsyncEventDispatcher extends EventDispatcher
      */
     public function __construct(EventDispatcherInterface $trueEventDispatcher, AsyncListener $asyncListener)
     {
+        if (method_exists(parent::class, '__construct')) {
+            parent::__construct();
+        }
+
         $this->trueEventDispatcher = $trueEventDispatcher;
         $this->asyncListener = $asyncListener;
     }


### PR DESCRIPTION
Also moves PHPStan level declaration from command line to configuration file.

Note that `EventDispatcher`'s constructor is basically a no-op, unless instantiated class is actually an instance of `EventDispatcher` itself, so we might be better off silencing this PhpStan error instead?