### PR TITLE
[DoctrineClearIdentityMapExtension] allow instances of ManagerRegistry

### DIFF
--- a/pkg/enqueue-bundle/Consumption/Extension/DoctrineClearIdentityMapExtension.php
+++ b/pkg/enqueue-bundle/Consumption/Extension/DoctrineClearIdentityMapExtension.php
@@ -2,21 +2,21 @@
 
 namespace Enqueue\Bundle\Consumption\Extension;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Enqueue\Consumption\Context\MessageReceived;
 use Enqueue\Consumption\MessageReceivedExtensionInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class DoctrineClearIdentityMapExtension implements MessageReceivedExtensionInterface
 {
     /**
-     * @var RegistryInterface
+     * @var ManagerRegistry
      */
     protected $registry;
 
     /**
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         $this->registry = $registry;
     }

--- a/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/DoctrineClearIdentityMapExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/DoctrineClearIdentityMapExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\Tests\Unit\Consumption\Extension;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use Enqueue\Bundle\Consumption\Extension\DoctrineClearIdentityMapExtension;
 use Enqueue\Consumption\Context\MessageReceived;
@@ -11,7 +12,6 @@ use Interop\Queue\Message;
 use Interop\Queue\Processor;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class DoctrineClearIdentityMapExtensionTest extends TestCase
 {
@@ -59,11 +59,11 @@ class DoctrineClearIdentityMapExtensionTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|ManagerRegistry
      */
-    protected function createRegistryMock(): RegistryInterface
+    protected function createRegistryMock(): ManagerRegistry
     {
-        return $this->createMock(RegistryInterface::class);
+        return $this->createMock(ManagerRegistry::class);
     }
 
     /**


### PR DESCRIPTION
We only use the method `getManagers()` which comes from this interface, and not the RegistryInterface from Sf's doctrine bridge. So it makes sense to allow passing implementations of parent interfaces.

This will also allow us to use this class with Doctrine ODM.