### PR TITLE
[SNS] Fix: Missing throw issue

### DIFF
--- a/pkg/sns/SnsProducer.php
+++ b/pkg/sns/SnsProducer.php
@@ -87,6 +87,8 @@ class SnsProducer implements Producer
     }
 
     /**
+     * @throws DeliveryDelayNotSupportedException
+     *
      * @return SnsProducer
      */
     public function setDeliveryDelay(int $deliveryDelay = null): Producer
@@ -95,7 +97,7 @@ class SnsProducer implements Producer
             return $this;
         }
 
-        DeliveryDelayNotSupportedException::providerDoestNotSupportIt();
+        throw DeliveryDelayNotSupportedException::providerDoestNotSupportIt();
     }
 
     public function getDeliveryDelay(): ?int
@@ -104,6 +106,8 @@ class SnsProducer implements Producer
     }
 
     /**
+     * @throws PriorityNotSupportedException
+     *
      * @return SnsProducer
      */
     public function setPriority(int $priority = null): Producer
@@ -121,6 +125,8 @@ class SnsProducer implements Producer
     }
 
     /**
+     * @throws TimeToLiveNotSupportedException
+     *
      * @return SnsProducer
      */
     public function setTimeToLive(int $timeToLive = null): Producer

--- a/pkg/sns/Tests/SnsProducerTest.php
+++ b/pkg/sns/Tests/SnsProducerTest.php
@@ -10,8 +10,11 @@ use Enqueue\Sns\SnsMessage;
 use Enqueue\Sns\SnsProducer;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Destination;
+use Interop\Queue\Exception\DeliveryDelayNotSupportedException;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Interop\Queue\Exception\InvalidMessageException;
+use Interop\Queue\Exception\PriorityNotSupportedException;
+use Interop\Queue\Exception\TimeToLiveNotSupportedException;
 use Interop\Queue\Producer;
 use PHPUnit\Framework\TestCase;
 
@@ -82,6 +85,48 @@ class SnsProducerTest extends TestCase
 
         $producer = new SnsProducer($context);
         $producer->send($destination, $message);
+    }
+
+    public function testShouldThrowIfsetTimeToLiveIsNotNull()
+    {
+        $this->expectException(TimeToLiveNotSupportedException::class);
+
+        $producer = new SnsProducer($this->createSnsContextMock());
+        $result = $producer->setTimeToLive();
+
+        $this->assertInstanceOf(SnsProducer::class, $result);
+
+        $this->expectExceptionMessage('The provider does not support time to live feature');
+
+        $producer->setTimeToLive(200);
+    }
+
+    public function testShouldThrowIfsetPriorityIsNotNull()
+    {
+        $this->expectException(PriorityNotSupportedException::class);
+
+        $producer = new SnsProducer($this->createSnsContextMock());
+        $result = $producer->setPriority();
+
+        $this->assertInstanceOf(SnsProducer::class, $result);
+
+        $this->expectExceptionMessage('The provider does not support priority feature');
+
+        $producer->setPriority(200);
+    }
+
+    public function testShouldThrowIfsetDeliveryDelayIsNotNull()
+    {
+        $this->expectException(DeliveryDelayNotSupportedException::class);
+
+        $producer = new SnsProducer($this->createSnsContextMock());
+        $result = $producer->setDeliveryDelay();
+
+        $this->assertInstanceOf(SnsProducer::class, $result);
+
+        $this->expectExceptionMessage('The provider does not support delivery delay feature');
+
+        $producer->setDeliveryDelay(200);
     }
 
     public function testShouldPublish()


### PR DESCRIPTION
I found out that SNS producer is not throwing an exception which causes another issue - method response is not `Producer`. 

I fixed this and covered with tests. 

PS:
Probably, this was done to make it work with #909 but it's not. Now both of the functionalities should work as they should.