### PR TITLE
[SNSQS] Fix issue with delay

### DIFF
--- a/pkg/snsqs/SnsQsProducer.php
+++ b/pkg/snsqs/SnsQsProducer.php
@@ -77,17 +77,28 @@ class SnsQsProducer implements Producer
         }
     }
 
+    /**
+     * Delivery delay is supported by SQSProducer.
+     *
+     * @param int|null $deliveryDelay
+     *
+     * @return Producer
+     */
     public function setDeliveryDelay(int $deliveryDelay = null): Producer
     {
-        $this->getSnsProducer()->setDeliveryDelay($deliveryDelay);
         $this->getSqsProducer()->setDeliveryDelay($deliveryDelay);
 
         return $this;
     }
 
+    /**
+     * Delivery delay is supported by SQSProducer.
+     *
+     * @return int|null
+     */
     public function getDeliveryDelay(): ?int
     {
-        return $this->getSnsProducer()->getDeliveryDelay();
+        return $this->getSqsProducer()->getDeliveryDelay();
     }
 
     public function setPriority(int $priority = null): Producer

--- a/pkg/snsqs/Tests/SnsQsProducerTest.php
+++ b/pkg/snsqs/Tests/SnsQsProducerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Enqueue\SnsQs\Tests;
+
+use Enqueue\Sns\SnsContext;
+use Enqueue\Sns\SnsProducer;
+use Enqueue\SnsQs\SnsQsMessage;
+use Enqueue\SnsQs\SnsQsProducer;
+use Enqueue\SnsQs\SnsQsQueue;
+use Enqueue\SnsQs\SnsQsTopic;
+use Enqueue\Sqs\SqsContext;
+use Enqueue\Sqs\SqsProducer;
+use Enqueue\Test\ClassExtensionTrait;
+use Interop\Queue\Destination;
+use Interop\Queue\Exception\InvalidDestinationException;
+use Interop\Queue\Exception\InvalidMessageException;
+use Interop\Queue\Message;
+use Interop\Queue\Producer;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+class SnsQsProducerTest extends TestCase
+{
+    use ClassExtensionTrait;
+
+    public function testShouldImplementProducerInterface()
+    {
+        $this->assertClassImplements(Producer::class, SnsQsProducer::class);
+    }
+
+    public function testCouldBeConstructedWithRequiredArguments()
+    {
+        new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
+    }
+
+    public function testShouldThrowIfMessageIsInvalidType()
+    {
+        $this->expectException(InvalidMessageException::class);
+        $this->expectExceptionMessage('The message must be an instance of Enqueue\SnsQs\SnsQsMessage but it is Double\Message\P1');
+
+        $producer = new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
+
+        $message = $this->prophesize(Message::class)->reveal();
+
+        $producer->send(new SnsQsTopic(''), $message);
+    }
+
+    public function testShouldThrowIfDestinationOfInvalidType()
+    {
+        $this->expectException(InvalidDestinationException::class);
+
+        $producer = new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
+
+        $destination = $this->prophesize(Destination::class)->reveal();
+
+        $producer->send($destination, new SnsQsMessage());
+    }
+
+    public function testShouldSetDeliveryDelayToSQSProducer()
+    {
+        $delay = 10;
+
+        $sqsProducerStub = $this->prophesize(SqsProducer::class);
+        $sqsProducerStub->setDeliveryDelay(Argument::is($delay))->shouldBeCalledTimes(1);
+
+        $sqsMock = $this->createSqsContextMock();
+        $sqsMock->method('createProducer')->willReturn($sqsProducerStub->reveal());
+
+        $producer = new SnsQsProducer($this->createSnsContextMock(), $sqsMock);
+
+        $producer->setDeliveryDelay($delay);
+    }
+
+    public function testShouldGetDeliveryDelayFromSQSProducer()
+    {
+        $delay = 10;
+
+        $sqsProducerStub = $this->prophesize(SqsProducer::class);
+        $sqsProducerStub->getDeliveryDelay()->willReturn($delay);
+
+        $sqsMock = $this->createSqsContextMock();
+        $sqsMock->method('createProducer')->willReturn($sqsProducerStub->reveal());
+
+        $producer = new SnsQsProducer($this->createSnsContextMock(), $sqsMock);
+
+        $this->assertEquals($delay, $producer->getDeliveryDelay());
+    }
+
+    public function testShouldSendSnsTopicMessageToSnsProducer()
+    {
+        $snsMock = $this->createSnsContextMock();
+        $destination = new SnsQsTopic('');
+
+        $snsProducerStub = $this->prophesize(SnsProducer::class);
+        $snsProducerStub->send($destination, Argument::any())->shouldBeCalledOnce();
+
+        $snsMock->method('createProducer')->willReturn($snsProducerStub->reveal());
+
+        $producer = new SnsQsProducer($snsMock, $this->createSqsContextMock());
+        $producer->send($destination, new SnsQsMessage());
+    }
+
+    public function testShouldSendSqsMessageToSqsProducer()
+    {
+        $sqsMock = $this->createSqsContextMock();
+        $destination = new SnsQsQueue('');
+
+        $snsProducerStub = $this->prophesize(SqsProducer::class);
+        $snsProducerStub->send($destination, Argument::any())->shouldBeCalledOnce();
+
+        $sqsMock->method('createProducer')->willReturn($snsProducerStub->reveal());
+
+        $producer = new SnsQsProducer($this->createSnsContextMock(), $sqsMock);
+        $producer->send($destination, new SnsQsMessage());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|SnsContext
+     */
+    private function createSnsContextMock(): SnsContext
+    {
+        return $this->createMock(SnsContext::class);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|SqsContext
+     */
+    private function createSqsContextMock(): SqsContext
+    {
+        return $this->createMock(SqsContext::class);
+    }
+}


### PR DESCRIPTION
I'm trying to use SNSQS in my infrastructure with Symfony Client. 

I found out that `\Enqueue\Client\Driver\GenericDriver` calls `setDeliveryDelay` in method `sendToProcessor` when the message is delayed. 
SNSQS should support that as the `commands` sent from the Client should support it (it's going through SQS). 

I fixed the bug and test the producer. 