### PR TITLE
[SQS] add messageId to the sqsMessage

### DIFF
--- a/pkg/snsqs/Tests/SnsQsProducerTest.php
+++ b/pkg/snsqs/Tests/SnsQsProducerTest.php
@@ -36,7 +36,7 @@ class SnsQsProducerTest extends TestCase
     public function testShouldThrowIfMessageIsInvalidType()
     {
         $this->expectException(InvalidMessageException::class);
-        $this->expectExceptionMessage('The message must be an instance of Enqueue\SnsQs\SnsQsMessage but it is Double\Message\P1');
+        $this->expectExceptionMessage('The message must be an instance of Enqueue\SnsQs\SnsQsMessage but it is Double\Message\P4');
 
         $producer = new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
 

--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -185,6 +185,10 @@ class SqsConsumer implements Consumer
     {
         $message = $this->context->createMessage();
 
+        if (isset($sqsMessage['MessageId'])) {
+            $message->setMessageId($sqsMessage['MessageId']);
+        }
+
         $message->setBody($sqsMessage['Body']);
         $message->setReceiptHandle($sqsMessage['ReceiptHandle']);
 

--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -207,6 +207,8 @@ class SqsConsumer implements Consumer
             $message->setProperties($headers[1]);
         }
 
+        $message->setMessageId($sqsMessage['MessageId']);
+
         return $message;
     }
 }

--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -185,10 +185,6 @@ class SqsConsumer implements Consumer
     {
         $message = $this->context->createMessage();
 
-        if (isset($sqsMessage['MessageId'])) {
-            $message->setMessageId($sqsMessage['MessageId']);
-        }
-
         $message->setBody($sqsMessage['Body']);
         $message->setReceiptHandle($sqsMessage['ReceiptHandle']);
 

--- a/pkg/sqs/SqsMessage.php
+++ b/pkg/sqs/SqsMessage.php
@@ -58,6 +58,11 @@ class SqsMessage implements Message
      */
     private $requeueVisibilityTimeout;
 
+    /**
+     * @var string|null
+     */
+    private $messageId;
+
     public function __construct(string $body = '', array $properties = [], array $headers = [])
     {
         $this->body = $body;
@@ -166,12 +171,12 @@ class SqsMessage implements Message
 
     public function setMessageId(string $messageId = null): void
     {
-        $this->setHeader('message_id', $messageId);
+        $this->messageId = $messageId;
     }
 
     public function getMessageId(): ?string
     {
-        return $this->getHeader('message_id');
+        return $this->messageId;
     }
 
     public function getTimestamp(): ?int

--- a/pkg/sqs/SqsMessage.php
+++ b/pkg/sqs/SqsMessage.php
@@ -58,11 +58,6 @@ class SqsMessage implements Message
      */
     private $requeueVisibilityTimeout;
 
-    /**
-     * @var string|null
-     */
-    private $messageId;
-
     public function __construct(string $body = '', array $properties = [], array $headers = [])
     {
         $this->body = $body;
@@ -171,12 +166,12 @@ class SqsMessage implements Message
 
     public function setMessageId(string $messageId = null): void
     {
-        $this->messageId = $messageId;
+        $this->setHeader('message_id', $messageId);
     }
 
     public function getMessageId(): ?string
     {
-        return $this->messageId;
+        return $this->getHeader('message_id');
     }
 
     public function getTimestamp(): ?int

--- a/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
@@ -102,7 +102,7 @@ class SqsCommonUseCasesTest extends TestCase
 
         $this->assertEquals(__METHOD__, $message->getBody());
         $this->assertEquals(['FooProperty' => 'FooVal'], $message->getProperties());
-        $this->assertEquals('BarVal', $message->getHeaders()['BarHeader']);
+        $this->assertEquals(['BarHeader' => 'BarVal'], $message->getHeaders());
         $this->assertNotNull($message->getMessageId());
     }
 

--- a/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
@@ -102,7 +102,8 @@ class SqsCommonUseCasesTest extends TestCase
 
         $this->assertEquals(__METHOD__, $message->getBody());
         $this->assertEquals(['FooProperty' => 'FooVal'], $message->getProperties());
-        $this->assertEquals(['BarHeader' => 'BarVal'], $message->getHeaders());
+        $this->assertEquals('BarVal', $message->getHeaders()['BarHeader']);
+        $this->assertNotNull($message->getMessageId());
     }
 
     public function testProduceAndReceiveOneMessageSentDirectlyToTopic()

--- a/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
@@ -102,7 +102,7 @@ class SqsCommonUseCasesTest extends TestCase
 
         $this->assertEquals(__METHOD__, $message->getBody());
         $this->assertEquals(['FooProperty' => 'FooVal'], $message->getProperties());
-        $this->assertEquals(['BarHeader' => 'BarVal'], $message->getHeaders());
+        $this->assertEquals('BarVal', $message->getHeaders()['BarHeader']);
         $this->assertNotNull($message->getMessageId());
     }
 

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -338,7 +338,7 @@ class SqsConsumerTest extends TestCase
 
         $this->assertInstanceOf(SqsMessage::class, $result);
         $this->assertEquals('The Body', $result->getBody());
