### PR TITLE
SQS Transport - Add support for AWS profiles.

### DIFF
--- a/pkg/snsqs/Tests/SnsQsProducerTest.php
+++ b/pkg/snsqs/Tests/SnsQsProducerTest.php
@@ -36,7 +36,7 @@ class SnsQsProducerTest extends TestCase
     public function testShouldThrowIfMessageIsInvalidType()
     {
         $this->expectException(InvalidMessageException::class);
-        $this->expectExceptionMessage('The message must be an instance of Enqueue\SnsQs\SnsQsMessage but it is Double\Message\P1');
+        $this->expectExceptionMessage('The message must be an instance of Enqueue\SnsQs\SnsQsMessage but it is Double\Message\P4');
 
         $producer = new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
 

--- a/pkg/sqs/SqsConnectionFactory.php
+++ b/pkg/sqs/SqsConnectionFactory.php
@@ -31,7 +31,8 @@ class SqsConnectionFactory implements ConnectionFactory
      *   'retries' => 3,              (int, default=int(3)) Configures the maximum number of allowed retries for a client (pass 0 to disable retries).
      *   'version' => '2012-11-05',   (string, required) The version of the webservice to utilize
      *   'lazy' => true,              Enable lazy connection (boolean)
-     *   'endpoint' => null           (string, default=null) The full URI of the webservice. This is only required when connecting to a custom endpoint e.g. localstack
+     *   'endpoint' => null,          (string, default=null) The full URI of the webservice. This is only required when connecting to a custom endpoint e.g. localstack
+     *   'profile' => null,           (string, default=null) The name of an AWS profile to used, if provided the SDK will attempt to read associated credentials from the ~/.aws/credentials file.
      *   'queue_owner_aws_account_id' The AWS account ID of the account that created the queue.
      * ].
      *
@@ -92,6 +93,10 @@ class SqsConnectionFactory implements ConnectionFactory
             $config['endpoint'] = $this->config['endpoint'];
         }
 
+        if (isset($this->config['profile'])) {
+            $config['profile'] = $this->config['profile'];
+        }
+
         if ($this->config['key'] && $this->config['secret']) {
             $config['credentials'] = [
                 'key' => $this->config['key'],
@@ -120,10 +125,7 @@ class SqsConnectionFactory implements ConnectionFactory
         $dsn = Dsn::parseFirst($dsn);
 
         if ('sqs' !== $dsn->getSchemeProtocol()) {
-            throw new \LogicException(sprintf(
-                'The given scheme protocol "%s" is not supported. It must be "sqs"',
-                $dsn->getSchemeProtocol()
-            ));
+            throw new \LogicException(sprintf('The given scheme protocol "%s" is not supported. It must be "sqs"', $dsn->getSchemeProtocol()));
         }
 
         return array_filter(array_replace($dsn->getQuery(), [
@@ -135,6 +137,7 @@ class SqsConnectionFactory implements ConnectionFactory
             'version' => $dsn->getString('version'),
             'lazy' => $dsn->getBool('lazy'),
             'endpoint' => $dsn->getString('endpoint'),
+            'profile' => $dsn->getString('profile'),
             'queue_owner_aws_account_id' => $dsn->getString('queue_owner_aws_account_id'),
         ]), function ($value) { return null !== $value; });
     }
@@ -150,6 +153,7 @@ class SqsConnectionFactory implements ConnectionFactory
             'version' => '2012-11-05',
             'lazy' => true,
             'endpoint' => null,
+            'profile' => null,
             'queue_owner_aws_account_id' => null,
         ];
     }

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -63,6 +63,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'version' => '2012-11-05',
                 'lazy' => true,
                 'endpoint' => null,
+                'profile' => null,
                 'queue_owner_aws_account_id' => null,
             ],
         ];
@@ -78,6 +79,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'version' => '2012-11-05',
                 'lazy' => true,
                 'endpoint' => null,
+                'profile' => null,
                 'queue_owner_aws_account_id' => null,
             ],
         ];
@@ -93,6 +95,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'version' => '2012-11-05',
                 'lazy' => true,
                 'endpoint' => null,
+                'profile' => null,
                 'queue_owner_aws_account_id' => null,
             ],
         ];
@@ -108,6 +111,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => null,
+                'profile' => null,
                 'queue_owner_aws_account_id' => null,
             ],
         ];
@@ -123,6 +127,23 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => null,
+                'profile' => null,
+                'queue_owner_aws_account_id' => null,
+            ],
+        ];
+
+        yield [
+            ['dsn' => 'sqs:?profile=staging&lazy=0'],
+            [
+                'key' => null,
+                'secret' => null,
+                'token' => null,
+                'region' => null,
+                'retries' => 3,
+                'version' => '2012-11-05',
+                'lazy' => false,
+                'endpoint' => null,
+                'profile' => 'staging',
                 'queue_owner_aws_account_id' => null,
             ],
         ];
@@ -138,6 +159,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => null,
+                'profile' => null,
                 'queue_owner_aws_account_id' => null,
             ],
         ];
@@ -159,6 +181,25 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
+                'profile' => null,
+                'queue_owner_aws_account_id' => null,
+            ],
+        ];
+
+        yield [
+            [
+                'profile' => 'staging',
+            ],
+            [
+                'key' => null,
+                'secret' => null,
+                'token' => null,
+                'region' => null,
+                'retries' => 3,
+                'version' => '2012-11-05',
+                'lazy' => true,
+                'endpoint' => null,
+                'profile' => 'staging',
                 'queue_owner_aws_account_id' => null,
             ],
         ];

--- a/pkg/sqs/Tests/SqsConnectionFactoryTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryTest.php
@@ -32,6 +32,7 @@ class SqsConnectionFactoryTest extends TestCase
             'retries' => 3,
             'version' => '2012-11-05',
             'endpoint' => null,
+            'profile' => null,
             'queue_owner_aws_account_id' => null,
         ], 'config', $factory);
     }
@@ -49,6 +50,7 @@ class SqsConnectionFactoryTest extends TestCase
             'retries' => 3,
             'version' => '2012-11-05',
             'endpoint' => null,
+            'profile' => null,
             'queue_owner_aws_account_id' => null,
         ], 'config', $factory);
     }


### PR DESCRIPTION
This PR add support for AWS profiles, it reponds to issue https://github.com/php-enqueue/enqueue-dev/issues/1007.

Closes: #1007