### PR TITLE
DBAL Change ParameterType class to Type class

### DIFF
--- a/pkg/dbal/DbalConsumerHelperTrait.php
+++ b/pkg/dbal/DbalConsumerHelperTrait.php
@@ -6,7 +6,6 @@ namespace Enqueue\Dbal;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\RetryableException;
-use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 use Ramsey\Uuid\Uuid;
 
@@ -40,7 +39,7 @@ trait DbalConsumerHelperTrait
             ->addOrderBy('priority', 'asc')
             ->addOrderBy('published_at', 'asc')
             ->setParameter('queues', $queues, Connection::PARAM_STR_ARRAY)
-            ->setParameter('delayedUntil', $now, ParameterType::INTEGER)
+            ->setParameter('delayedUntil', $now, Type::INTEGER)
             ->setMaxResults(1);
 
         $update = $this->getConnection()->createQueryBuilder()


### PR DESCRIPTION
Doctrine DBAL version 2.6 does not have ParameterType class.
and the library supports version 2.6 of Doctrine DBAL.

Hope it will be merge soon.
Thanks.