### PR TITLE
Change FS Driver to be FIFO per Issues #170 & #171

### DIFF
--- a/pkg/fs/FsConsumer.php
+++ b/pkg/fs/FsConsumer.php
@@ -204,7 +204,9 @@ class FsConsumer implements Consumer
             if (substr_count($frame, $needle) > 1) {
                 $pos = strpos($frame, $needle);
                 $pos = strpos($frame, $needle, $pos + 1);
-                return rtrim(substr($frame, 0, $pos));
+                $frame = rtrim(substr($frame, 0, $pos));
+
+                return $frame;
             }
         }
 

--- a/pkg/fs/FsConsumer.php
+++ b/pkg/fs/FsConsumer.php
@@ -208,7 +208,7 @@ class FsConsumer implements Consumer
             }
         }
 
-        if (substr_count($frame, $needle) == 1) {
+        if (1 == substr_count($frame, $needle)) {
             return $frame;
         }
 


### PR DESCRIPTION
By definition, a Queue is FIFO, otherwise it's a Stack. Though FS shouldn't be used in prod, I personally use it for testing and it's helpful to be able to see the queue when debugging. If a message needs requeued, recursive behavior occurs where the requeued message is immediately re-consumed. This fix will recursive requeuing by reading from the front of the file while writing to the end.