-        $this->assertEquals(['hkey' => 'hvalue'], $result->getHeaders());
+        $this->assertEquals(['hkey' => 'hvalue', 'message_id' => 'theMessageId'], $result->getHeaders());
         $this->assertEquals(['key' => 'value'], $result->getProperties());
         $this->assertEquals([
             'SenderId' => 'AROAX5IAWYILCTYIS3OZ5:foo@bar.com',

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -293,6 +293,7 @@ class SqsConsumerTest extends TestCase
         $expectedSqsMessage = [
             'Body' => 'The Body',
             'ReceiptHandle' => 'The Receipt',
+            'MessageId' => 'theMessageId',
             'Attributes' => [
                 'SenderId' => 'AROAX5IAWYILCTYIS3OZ5:foo@bar.com',
                 'ApproximateFirstReceiveTimestamp' => '1560512269481',
@@ -337,7 +338,7 @@ class SqsConsumerTest extends TestCase
 
         $this->assertInstanceOf(SqsMessage::class, $result);
         $this->assertEquals('The Body', $result->getBody());
-        $this->assertEquals(['hkey' => 'hvalue'], $result->getHeaders());
+        $this->assertEquals(['hkey' => 'hvalue', 'message_id' => 'theMessageId'], $result->getHeaders());
         $this->assertEquals(['key' => 'value'], $result->getProperties());
         $this->assertEquals([
             'SenderId' => 'AROAX5IAWYILCTYIS3OZ5:foo@bar.com',
@@ -347,6 +348,7 @@ class SqsConsumerTest extends TestCase
         ], $result->getAttributes());
         $this->assertTrue($result->isRedelivered());
         $this->assertEquals('The Receipt', $result->getReceiptHandle());
+        $this->assertEquals('theMessageId', $result->getMessageId());
     }
 
     public function testShouldReceiveMessageWithCustomRegion()
@@ -368,6 +370,7 @@ class SqsConsumerTest extends TestCase
             ->willReturn(new Result(['Messages' => [[
                 'Body' => 'The Body',
                 'ReceiptHandle' => 'The Receipt',
+                'MessageId' => 'theMessageId',
                 'Attributes' => [
                     'ApproximateReceiveCount' => 3,
                 ],

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -338,7 +338,7 @@ class SqsConsumerTest extends TestCase
 
         $this->assertInstanceOf(SqsMessage::class, $result);
         $this->assertEquals('The Body', $result->getBody());
-        $this->assertEquals(['hkey' => 'hvalue', 'message_id' => 'theMessageId'], $result->getHeaders());
+        $this->assertEquals(['hkey' => 'hvalue'], $result->getHeaders());
         $this->assertEquals(['key' => 'value'], $result->getProperties());
         $this->assertEquals([
             'SenderId' => 'AROAX5IAWYILCTYIS3OZ5:foo@bar.com',


### PR DESCRIPTION
Hi,

I saw that we are not allowing user to access the messageId of a sqs message.

following the issue #837 i have added the messageId in the convertMessage method.

