### PR TITLE
Fix empty class for autowired services (Fix #957)

### DIFF
--- a/pkg/enqueue/Symfony/Client/DependencyInjection/BuildCommandSubscriberRoutesPass.php
+++ b/pkg/enqueue/Symfony/Client/DependencyInjection/BuildCommandSubscriberRoutesPass.php
@@ -35,7 +35,7 @@ final class BuildCommandSubscriberRoutesPass implements CompilerPassInterface
                     throw new \LogicException('The command subscriber tag could not be applied to a service created by factory.');
                 }
 
-                $processorClass = $processorDefinition->getClass();
+                $processorClass = $processorDefinition->getClass() ?? $serviceId;
                 if (false == class_exists($processorClass)) {
                     throw new \LogicException(sprintf('The processor class "%s" could not be found.', $processorClass));
                 }

--- a/pkg/enqueue/Symfony/Client/DependencyInjection/BuildTopicSubscriberRoutesPass.php
+++ b/pkg/enqueue/Symfony/Client/DependencyInjection/BuildTopicSubscriberRoutesPass.php
@@ -35,7 +35,7 @@ final class BuildTopicSubscriberRoutesPass implements CompilerPassInterface
                     throw new \LogicException('The topic subscriber tag could not be applied to a service created by factory.');
                 }
 
-                $processorClass = $processorDefinition->getClass();
+                $processorClass = $processorDefinition->getClass() ?? $serviceId;
                 if (false == class_exists($processorClass)) {
                     throw new \LogicException(sprintf('The processor class "%s" could not be found.', $processorClass));
                 }


### PR DESCRIPTION
Fix empty class for autowired services at least in Symfony 3.4 (Not tested for other versions).

More information in the related issue #957.