### PR TITLE
Implement DeliveryDelay, Priority and TimeToLive in PheanstalkProducer

### DIFF
--- a/pkg/pheanstalk/Tests/PheanstalkProducerTest.php
+++ b/pkg/pheanstalk/Tests/PheanstalkProducerTest.php
@@ -66,34 +66,7 @@ class PheanstalkProducerTest extends TestCase
         );
     }
 
-    public function testPriorityPrecedesMessagePriority()
-    {
-        $message = new PheanstalkMessage('theBody');
-        $message->setPriority(100);
-
-        $pheanstalk = $this->createPheanstalkMock();
-        $pheanstalk
-            ->expects($this->once())
-            ->method('useTube')
-            ->with('theQueueName')
-            ->willReturnSelf()
-        ;
-        $pheanstalk
-            ->expects($this->once())
-            ->method('put')
-            ->with('{"body":"theBody","properties":[],"headers":{"priority":100}}', 50, Pheanstalk::DEFAULT_DELAY, Pheanstalk::DEFAULT_TTR)
-        ;
-
-        $producer = new PheanstalkProducer($pheanstalk);
-        $producer->setPriority(50);
-
-        $producer->send(
-            new PheanstalkDestination('theQueueName'),
-            $message
-        );
-    }
-
-    public function testNullPriorityFallsBackToMessagePriority()
+    public function testMessagePriorityPrecedesPriority()
     {
         $message = new PheanstalkMessage('theBody');
         $message->setPriority(100);
@@ -112,42 +85,12 @@ class PheanstalkProducerTest extends TestCase
         ;
 
         $producer = new PheanstalkProducer($pheanstalk);
-        $producer->setPriority(null);
+        $producer->setPriority(50);
 
         $producer->send(
             new PheanstalkDestination('theQueueName'),
             $message
         );
-    }
-
-    public function testPriorityDoesNotPersist()
-    {
-        $message = new PheanstalkMessage('theBody');
-
-        $pheanstalk = $this->createPheanstalkMock();
-        $pheanstalk
-            ->expects($this->once())
-            ->method('useTube')
-            ->with('theQueueName')
-            ->willReturnSelf()
-        ;
-        $pheanstalk
-            ->expects($this->once())
-            ->method('put')
-            ->with('{"body":"theBody","properties":[],"headers":[]}', 100, Pheanstalk::DEFAULT_DELAY, Pheanstalk::DEFAULT_TTR)
-        ;
-
-        $producer = new PheanstalkProducer($pheanstalk);
-        $producer->setPriority(100);
-
-        $this->assertEquals(100, $producer->getPriority());
-
-        $producer->send(
-            new PheanstalkDestination('theQueueName'),
-            $message
-        );
-
-        $this->assertNull($producer->getPriority());
     }
 
     public function testAccessDeliveryDelayAsMilliseconds()
@@ -184,34 +127,7 @@ class PheanstalkProducerTest extends TestCase
         );
     }
 
-    public function testDeliveryDelayPrecedesMessageDelay()
-    {
-        $message = new PheanstalkMessage('theBody');
-        $message->setDelay(25);
-
-        $pheanstalk = $this->createPheanstalkMock();
-        $pheanstalk
-            ->expects($this->once())
-            ->method('useTube')
-            ->with('theQueueName')
-            ->willReturnSelf()
-        ;
-        $pheanstalk
-            ->expects($this->once())
-            ->method('put')
-            ->with('{"body":"theBody","properties":[],"headers":{"delay":25}}', Pheanstalk::DEFAULT_PRIORITY, 1, Pheanstalk::DEFAULT_TTR)
-        ;
-
-        $producer = new PheanstalkProducer($pheanstalk);
-        $producer->setDeliveryDelay(1000);
-
-        $producer->send(
-            new PheanstalkDestination('theQueueName'),
-            $message
-        );
-    }
-
-    public function testNullDeliveryDelayFallsBackToMessageDelay()
+    public function testMessageDelayPrecedesDeliveryDelay()
     {
         $message = new PheanstalkMessage('theBody');
         $message->setDelay(25);
@@ -230,42 +146,12 @@ class PheanstalkProducerTest extends TestCase
         ;
 
         $producer = new PheanstalkProducer($pheanstalk);
-        $producer->setDeliveryDelay(null);
-
-        $producer->send(
-            new PheanstalkDestination('theQueueName'),
-            $message
-        );
-    }
-
-    public function testDeliveryDelayDoesNotPersist()
-    {
-        $message = new PheanstalkMessage('theBody');
-
-        $pheanstalk = $this->createPheanstalkMock();
-        $pheanstalk
-            ->expects($this->once())
-            ->method('useTube')
-            ->with('theQueueName')
-            ->willReturnSelf()
-        ;
-        $pheanstalk
-            ->expects($this->once())
-            ->method('put')
-            ->with('{"body":"theBody","properties":[],"headers":[]}', Pheanstalk::DEFAULT_PRIORITY, 1, Pheanstalk::DEFAULT_TTR)
-        ;
-
-        $producer = new PheanstalkProducer($pheanstalk);
         $producer->setDeliveryDelay(1000);
 
-        $this->assertEquals(1000, $producer->getDeliveryDelay());
-
         $producer->send(
             new PheanstalkDestination('theQueueName'),
             $message
         );
-
-        $this->assertNull($producer->getDeliveryDelay());
     }
 
     public function testAccessTimeToLiveAsMilliseconds()
