### PR TITLE
Catch consume error "Local: Broker transport failure" and continue consume

### DIFF
--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -161,6 +161,7 @@ class RdKafkaConsumer implements Consumer
         switch ($kafkaMessage->err) {
             case RD_KAFKA_RESP_ERR__PARTITION_EOF:
             case RD_KAFKA_RESP_ERR__TIMED_OUT:
+            case RD_KAFKA_RESP_ERR__TRANSPORT:
                 return null;
             case RD_KAFKA_RESP_ERR_NO_ERROR:
                 $message = $this->serializer->toMessage($kafkaMessage->payload);


### PR DESCRIPTION
Catch the Kafka `Local: Broker transport failure` (error -195) error when consuming, this happens sometimes when consuming messages. When we restart the consumer everything is just OK.

Settings for connection with Kafka:
```
enqueue:
    kafka:
        transport:
            global:
                group.id: XXX
                metadata.broker.list: XXX
                enable.auto.offset.store: 'false'
                socket.keepalive.enable: 'true'
                topic.metadata.refresh.interval.ms: '30000'
```
@makasim 