### PR TITLE
deserialize sqs message attributes

### DIFF
--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -188,6 +188,10 @@ class SqsConsumer implements Consumer
         $message->setBody($sqsMessage['Body']);
         $message->setReceiptHandle($sqsMessage['ReceiptHandle']);
 
+        if (isset($sqsMessage['Attributes'])) {
+            $message->setAttributes($sqsMessage['Attributes']);
+        }
+
         if (isset($sqsMessage['Attributes']['ApproximateReceiveCount'])) {
             $message->setRedelivered(((int) $sqsMessage['Attributes']['ApproximateReceiveCount']) > 1);
         }

--- a/pkg/sqs/SqsMessage.php
+++ b/pkg/sqs/SqsMessage.php
@@ -24,6 +24,11 @@ class SqsMessage implements Message
     private $headers;
 
     /**
+     * @var array
+     */
+    private $attributes;
+
+    /**
      * @var bool
      */
     private $redelivered;
@@ -58,6 +63,7 @@ class SqsMessage implements Message
         $this->body = $body;
         $this->properties = $properties;
         $this->headers = $headers;
+        $this->attributes = [];
         $this->redelivered = false;
         $this->delaySeconds = 0;
         $this->requeueVisibilityTimeout = 0;
@@ -111,6 +117,21 @@ class SqsMessage implements Message
     public function getHeader(string $name, $default = null)
     {
         return array_key_exists($name, $this->headers) ? $this->headers[$name] : $default;
+    }
+
+    public function setAttributes(array $attributes): void
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function getAttribute(string $name, $default = null)
+    {
+        return array_key_exists($name, $this->attributes) ? $this->attributes[$name] : $default;
     }
 
     public function isRedelivered(): bool

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -294,7 +294,10 @@ class SqsConsumerTest extends TestCase
             'Body' => 'The Body',
             'ReceiptHandle' => 'The Receipt',
             'Attributes' => [
-                'ApproximateReceiveCount' => 3,
+                'SenderId' => 'AROAX5IAWYILCTYIS3OZ5:foo@bar.com',
+                'ApproximateFirstReceiveTimestamp' => '1560512269481',
+                'ApproximateReceiveCount' => '3',
+                'SentTimestamp' => '1560512260079',
             ],
             'MessageAttributes' => [
                 'Headers' => [
@@ -336,6 +339,12 @@ class SqsConsumerTest extends TestCase
         $this->assertEquals('The Body', $result->getBody());
         $this->assertEquals(['hkey' => 'hvalue'], $result->getHeaders());
         $this->assertEquals(['key' => 'value'], $result->getProperties());
+        $this->assertEquals([
+            'SenderId' => 'AROAX5IAWYILCTYIS3OZ5:foo@bar.com',
+            'ApproximateFirstReceiveTimestamp' => '1560512269481',
+            'ApproximateReceiveCount' => '3',
+            'SentTimestamp' => '1560512260079',
+        ], $result->getAttributes());
         $this->assertTrue($result->isRedelivered());
         $this->assertEquals('The Receipt', $result->getReceiptHandle());
     }

--- a/pkg/sqs/Tests/SqsMessageTest.php
+++ b/pkg/sqs/Tests/SqsMessageTest.php
@@ -16,6 +16,7 @@ class SqsMessageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('', $message->getBody());
         $this->assertSame([], $message->getProperties());
         $this->assertSame([], $message->getHeaders());
+        $this->assertSame([], $message->getAttributes());
     }
 
     public function testCouldBeConstructedWithOptionalArguments()
@@ -89,5 +90,19 @@ class SqsMessageTest extends \PHPUnit\Framework\TestCase
         $message->setReceiptHandle('theId');
 
         $this->assertSame('theId', $message->getReceiptHandle());
+    }
+
+    public function testShouldAllowSettingAndGettingAttributes()
+    {
+        $message = new SqsMessage();
+        $message->setAttributes($attributes = [
+            'SenderId' => 'AROAX5IAWYILCTYIS3OZ5:foo@bar.com',
+            'ApproximateFirstReceiveTimestamp' => '1560512269481',
+            'ApproximateReceiveCount' => '2',
+            'SentTimestamp' => '1560512260079',
+        ]);
+
+        $this->assertSame($attributes, $message->getAttributes());
+        $this->assertSame($attributes['SenderId'], $message->getAttribute('SenderId'));
     }
 }


### PR DESCRIPTION
Allow deserializing all messages attributes, which we can use for logging and debugging.