### PR TITLE
Compatibility with Phprdkafka 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
     - if [ "$PHPSTAN" = true ] && [ ! -z "${PKG_PHP_CHANGED_FILES}" ]; then docker run --workdir="/mqdev" -v "`pwd`:/mqdev" --rm enqueue/dev:latest php -d memory_limit=1024M bin/phpstan analyse -l 1 -c phpstan.neon -- ${PKG_PHP_CHANGED_FILES[@]} ; fi
     - if [ "$UNIT_TESTS" = true ]; then bin/phpunit --exclude-group=functional; fi
     - if [ "$FUNCTIONAL_TESTS" = true ]; then bin/test.sh --exclude-group=rdkafka; fi
-    - if [ "RDKAFKA_TESTS" = true ]; then bin/test.sh --group=rdkafka; fi
+    - if [ "$RDKAFKA_TESTS" = true ]; then bin/test.sh --group=rdkafka; fi
 
 notifications:
   webhooks:

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "doctrine/doctrine-bundle": "~1.2|^2",
     "doctrine/mongodb-odm-bundle": "^3.5|^4",
     "alcaeus/mongo-php-adapter": "^1.0",
-    "kwn/php-rdkafka-stubs": "^1.0.2",
+    "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
     "friendsofphp/php-cs-fixer": "^2"
   },
   "autoload": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,13 +99,13 @@ services:
       - '2181:2181'
 
   kafka:
-    image: 'wurstmeister/kafka:0.10.2.1'
+    image: 'wurstmeister/kafka'
     ports:
       - '9092:9092'
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-    volumes:
-      - '/var/run/docker.sock:/var/run/docker.sock'
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
 
   google-pubsub:
       image: 'google/cloud-sdk:latest'

--- a/pkg/rdkafka/RdKafkaConnectionFactory.php
+++ b/pkg/rdkafka/RdKafkaConnectionFactory.php
@@ -28,6 +28,7 @@ class RdKafkaConnectionFactory implements ConnectionFactory
      *     'partitioner' => null,                          // https://arnaud-lb.github.io/php-rdkafka/phpdoc/rdkafka-topicconf.setpartitioner.html
      *     'log_level' => null,
      *     'commit_async' => false,
+     *     'shutdown_timeout' => -1,                       // https://github.com/arnaud-lb/php-rdkafka#proper-shutdown
      * ]
      *
      * or

--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -50,9 +50,6 @@ class RdKafkaContext implements Context
      */
     private $rdKafkaConsumers;
 
-    /**
-     * @param array $config
-     */
     public function __construct(array $config)
     {
         $this->config = $config;

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -111,4 +111,12 @@ class RdKafkaProducer implements Producer
     {
         return null;
     }
+
+    public function flush(int $timeout): void
+    {
+        // Flush method is exposed in phprdkafka 4.0
+        if (method_exists($this->producer, 'flush')) {
+            $this->producer->flush($timeout);
+        }
+    }
 }

--- a/pkg/rdkafka/Tests/Spec/RdKafkaSendToAndReceiveFromTopicTest.php
+++ b/pkg/rdkafka/Tests/Spec/RdKafkaSendToAndReceiveFromTopicTest.php
@@ -19,9 +19,14 @@ class RdKafkaSendToAndReceiveFromTopicTest extends SendToAndReceiveFromTopicSpec
 
         $topic = $this->createTopic($context, uniqid('', true));
 
-        $consumer = $context->createConsumer($topic);
-
         $expectedBody = __CLASS__.time();
+        $producer = $context->createProducer();
+        $producer->send($topic, $context->createMessage($expectedBody));
+
+        // Calling close causes Producer to flush (wait for messages to be delivered to Kafka)
+        $context->close();
+
+        $consumer = $context->createConsumer($topic);
 
         $context->createProducer()->send($topic, $context->createMessage($expectedBody));
 
@@ -47,8 +52,6 @@ class RdKafkaSendToAndReceiveFromTopicTest extends SendToAndReceiveFromTopicSpec
         ];
 
         $context = (new RdKafkaConnectionFactory($config))->createContext();
-
-        sleep(3);
 
         return $context;
     }

--- a/pkg/rdkafka/composer.json
+++ b/pkg/rdkafka/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
-        "ext-rdkafka": "^3.0.3",
+        "ext-rdkafka": "^3.0.3|^4.0",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
@@ -15,7 +15,7 @@
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6",
-        "kwn/php-rdkafka-stubs": "^1.0.2"
+        "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0"
     },
     "support": {
         "email": "opensource@forma-pro.com",


### PR DESCRIPTION
@see https://github.com/arnaud-lb/php-rdkafka/releases/tag/4.0.0

Since `poll` no longer gets called on destruct/shutdown, we should provide error handling (#749).

I'm marking this as draft PR since otherwise we might have people losing messages when PHP process shuts down before message is acknowledged by Kafka broker.