### PR TITLE
fixes #1003

### DIFF
--- a/pkg/amqp-lib/AmqpContext.php
+++ b/pkg/amqp-lib/AmqpContext.php
@@ -172,7 +172,7 @@ class AmqpContext implements InteropAmqpContext, DelayStrategyAware
             $queue->getArguments() ? new AMQPTable($queue->getArguments()) : null
         );
 
-        return $messageCount;
+        return $messageCount ?? 0;
     }
 
     public function deleteQueue(InteropAmqpQueue $queue): void


### PR DESCRIPTION
Fixes:

```
Return value of Enqueue\AmqpLib\AmqpContext::declareQueue() must be of the type int, null returned
```