### PR TITLE
fix: allow absolute paths for sqlite transport

### DIFF
--- a/pkg/dbal/DbalConnectionFactory.php
+++ b/pkg/dbal/DbalConnectionFactory.php
@@ -6,6 +6,7 @@ namespace Enqueue\Dbal;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Enqueue\Dsn\Dsn;
 use Interop\Queue\ConnectionFactory;
 use Interop\Queue\Context;
 
@@ -93,20 +94,7 @@ class DbalConnectionFactory implements ConnectionFactory
 
     private function parseDsn(string $dsn, array $config = null): array
     {
-        if (false === strpos($dsn, ':')) {
-            throw new \LogicException(sprintf('The DSN is invalid. It does not have scheme separator ":".'));
-        }
-
-        list($scheme) = explode(':', $dsn, 2);
-        $scheme = strtolower($scheme);
-
-        if (false === strpos($scheme, 'sqlite') && false === parse_url($dsn)) {
-            throw new \LogicException(sprintf('Failed to parse DSN "%s"', $dsn));
-        }
-
-        if (false == preg_match('/^[a-z\d+-.]*$/', $scheme)) {
-            throw new \LogicException('The DSN is invalid. Scheme contains illegal symbols.');
-        }
+        $parsedDsn = Dsn::parseFirst($dsn);
 
         $supported = [
             'db2' => 'db2',
@@ -124,13 +112,13 @@ class DbalConnectionFactory implements ConnectionFactory
             'sqlite+pdo' => 'pdo_sqlite',
         ];
 
-        if (false == isset($supported[$scheme])) {
-            throw new \LogicException(sprintf('The given DSN schema "%s" is not supported. There are supported schemes: "%s".', $scheme, implode('", "', array_keys($supported))));
+        if ($parsedDsn && false == isset($supported[$parsedDsn->getScheme()])) {
+            throw new \LogicException(sprintf('The given DSN schema "%s" is not supported. There are supported schemes: "%s".', $parsedDsn->getScheme(), implode('", "', array_keys($supported))));
         }
 
-        $doctrineScheme = $supported[$scheme];
-
-        if ($scheme.':' === $dsn && is_array($config) && array_key_exists('connection', $config)) {
+        $doctrineScheme = $supported[$parsedDsn->getScheme()];
+        $dsnHasProtocolOnly = $parsedDsn->getScheme().':' === $dsn;
+        if ($dsnHasProtocolOnly && is_array($config) && array_key_exists('connection', $config)) {
             $default = [
                 'driver' => $doctrineScheme,
                 'host' => 'localhost',
@@ -148,9 +136,9 @@ class DbalConnectionFactory implements ConnectionFactory
         return [
             'lazy' => true,
             'connection' => [
-                'url' => $scheme.':' === $dsn ?
+                'url' => $dsnHasProtocolOnly ?
                     $doctrineScheme.'://root@localhost' :
-                    str_replace($scheme, $doctrineScheme, $dsn),
+                    str_replace($parsedDsn->getScheme(), $doctrineScheme, $dsn),
             ],
         ];
     }

--- a/pkg/dbal/DbalConnectionFactory.php
+++ b/pkg/dbal/DbalConnectionFactory.php
@@ -91,25 +91,19 @@ class DbalConnectionFactory implements ConnectionFactory
         return $this->connection;
     }
 
-    /**
-     * @param string     $dsn
-     * @param array|null $config
-     *
-     * @return array
-     */
     private function parseDsn(string $dsn, array $config = null): array
     {
         if (false === strpos($dsn, ':')) {
             throw new \LogicException(sprintf('The DSN is invalid. It does not have scheme separator ":".'));
         }
 
-        if (false === parse_url($dsn)) {
+        list($scheme) = explode(':', $dsn, 2);
+        $scheme = strtolower($scheme);
+
+        if (false === strpos($scheme, 'sqlite') && false === parse_url($dsn)) {
             throw new \LogicException(sprintf('Failed to parse DSN "%s"', $dsn));
         }
 
-        list($scheme) = explode(':', $dsn, 2);
-
-        $scheme = strtolower($scheme);
         if (false == preg_match('/^[a-z\d+-.]*$/', $scheme)) {
             throw new \LogicException('The DSN is invalid. Scheme contains illegal symbols.');
         }
@@ -131,11 +125,7 @@ class DbalConnectionFactory implements ConnectionFactory
         ];
 
         if (false == isset($supported[$scheme])) {
-            throw new \LogicException(sprintf(
-                'The given DSN schema "%s" is not supported. There are supported schemes: "%s".',
-                $scheme,
-                implode('", "', array_keys($supported))
-            ));
+            throw new \LogicException(sprintf('The given DSN schema "%s" is not supported. There are supported schemes: "%s".', $scheme, implode('", "', array_keys($supported))));
         }
 
         $doctrineScheme = $supported[$scheme];

--- a/pkg/dbal/Tests/DbalConnectionFactoryTest.php
+++ b/pkg/dbal/Tests/DbalConnectionFactoryTest.php
@@ -28,4 +28,32 @@ class DbalConnectionFactoryTest extends TestCase
         $this->assertAttributeEquals(null, 'connection', $context);
         $this->assertAttributeInternalType('callable', 'connectionFactory', $context);
     }
+
+    public function testShouldParseGenericDSN()
+    {
+        $factory = new DbalConnectionFactory('pgsql+pdo://foo@bar');
+
+        $context = $factory->createContext();
+
+        $this->assertInstanceOf(DbalContext::class, $context);
+
+        $config = $context->getConfig();
+        $this->assertArrayHasKey('connection', $config);
+        $this->assertArrayHasKey('url', $config['connection']);
+        $this->assertEquals('pdo_pgsql://foo@bar', $config['connection']['url']);
+    }
+
+    public function testShouldParseSqliteAbsolutePathDSN()
+    {
+        $factory = new DbalConnectionFactory('sqlite+pdo:////tmp/some.sq3');
+
+        $context = $factory->createContext();
+
+        $this->assertInstanceOf(DbalContext::class, $context);
+
+        $config = $context->getConfig();
+        $this->assertArrayHasKey('connection', $config);
+        $this->assertArrayHasKey('url', $config['connection']);
+        $this->assertEquals('pdo_sqlite:////tmp/some.sq3', $config['connection']['url']);
+    }
 }


### PR DESCRIPTION
Hi,

when switching from `amqp+lib` to `sqlite3` transport, we were not able to setup DSNs with absolute paths. It seems that `parse_url()` only allows more than 2 slashes for `file:` scheme and fails for other schemes (see [Notes in the documentation](https://www.php.net/manual/en/function.parse-url.php)). SQLite however happily uses [3 and more slashes for DSNs](https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/reference/configuration.html#connecting-using-a-url).

This PR proposes a special handling for `sqlite:` scheme and fixes #780. Relevant changes are lines 100-103, the rest is php-cs-fixer.