### PR TITLE
Gearman Consumer receive should only fetch one message

### DIFF
--- a/pkg/gearman/GearmanConsumer.php
+++ b/pkg/gearman/GearmanConsumer.php
@@ -59,7 +59,7 @@ class GearmanConsumer implements Consumer
                 $message = GearmanMessage::jsonUnserialize($job->workload());
             });
 
-            while ($this->worker->work());
+            $this->worker->work();
         } finally {
             restore_error_handler();
         }


### PR DESCRIPTION
When looping the worker->work() call, the receive method will fetch all messages in the queue, but only return the last one.
The fix will return only one message.