@@ -302,34 +188,7 @@ class PheanstalkProducerTest extends TestCase
         );
     }
 
-    public function testTimeToLivePrecedesMessageTimeToRun()
-    {
-        $message = new PheanstalkMessage('theBody');
-        $message->setTimeToRun(25);
-
-        $pheanstalk = $this->createPheanstalkMock();
-        $pheanstalk
-            ->expects($this->once())
-            ->method('useTube')
-            ->with('theQueueName')
-            ->willReturnSelf()
-        ;
-        $pheanstalk
-            ->expects($this->once())
-            ->method('put')
-            ->with('{"body":"theBody","properties":[],"headers":{"ttr":25}}', Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, 1)
-        ;
-
-        $producer = new PheanstalkProducer($pheanstalk);
-        $producer->setTimeToLive(1000);
-
-        $producer->send(
-            new PheanstalkDestination('theQueueName'),
-            $message
-        );
-    }
-
-    public function testNullTimeToLiveFallsBackToMessageTimeToRun()
+    public function testMessageTimeToRunPrecedesTimeToLive()
     {
         $message = new PheanstalkMessage('theBody');
         $message->setTimeToRun(25);
@@ -348,42 +207,12 @@ class PheanstalkProducerTest extends TestCase
         ;
 
         $producer = new PheanstalkProducer($pheanstalk);
-        $producer->setTimeToLive(null);
-
-        $producer->send(
-            new PheanstalkDestination('theQueueName'),
-            $message
-        );
-    }
-
-    public function testTimeToLiveDoesNotPersist()
-    {
-        $message = new PheanstalkMessage('theBody');
-
-        $pheanstalk = $this->createPheanstalkMock();
-        $pheanstalk
-            ->expects($this->once())
-            ->method('useTube')
-            ->with('theQueueName')
-            ->willReturnSelf()
-        ;
-        $pheanstalk
-            ->expects($this->once())
-            ->method('put')
-            ->with('{"body":"theBody","properties":[],"headers":[]}', Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, 1)
-        ;
-
-        $producer = new PheanstalkProducer($pheanstalk);
         $producer->setTimeToLive(1000);
 
-        $this->assertEquals(1000, $producer->getTimeToLive());
-
         $producer->send(
             new PheanstalkDestination('theQueueName'),
             $message
         );
-
-        $this->assertNull($producer->getTimeToLive());
     }
 
     /**

--- a/pkg/pheanstalk/Tests/PheanstalkProducerTest.php
+++ b/pkg/pheanstalk/Tests/PheanstalkProducerTest.php
@@ -66,6 +66,326 @@ class PheanstalkProducerTest extends TestCase
         );
     }
 
+    public function testPriorityPrecedesMessagePriority()
+    {
+        $message = new PheanstalkMessage('theBody');
+        $message->setPriority(100);
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":{"priority":100}}', 50, Pheanstalk::DEFAULT_DELAY, Pheanstalk::DEFAULT_TTR)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setPriority(50);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testNullPriorityFallsBackToMessagePriority()
+    {
+        $message = new PheanstalkMessage('theBody');
+        $message->setPriority(100);
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":{"priority":100}}', 100, Pheanstalk::DEFAULT_DELAY, Pheanstalk::DEFAULT_TTR)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setPriority(null);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testPriorityDoesNotPersist()
+    {
+        $message = new PheanstalkMessage('theBody');
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":[]}', 100, Pheanstalk::DEFAULT_DELAY, Pheanstalk::DEFAULT_TTR)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setPriority(100);
+
+        $this->assertEquals(100, $producer->getPriority());
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+
+        $this->assertNull($producer->getPriority());
+    }
+
+    public function testAccessDeliveryDelayAsMilliseconds()
+    {
+        $producer = new PheanstalkProducer($this->createPheanstalkMock());
+        $producer->setDeliveryDelay(5000);
+
+        $this->assertEquals(5000, $producer->getDeliveryDelay());
+    }
+
+    public function testDeliveryDelayResolvesToSeconds()
+    {
+        $message = new PheanstalkMessage('theBody');
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":[]}', Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk::DEFAULT_TTR)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setDeliveryDelay(5000);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testDeliveryDelayPrecedesMessageDelay()
+    {
+        $message = new PheanstalkMessage('theBody');
+        $message->setDelay(25);
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":{"delay":25}}', Pheanstalk::DEFAULT_PRIORITY, 1, Pheanstalk::DEFAULT_TTR)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setDeliveryDelay(1000);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testNullDeliveryDelayFallsBackToMessageDelay()
+    {
+        $message = new PheanstalkMessage('theBody');
+        $message->setDelay(25);
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":{"delay":25}}', Pheanstalk::DEFAULT_PRIORITY, 25, Pheanstalk::DEFAULT_TTR)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setDeliveryDelay(null);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testDeliveryDelayDoesNotPersist()
+    {
+        $message = new PheanstalkMessage('theBody');
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":[]}', Pheanstalk::DEFAULT_PRIORITY, 1, Pheanstalk::DEFAULT_TTR)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setDeliveryDelay(1000);
+
+        $this->assertEquals(1000, $producer->getDeliveryDelay());
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+
+        $this->assertNull($producer->getDeliveryDelay());
+    }
+
+    public function testAccessTimeToLiveAsMilliseconds()
+    {
+        $producer = new PheanstalkProducer($this->createPheanstalkMock());
+        $producer->setTimeToLive(5000);
+
+        $this->assertEquals(5000, $producer->getTimeToLive());
+    }
+
+    public function testTimeToLiveResolvesToSeconds()
+    {
+        $message = new PheanstalkMessage('theBody');
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":[]}', Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, 5)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setTimeToLive(5000);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testTimeToLivePrecedesMessageTimeToRun()
+    {
+        $message = new PheanstalkMessage('theBody');
+        $message->setTimeToRun(25);
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":{"ttr":25}}', Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, 1)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setTimeToLive(1000);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testNullTimeToLiveFallsBackToMessageTimeToRun()
+    {
+        $message = new PheanstalkMessage('theBody');
+        $message->setTimeToRun(25);
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":{"ttr":25}}', Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, 25)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setTimeToLive(null);
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+    }
+
+    public function testTimeToLiveDoesNotPersist()
+    {
+        $message = new PheanstalkMessage('theBody');
+
+        $pheanstalk = $this->createPheanstalkMock();
+        $pheanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('theQueueName')
+            ->willReturnSelf()
+        ;
+        $pheanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with('{"body":"theBody","properties":[],"headers":[]}', Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, 1)
+        ;
+
+        $producer = new PheanstalkProducer($pheanstalk);
+        $producer->setTimeToLive(1000);
+
+        $this->assertEquals(1000, $producer->getTimeToLive());
+
+        $producer->send(
+            new PheanstalkDestination('theQueueName'),
+            $message
+        );
+
+        $this->assertNull($producer->getTimeToLive());
+    }
+
     /**
      * @return MockObject|Pheanstalk
      */


### PR DESCRIPTION
I could not take advantage of the `MultiplierRetryStrategy` built in to the Symfony Messenger component, because the Pheanstalk producer did not fully implement the `setDeliveryDelay` method (see also #821). Even though I only needed the delay, I went ahead and fully implemented the priority and time to live functionality of the `Producer` interface as well.

The code changes in the PR essentially do three things:

1.  ensures that “delivery delay” and “time to live” are set as milliseconds on the producer but passed to the transport as seconds; 
2. ensures that the respective message values are used when priority, delay or TTL is null; and
3. ensures that any producer values do not persist for more than one send.

Each of these points has test coverage.