### PR TITLE
Add header support for kafka

### DIFF
--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -138,6 +138,17 @@ class RdKafkaContext implements Context
         throw PurgeQueueNotSupportedException::providerDoestNotSupportIt();
     }
 
+    public static function getLibrdKafkaVersion(): string
+    {
+        if (!defined('RD_KAFKA_VERSION')) {
+            throw new \RuntimeException('RD_KAFKA_VERSION constant is not defined. Phprdkafka is probably not installed');
+        }
+        $major = (RD_KAFKA_VERSION & 0xFF000000) >> 24;
+        $minor = (RD_KAFKA_VERSION & 0x00FF0000) >> 16;
+        $patch = (RD_KAFKA_VERSION & 0x0000FF00) >> 8;
+        return "$major.$minor.$patch";
+    }
+
     private function getProducer(): VendorProducer
     {
         if (null === $this->producer) {

--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -146,6 +146,7 @@ class RdKafkaContext implements Context
         $major = (RD_KAFKA_VERSION & 0xFF000000) >> 24;
         $minor = (RD_KAFKA_VERSION & 0x00FF0000) >> 16;
         $patch = (RD_KAFKA_VERSION & 0x0000FF00) >> 8;
+
         return "$major.$minor.$patch";
     }
 

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -50,12 +50,13 @@ class RdKafkaProducer implements Producer
             if (version_compare(RdKafkaContext::getLibrdKafkaVersion(), '1.0.0', '>=')
                 && version_compare(phpversion('rdkafka'), '3.1.0', '<=')) {
                 trigger_error(
-                    'Phprdkafka <= 3.1.0 is incompatible with librdkafka 1.0.0 when calling `producev`. ' .
+                    'Phprdkafka <= 3.1.0 is incompatible with librdkafka 1.0.0 when calling `producev`. '.
                     'Falling back to `produce` (without message headers) instead.',
                     E_USER_WARNING
                 );
             } else {
                 $topic->producev($partition, 0 /* must be 0 */, $payload, $key, $message->getHeaders());
+
                 return;
             }
         }

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -42,7 +42,7 @@ class RdKafkaProducer implements Producer
         $key = $message->getKey() ?: $destination->getKey() ?: null;
 
         $topic = $this->producer->newTopic($destination->getTopicName(), $destination->getConf());
-        $topic->produce($partition, 0 /* must be 0 */, $payload, $key);
+        $topic->producev($partition, 0 /* must be 0 */, $payload, $key, $message->getHeaders());
     }
 
     /**

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -50,7 +50,8 @@ class RdKafkaProducer implements Producer
             if (version_compare(RdKafkaContext::getLibrdKafkaVersion(), '1.0.0', '>=')
                 && version_compare(phpversion('rdkafka'), '3.1.0', '<=')) {
                 trigger_error(
-                    'Phprdkafka <= 3.1.0 is incompatible with librdkafka 1.0.0 when calling `producev`',
+                    'Phprdkafka <= 3.1.0 is incompatible with librdkafka 1.0.0 when calling `producev`. ' .
+                    'Falling back to `produce` (without message headers) instead.',
                     E_USER_WARNING
                 );
             } else {

--- a/pkg/rdkafka/Tests/RdKafkaProducerTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaProducerTest.php
@@ -45,18 +45,20 @@ class RdKafkaProducerTest extends TestCase
 
     public function testShouldUseSerializerToEncodeMessageAndPutToExpectedTube()
     {
-        $message = new RdKafkaMessage('theBody', ['foo' => 'fooVal'], ['bar' => 'barVal']);
+        $messageHeaders = ['bar' => 'barVal'];
+        $message = new RdKafkaMessage('theBody', ['foo' => 'fooVal'], $messageHeaders);
         $message->setKey('key');
 
         $kafkaTopic = $this->createKafkaTopicMock();
         $kafkaTopic
             ->expects($this->once())
-            ->method('produce')
+            ->method('producev')
             ->with(
                 RD_KAFKA_PARTITION_UA,
                 0,
                 'theSerializedMessage',
-                'key'
+                'key',
+                $messageHeaders
             )
         ;
 
@@ -87,7 +89,7 @@ class RdKafkaProducerTest extends TestCase
         $kafkaTopic = $this->createKafkaTopicMock();
         $kafkaTopic
             ->expects($this->once())
-            ->method('produce')
+            ->method('producev')
         ;
 
         $kafkaProducer = $this->createKafkaProducerMock();
@@ -123,7 +125,7 @@ class RdKafkaProducerTest extends TestCase
         $kafkaTopic = $this->createKafkaTopicMock();
         $kafkaTopic
             ->expects($this->once())
-            ->method('produce')
+            ->method('producev')
         ;
 
         $kafkaProducer = $this->createKafkaProducerMock();
@@ -165,13 +167,14 @@ class RdKafkaProducerTest extends TestCase
 
     public function testShouldAllowSerializersToSerializeKeys()
     {
-        $message = new RdKafkaMessage('theBody', ['foo' => 'fooVal'], ['bar' => 'barVal']);
+        $messageHeaders = ['bar' => 'barVal'];
+        $message = new RdKafkaMessage('theBody', ['foo' => 'fooVal'], $messageHeaders);
         $message->setKey('key');
 
         $kafkaTopic = $this->createKafkaTopicMock();
         $kafkaTopic
             ->expects($this->once())
-            ->method('produce')
+            ->method('producev')
             ->with(
                 RD_KAFKA_PARTITION_UA,
                 0,

--- a/pkg/rdkafka/composer.json
+++ b/pkg/rdkafka/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
-        "ext-rdkafka": "^3.1.0",
+        "ext-rdkafka": "^3.0.3",
         "queue-interop/queue-interop": "^0.7|^0.8"
     },
     "require-dev": {

--- a/pkg/rdkafka/composer.json
+++ b/pkg/rdkafka/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
-        "ext-rdkafka": "^3.0.3",
+        "ext-rdkafka": "^3.1.0",
         "queue-interop/queue-interop": "^0.7|^0.8"
     },
     "require-dev": {


### PR DESCRIPTION
This bumps the dependency on rdkafka extension from version `3.0.3` to `3.1.0`.