### PR TITLE
fix error in mysql 5.5 and 5.6

### DIFF
--- a/pkg/job-queue/Doctrine/mapping/JobUnique.orm.xml
+++ b/pkg/job-queue/Doctrine/mapping/JobUnique.orm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Enqueue\JobQueue\Doctrine\Entity\JobUnique" table="enqueue_job_unique">
-        <id name="name" type="string" length="255">
+        <id name="name" type="string" length="128">
             <generator strategy="NONE" />
         </id>
     </entity>


### PR DESCRIPTION
SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes