### PR TITLE
Kafka singleton consumer

### DIFF
--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -133,6 +133,7 @@ class RdKafkaContext implements Context
     {
         $kafkaConsumers = $this->kafkaConsumers;
         $this->kafkaConsumers = [];
+        $this->rdKafkaConsumers = [];
 
         foreach ($kafkaConsumers as $kafkaConsumer) {
             $kafkaConsumer->unsubscribe();

--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -57,6 +57,7 @@ class RdKafkaContext implements Context
     {
         $this->config = $config;
         $this->kafkaConsumers = [];
+        $this->rdKafkaConsumers = [];
 
         $this->setSerializer(new JsonSerializer());
     }

--- a/pkg/rdkafka/Tests/RdKafkaContextTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaContextTest.php
@@ -69,4 +69,27 @@ class RdKafkaContextTest extends TestCase
 
         $this->assertSame($context->getSerializer(), $producer->getSerializer());
     }
+
+    public function testShouldNotCreateConsumerTwice()
+    {
+        $context = new RdKafkaContext([]);
+        $queue = $context->createQueue('aQueue');
+
+        $consumer = $context->createConsumer($queue);
+        $consumer2 = $context->createConsumer($queue);
+
+        $this->assertSame($consumer, $consumer2);
+    }
+
+    public function testShouldCreateTwoConsumers()
+    {
+        $context = new RdKafkaContext([]);
+        $queueA = $context->createQueue('aQueue');
+        $queueB = $context->createQueue('aQueue');
+
+        $consumer = $context->createConsumer($queueA);
+        $consumer2 = $context->createConsumer($queueB);
+
+        $this->assertNotSame($consumer, $consumer2);
+    }
 }

--- a/pkg/rdkafka/Tests/RdKafkaContextTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaContextTest.php
@@ -72,7 +72,9 @@ class RdKafkaContextTest extends TestCase
 
     public function testShouldNotCreateConsumerTwice()
     {
-        $context = new RdKafkaContext([]);
+        $context = new RdKafkaContext(['global' => [
+            'group.id' => uniqid('', true),
+        ]]);
         $queue = $context->createQueue('aQueue');
 
         $consumer = $context->createConsumer($queue);
@@ -83,9 +85,11 @@ class RdKafkaContextTest extends TestCase
 
     public function testShouldCreateTwoConsumers()
     {
-        $context = new RdKafkaContext([]);
+        $context = new RdKafkaContext(['global' => [
+            'group.id' => uniqid('', true),
+        ]]);
         $queueA = $context->createQueue('aQueue');
-        $queueB = $context->createQueue('aQueue');
+        $queueB = $context->createQueue('bQueue');
 
         $consumer = $context->createConsumer($queueA);
         $consumer2 = $context->createConsumer($queueB);


### PR DESCRIPTION
Hi, introduce a `rdKafkaConsumers` collection to avoid the creation of multiple consumers for the same queue. This PR solve the issue #894 and #893  (I've tried the solution on this [project](https://github.com/marcoreni/enqueue-kafka-894-repro) and it works)   