### PR TITLE
Add Async Aws

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,8 @@
     "datadog/php-datadogstatsd": "^1.3"
   },
   "require-dev": {
+    "async-aws/sns": "^0.5.0",
+    "async-aws/sqs": "^1.0.0",
     "phpunit/phpunit": "^7.5",
     "phpstan/phpstan": "^0.12",
     "queue-interop/queue-spec": "^0.6",

--- a/docs/transport/sqs.md
+++ b/docs/transport/sqs.md
@@ -44,7 +44,7 @@ $factory = new SqsConnectionFactory('sqs:?key=aKey&secret=aSecret&region=aRegion
 $context = $factory->createContext();
 
 // using a pre-configured client
-$client = new Aws\Sqs\SqsClient([ /* ... */ ]);
+$client = new AsyncAws\Sqs\SqsClient([ /* ... */ ]);
 $factory = new SqsConnectionFactory($client);
 
 // if you have enqueue/enqueue library installed you can use a factory to build context from DSN

--- a/pkg/enqueue-bundle/Tests/Functional/App/config/custom-config.yml
+++ b/pkg/enqueue-bundle/Tests/Functional/App/config/custom-config.yml
@@ -69,15 +69,13 @@ services:
 
     test.sqs_client:
         public: true
-        class: 'Aws\Sqs\SqsClient'
+        class: 'AsyncAws\Sqs\SqsClient'
         arguments:
             -
                 endpoint: '%env(AWS_SQS_ENDPOINT)%'
                 region: '%env(AWS_SQS_REGION)%'
-                version: '%env(AWS_SQS_VERSION)%'
-                credentials:
-                    key: '%env(AWS_SQS_KEY)%'
-                    secret: '%env(AWS_SQS_SECRET)%'
+                accessKeyId: '%env(AWS_SQS_KEY)%'
+                accessKeySecret: '%env(AWS_SQS_SECRET)%'
 
     test.sqs_custom_connection_factory_factory:
         class: 'Enqueue\Bundle\Tests\Functional\App\SqsCustomConnectionFactoryFactory'

--- a/pkg/sns/SnsAsyncClient.php
+++ b/pkg/sns/SnsAsyncClient.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enqueue\Sns;
+
+use AsyncAws\Sns\Result\CreateTopicResponse;
+use AsyncAws\Sns\Result\ListSubscriptionsByTopicResponse;
+use AsyncAws\Sns\Result\PublishResponse;
+use AsyncAws\Sns\Result\SubscribeResponse;
+use AsyncAws\Sns\SnsClient as AwsSnsClient;
+
+/**
+ * @internal
+ */
+class SnsAsyncClient
+{
+    private $client;
+
+    public function __construct(AwsSnsClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function createTopic(array $args): CreateTopicResponse
+    {
+        return $this->client->CreateTopic($args);
+    }
+
+    public function deleteTopic(string $topicArn): void
+    {
+        $this->client->DeleteTopic([
+            'TopicArn' => $topicArn,
+        ]);
+    }
+
+    public function publish(array $args): PublishResponse
+    {
+        return $this->client->Publish($args);
+    }
+
+    public function subscribe(array $args): SubscribeResponse
+    {
+        return $this->client->Subscribe($args);
+    }
+
+    public function unsubscribe(array $args): void
+    {
+        $this->client->Unsubscribe($args);
+    }
+
+    public function listSubscriptionsByTopic(array $args): ListSubscriptionsByTopicResponse
+    {
+        return $this->client->ListSubscriptionsByTopic($args);
+    }
+}

--- a/pkg/sns/SnsContext.php
+++ b/pkg/sns/SnsContext.php
@@ -128,7 +128,7 @@ class SnsContext implements Context
 
     public function getTopicArn(SnsDestination $destination): string
     {
-        if (false == array_key_exists($destination->getTopicName(), $this->topicArns)) {
+        if (!array_key_exists($destination->getTopicName(), $this->topicArns)) {
             $this->declareTopic($destination);
         }
 

--- a/pkg/sns/SnsProducer.php
+++ b/pkg/sns/SnsProducer.php
@@ -79,11 +79,7 @@ class SnsProducer implements Producer
 
         $result = $this->context->getSnsClient()->publish($arguments);
 
-        if (false == $result->hasKey('MessageId')) {
-            throw new \RuntimeException('Message was not sent');
-        }
-
-        $message->setSnsMessageId((string) $result->get('MessageId'));
+        $message->setSnsMessageId($result->getMessageId());
     }
 
     /**

--- a/pkg/sns/Tests/SnsAsyncClientTest.php
+++ b/pkg/sns/Tests/SnsAsyncClientTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Enqueue\Sns\Tests;
+
+use AsyncAws\Core\Result;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sns\Result\CreateTopicResponse;
+use AsyncAws\Sns\Result\PublishResponse;
+use AsyncAws\Sns\SnsClient as AwsSnsClient;
+use Enqueue\Sns\SnsAsyncClient;
+use PHPUnit\Framework\TestCase;
+
+class SnsAsyncClientTest extends TestCase
+{
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCall(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $expectedResult = ResultMockFactory::create(...$result);
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($args))
+            ->willReturn($expectedResult);
+
+        $client = new SnsAsyncClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        if ($actualResult !== null || !$expectedResult instanceof Result) {
+            $this->assertInstanceOf(Result::class, $actualResult);
+            $this->assertSame($expectedResult, $actualResult);
+        }
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithMultiClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $args['@region'] = 'theRegion';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $expectedResult = ResultMockFactory::create(...$result);
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($args))
+            ->willReturn($expectedResult);
+
+        $client = new SnsAsyncClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        if ($actualResult !== null || !$expectedResult instanceof Result) {
+            $this->assertInstanceOf(Result::class, $actualResult);
+            $this->assertSame($expectedResult, $actualResult);
+        }
+    }
+
+    public function provideApiCallsSingleClient()
+    {
+        yield [
+            'createTopic',
+            ['fooArg' => 'fooArgVal'],
+            [CreateTopicResponse::class, []],
+            AwsSnsClient::class,
+        ];
+
+        yield [
+            'publish',
+            ['fooArg' => 'fooArgVal'],
+            [PublishResponse::class, []],
+            AwsSnsClient::class,
+        ];
+    }
+}

--- a/pkg/sns/Tests/SnsClientTest.php
+++ b/pkg/sns/Tests/SnsClientTest.php
@@ -2,11 +2,10 @@
 
 namespace Enqueue\Sns\Tests;
 
-use AsyncAws\Core\Result;
-use AsyncAws\Core\Test\ResultMockFactory;
-use AsyncAws\Sns\Result\CreateTopicResponse;
-use AsyncAws\Sns\Result\PublishResponse;
-use AsyncAws\Sns\SnsClient as AwsSnsClient;
+use Aws\MultiRegionClient;
+use Aws\Result;
+use Aws\Sdk;
+use Aws\Sns\SnsClient as AwsSnsClient;
 use Enqueue\Sns\SnsClient;
 use PHPUnit\Framework\TestCase;
 
@@ -14,17 +13,39 @@ class SnsClientTest extends TestCase
 {
     public function testShouldAllowGetAwsClientIfSingleClientProvided()
     {
-        $awsClient = new AwsSnsClient([
+        $awsClient = (new Sdk(['Sns' => [
+            'key' => '',
+            'secret' => '',
+            'token' => '',
+            'region' => '',
+            'version' => '2010-03-31',
             'endpoint' => 'http://localhost',
-        ]);
+        ]]))->createSns();
 
         $client = new SnsClient($awsClient);
 
         $this->assertSame($awsClient, $client->getAWSClient());
     }
 
+    public function testShouldAllowGetAwsClientIfMultipleClientProvided()
+    {
+        $awsClient = (new Sdk(['Sns' => [
+            'key' => '',
+            'secret' => '',
+            'token' => '',
+            'region' => '',
+            'version' => '2010-03-31',
+            'endpoint' => 'http://localhost',
+        ]]))->createMultiRegionSns();
+
+        $client = new SnsClient($awsClient);
+
+        $this->assertInstanceOf(AwsSnsClient::class, $client->getAWSClient());
+    }
+
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
@@ -32,25 +53,23 @@ class SnsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
-        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn($expectedResult);
+            ->willReturn(new Result($result));
 
         $client = new SnsClient($awsClient);
 
         $actualResult = $client->{$method}($args);
 
-        if ($actualResult !== null || !$expectedResult instanceof Result) {
-            $this->assertInstanceOf(Result::class, $actualResult);
-            $this->assertSame($expectedResult, $actualResult);
-        }
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testLazyApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
@@ -58,12 +77,11 @@ class SnsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
-        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn($expectedResult);
+            ->willReturn(new Result($result));
 
         $client = new SnsClient(function () use ($awsClient) {
             return $awsClient;
@@ -71,38 +89,38 @@ class SnsClientTest extends TestCase
 
         $actualResult = $client->{$method}($args);
 
-        if ($actualResult !== null || !$expectedResult instanceof Result) {
-            $this->assertInstanceOf(Result::class, $actualResult);
-            $this->assertSame($expectedResult, $actualResult);
-        }
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testThrowIfInvalidInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
         $client = new SnsClient(new \stdClass());
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The input client must be an instance of "AsyncAws\Sns\SnsClient" or a callable that returns it. Got "stdClass"');
+        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sns\SnsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
         $client->{$method}($args);
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testThrowIfInvalidLazyInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
         $client = new SnsClient(function () { return new \stdClass(); });
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The input client must be an instance of "AsyncAws\Sns\SnsClient" or a callable that returns it. Got "stdClass"');
+        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sns\SnsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
         $client->{$method}($args);
     }
 
     /**
-     * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testApiCallWithMultiClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
     {
@@ -112,21 +130,67 @@ class SnsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
-        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn($expectedResult);
+            ->willReturn(new Result($result));
 
         $client = new SnsClient($awsClient);
 
         $actualResult = $client->{$method}($args);
 
-        if ($actualResult !== null || !$expectedResult instanceof Result) {
-            $this->assertInstanceOf(Result::class, $actualResult);
-            $this->assertSame($expectedResult, $actualResult);
-        }
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithSingleClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $args['@region'] = 'theRegion';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->never())
+            ->method($method)
+        ;
+
+        $client = new SnsClient($awsClient);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot send message to another region because transport is configured with single aws client');
+        $client->{$method}($args);
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithMultiClientAndEmptyCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $expectedArgs = $args;
+        $args['@region'] = '';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($expectedArgs))
+            ->willReturn(new Result($result));
+
+        $client = new SnsClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
     }
 
     public function provideApiCallsSingleClient()
@@ -134,15 +198,32 @@ class SnsClientTest extends TestCase
         yield [
             'createTopic',
             ['fooArg' => 'fooArgVal'],
-            [CreateTopicResponse::class, []],
+            ['bar' => 'barVal'],
             AwsSnsClient::class,
         ];
 
         yield [
             'publish',
             ['fooArg' => 'fooArgVal'],
-            [PublishResponse::class, []],
+            ['bar' => 'barVal'],
             AwsSnsClient::class,
+        ];
+    }
+
+    public function provideApiCallsMultipleClient()
+    {
+        yield [
+            'createTopic',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'publish',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
         ];
     }
 }

--- a/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
@@ -16,7 +16,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The config must be either an array of options, a DSN string, null or instance of Aws\Sns\SnsClient');
+        $this->expectExceptionMessage('The config must be either an array of options, a DSN string, null or instance of AsyncAws\Sns\SnsClient');
 
         new SnsConnectionFactory(new \stdClass());
     }
@@ -59,9 +59,9 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'version' => '2010-03-31',
                 'lazy' => true,
                 'endpoint' => null,
+                'profile' => null,
             ],
         ];
 
@@ -72,9 +72,9 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'version' => '2010-03-31',
                 'lazy' => true,
                 'endpoint' => null,
+                'profile' => null,
             ],
         ];
 
@@ -85,9 +85,9 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'version' => '2010-03-31',
                 'lazy' => true,
                 'endpoint' => null,
+                'profile' => null,
             ],
         ];
 
@@ -98,9 +98,9 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'version' => '2010-03-31',
                 'lazy' => false,
                 'endpoint' => null,
+                'profile' => null,
             ],
         ];
 
@@ -111,9 +111,9 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'version' => '2010-03-31',
                 'lazy' => false,
                 'endpoint' => null,
+                'profile' => null,
             ],
         ];
 
@@ -124,9 +124,9 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'version' => '2010-03-31',
                 'lazy' => false,
                 'endpoint' => null,
+                'profile' => null,
             ],
         ];
 
@@ -137,15 +137,16 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'token' => 'theToken',
                 'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
+                'profile' => 'theProfile',
             ],
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'version' => '2010-03-31',
                 'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
+                'profile' => 'theProfile',
             ],
         ];
     }

--- a/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
@@ -59,7 +59,6 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
             ],
@@ -72,7 +71,6 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
             ],
@@ -85,46 +83,42 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
             ],
         ];
 
         yield [
-            'sns:?key=theKey&secret=theSecret&token=theToken&lazy=0',
+            'sns:?key=theKey&secret=theSecret&token=theToken',
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
             ],
         ];
 
         yield [
-            ['dsn' => 'sns:?key=theKey&secret=theSecret&token=theToken&lazy=0'],
+            ['dsn' => 'sns:?key=theKey&secret=theSecret&token=theToken'],
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
             ],
         ];
 
         yield [
-            ['key' => 'theKey', 'secret' => 'theSecret', 'token' => 'theToken', 'lazy' => false],
+            ['key' => 'theKey', 'secret' => 'theSecret', 'token' => 'theToken'],
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
             ],
@@ -135,7 +129,6 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
-                'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
                 'profile' => 'theProfile',
             ],
@@ -144,7 +137,6 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
                 'profile' => 'theProfile',
             ],

--- a/pkg/sns/Tests/SnsConnectionFactoryTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Enqueue\Sns\Tests;
 
 use AsyncAws\Sns\SnsClient as AwsSnsClient;
-use Enqueue\Sns\SnsClient;
+use Enqueue\Sns\SnsAsyncClient;
 use Enqueue\Sns\SnsConnectionFactory;
 use Enqueue\Sns\SnsContext;
 use Enqueue\Test\ClassExtensionTrait;
@@ -24,7 +24,6 @@ class SnsConnectionFactoryTest extends TestCase
         $factory = new SnsConnectionFactory([]);
 
         $this->assertAttributeEquals([
-            'lazy' => true,
             'key' => null,
             'secret' => null,
             'token' => null,
@@ -39,7 +38,6 @@ class SnsConnectionFactoryTest extends TestCase
         $factory = new SnsConnectionFactory(['key' => 'theKey']);
 
         $this->assertAttributeEquals([
-            'lazy' => true,
             'key' => 'theKey',
             'secret' => null,
             'token' => null,
@@ -60,20 +58,7 @@ class SnsConnectionFactoryTest extends TestCase
         $this->assertInstanceOf(SnsContext::class, $context);
 
         $client = $this->readAttribute($context, 'client');
-        $this->assertInstanceOf(SnsClient::class, $client);
-        $this->assertAttributeSame($awsClient, 'inputClient', $client);
-    }
-
-    public function testShouldCreateLazyContext()
-    {
-        $factory = new SnsConnectionFactory(['lazy' => true]);
-
-        $context = $factory->createContext();
-
-        $this->assertInstanceOf(SnsContext::class, $context);
-
-        $client = $this->readAttribute($context, 'client');
-        $this->assertInstanceOf(SnsClient::class, $client);
-        $this->assertAttributeInstanceOf(\Closure::class, 'inputClient', $client);
+        $this->assertInstanceOf(SnsAsyncClient::class, $client);
+        $this->assertAttributeSame($awsClient, 'client', $client);
     }
 }

--- a/pkg/sns/Tests/SnsConnectionFactoryTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Enqueue\Sns\Tests;
 
-use Aws\Sns\SnsClient as AwsSnsClient;
+use AsyncAws\Sns\SnsClient as AwsSnsClient;
 use Enqueue\Sns\SnsClient;
 use Enqueue\Sns\SnsConnectionFactory;
 use Enqueue\Sns\SnsContext;
@@ -29,8 +29,8 @@ class SnsConnectionFactoryTest extends TestCase
             'secret' => null,
             'token' => null,
             'region' => null,
-            'version' => '2010-03-31',
             'endpoint' => null,
+            'profile' => null,
         ], 'config', $factory);
     }
 
@@ -44,8 +44,8 @@ class SnsConnectionFactoryTest extends TestCase
             'secret' => null,
             'token' => null,
             'region' => null,
-            'version' => '2010-03-31',
             'endpoint' => null,
+            'profile' => null,
         ], 'config', $factory);
     }
 

--- a/pkg/sns/Tests/SnsProducerTest.php
+++ b/pkg/sns/Tests/SnsProducerTest.php
@@ -2,10 +2,9 @@
 
 namespace Enqueue\Sns\Tests;
 
-use AsyncAws\Core\Result;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\Sns\Result\PublishResponse;
-use Enqueue\Sns\SnsClient;
+use Enqueue\Sns\SnsAsyncClient;
 use Enqueue\Sns\SnsContext;
 use Enqueue\Sns\SnsDestination;
 use Enqueue\Sns\SnsMessage;
@@ -243,10 +242,10 @@ class SnsProducerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|SnsClient
+     * @return \PHPUnit\Framework\MockObject\MockObject|SnsAsyncClient
      */
-    private function createSnsClientMock(): SnsClient
+    private function createSnsClientMock(): SnsAsyncClient
     {
-        return $this->createMock(SnsClient::class);
+        return $this->createMock(SnsAsyncClient::class);
     }
 }

--- a/pkg/sns/Tests/SnsProducerTest.php
+++ b/pkg/sns/Tests/SnsProducerTest.php
@@ -2,7 +2,9 @@
 
 namespace Enqueue\Sns\Tests;
 
-use Aws\Result;
+use AsyncAws\Core\Result;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sns\Result\PublishResponse;
 use Enqueue\Sns\SnsClient;
 use Enqueue\Sns\SnsContext;
 use Enqueue\Sns\SnsDestination;
@@ -62,7 +64,7 @@ class SnsProducerTest extends TestCase
         $client
             ->expects($this->once())
             ->method('publish')
-            ->willReturn(new Result())
+            ->willReturn(ResultMockFactory::createFailing(PublishResponse::class, 400))
         ;
 
         $context = $this->createSnsContextMock();
@@ -81,7 +83,7 @@ class SnsProducerTest extends TestCase
         $message = new SnsMessage('foo');
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Message was not sent');
+        $this->expectExceptionMessageRegExp('/HTTP 400 returned/');
 
         $producer = new SnsProducer($context);
         $producer->send($destination, $message);
@@ -149,7 +151,7 @@ class SnsProducerTest extends TestCase
             ->expects($this->once())
             ->method('publish')
             ->with($this->identicalTo($expectedArguments))
-            ->willReturn(new Result(['MessageId' => 'theMessageId']))
+            ->willReturn(ResultMockFactory::create(PublishResponse::class, ['MessageId' => 'theMessageId']))
         ;
 
         $context = $this->createSnsContextMock();
@@ -211,7 +213,7 @@ class SnsProducerTest extends TestCase
             ->expects($this->once())
             ->method('publish')
             ->with($this->identicalTo($expectedArgument))
-            ->willReturn(new Result(['MessageId' => 'theMessageId']));
+            ->willReturn(ResultMockFactory::create(PublishResponse::class, ['MessageId' => 'theMessageId']));
 
         $attributes = [
             'Foo' => [

--- a/pkg/sns/Tests/Spec/SnsContextTest.php
+++ b/pkg/sns/Tests/Spec/SnsContextTest.php
@@ -2,7 +2,7 @@
 
 namespace Enqueue\Sns\Tests\Spec;
 
-use Enqueue\Sns\SnsClient;
+use Enqueue\Sns\SnsAsyncClient;
 use Enqueue\Sns\SnsContext;
 use Interop\Queue\Spec\ContextSpec;
 
@@ -18,7 +18,7 @@ class SnsContextTest extends ContextSpec
 
     protected function createContext()
     {
-        $client = $this->createMock(SnsClient::class);
+        $client = $this->createMock(SnsAsyncClient::class);
 
         return new SnsContext($client, []);
     }

--- a/pkg/sns/composer.json
+++ b/pkg/sns/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
-        "async-aws/sns": "^0.4"
+        "async-aws/sns": "^0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5",

--- a/pkg/sns/composer.json
+++ b/pkg/sns/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
-        "aws/aws-sdk-php": "~3.26"
+        "async-aws/sns": "^0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5",

--- a/pkg/snsqs/SnsQsConnectionFactory.php
+++ b/pkg/snsqs/SnsQsConnectionFactory.php
@@ -28,9 +28,9 @@ class SnsQsConnectionFactory implements ConnectionFactory
      *   'secret' => null,            AWS credentials. If no credentials are provided, the SDK will attempt to load them from the environment.
      *   'token' => null,             AWS credentials. If no credentials are provided, the SDK will attempt to load them from the environment.
      *   'region' => null,            (string, required) Region to connect to. See http://docs.aws.amazon.com/general/latest/gr/rande.html for a list of available regions.
-     *   'version' => '2012-11-05',   (string, required) The version of the webservice to utilize
      *   'lazy' => true,              Enable lazy connection (boolean)
      *   'endpoint' => null           (string, default=null) The full URI of the webservice. This is only required when connecting to a custom endpoint e.g. localstack
+     *   'profile' => null,           (string, default=null) The name of an AWS profile to used, if provided the SDK will attempt to read associated credentials from the ~/.aws/credentials file.
      * ].
      *
      * or
@@ -96,7 +96,7 @@ class SnsQsConnectionFactory implements ConnectionFactory
     {
         // set default options
         foreach ($options as $key => $value) {
-            if (false === in_array(substr($key, 0, 4), ['sns_', 'sqs_'], true)) {
+            if (!in_array(substr($key, 0, 4), ['sns_', 'sqs_'], true)) {
                 $this->snsConfig[$key] = $value;
                 $this->sqsConfig[$key] = $value;
             }

--- a/pkg/snsqs/SnsQsContext.php
+++ b/pkg/snsqs/SnsQsContext.php
@@ -180,7 +180,7 @@ class SnsQsContext implements Context
     {
         if (null === $this->snsContext) {
             $context = call_user_func($this->snsContextFactory);
-            if (false == $context instanceof SnsContext) {
+            if (!$context instanceof SnsContext) {
                 throw new \LogicException(sprintf(
                     'The factory must return instance of %s. It returned %s',
                     SnsContext::class,
@@ -198,7 +198,7 @@ class SnsQsContext implements Context
     {
         if (null === $this->sqsContext) {
             $context = call_user_func($this->sqsContextFactory);
-            if (false == $context instanceof SqsContext) {
+            if (!$context instanceof SqsContext) {
                 throw new \LogicException(sprintf(
                     'The factory must return instance of %s. It returned %s',
                     SqsContext::class,

--- a/pkg/snsqs/SnsQsContext.php
+++ b/pkg/snsqs/SnsQsContext.php
@@ -163,7 +163,7 @@ class SnsQsContext implements Context
 
     public function unbind(SnsQsTopic $topic, SnsQsQueue $queue): void
     {
-        $this->getSnsContext()->unsubscibe(new SnsUnsubscribe(
+        $this->getSnsContext()->unsubscribe(new SnsUnsubscribe(
             $topic,
             $this->getSqsContext()->getQueueArn($queue),
             SnsSubscribe::PROTOCOL_SQS

--- a/pkg/snsqs/SnsQsProducer.php
+++ b/pkg/snsqs/SnsQsProducer.php
@@ -50,7 +50,7 @@ class SnsQsProducer implements Producer
     {
         InvalidMessageException::assertMessageInstanceOf($message, SnsQsMessage::class);
 
-        if (false == $destination instanceof SnsQsTopic && false == $destination instanceof SnsQsQueue) {
+        if (!$destination instanceof SnsQsTopic && !$destination instanceof SnsQsQueue) {
             throw new InvalidDestinationException(sprintf(
                 'The destination must be an instance of [%s|%s] but got %s.',
                 SnsQsTopic::class, SnsQsQueue::class,

--- a/pkg/snsqs/Tests/SnsQsProducerTest.php
+++ b/pkg/snsqs/Tests/SnsQsProducerTest.php
@@ -30,13 +30,14 @@ class SnsQsProducerTest extends TestCase
 
     public function testCouldBeConstructedWithRequiredArguments()
     {
-        new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
+        $producer = new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
+        $this->assertInstanceOf(SnsQsProducer::class, $producer);
     }
 
     public function testShouldThrowIfMessageIsInvalidType()
     {
         $this->expectException(InvalidMessageException::class);
-        $this->expectExceptionMessage('The message must be an instance of Enqueue\SnsQs\SnsQsMessage but it is Double\Message\P4');
+        $this->expectExceptionMessage('The message must be an instance of Enqueue\SnsQs\SnsQsMessage but it is Double\Message\P1');
 
         $producer = new SnsQsProducer($this->createSnsContextMock(), $this->createSqsContextMock());
 

--- a/pkg/sqs/SqsAsyncClient.php
+++ b/pkg/sqs/SqsAsyncClient.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enqueue\Sqs;
+
+use AsyncAws\Sqs\Result\CreateQueueResult;
+use AsyncAws\Sqs\Result\GetQueueAttributesResult;
+use AsyncAws\Sqs\Result\GetQueueUrlResult;
+use AsyncAws\Sqs\Result\ReceiveMessageResult;
+use AsyncAws\Sqs\Result\SendMessageResult;
+use AsyncAws\Sqs\SqsClient;
+
+/**
+ * @internal
+ */
+class SqsAsyncClient
+{
+    private $client;
+
+    public function __construct(SqsClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function deleteMessage(array $args): void
+    {
+        $this->client->deleteMessage($args);
+    }
+
+    public function receiveMessage(array $args): ReceiveMessageResult
+    {
+        return $this->client->receiveMessage($args);
+    }
+
+    public function changeMessageVisibility(array $args): void
+    {
+        $this->client->changeMessageVisibility($args);
+    }
+
+    public function purgeQueue(array $args): void
+    {
+        $this->client->purgeQueue($args);
+    }
+
+    public function getQueueUrl(array $args): GetQueueUrlResult
+    {
+        return $this->client->getQueueUrl($args);
+    }
+
+    public function getQueueAttributes(array $args): GetQueueAttributesResult
+    {
+        return $this->client->getQueueAttributes($args);
+    }
+
+    public function createQueue(array $args): CreateQueueResult
+    {
+        return $this->client->createQueue($args);
+    }
+
+    public function deleteQueue(array $args): void
+    {
+        $this->client->deleteQueue($args);
+    }
+
+    public function sendMessage(array $args): SendMessageResult
+    {
+        return $this->client->sendMessage($args);
+    }
+}

--- a/pkg/sqs/SqsProducer.php
+++ b/pkg/sqs/SqsProducer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Enqueue\Sqs;
 
+use AsyncAws\Core\Result;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Interop\Queue\Exception\InvalidMessageException;
@@ -71,7 +72,18 @@ class SqsProducer implements Producer
             $arguments['MessageGroupId'] = $message->getMessageGroupId();
         }
 
-        $this->context->getSqsClient()->sendMessage($arguments)->resolve();
+        $result = $this->context->getSqsClient()->sendMessage($arguments);
+
+        if ($result instanceof Result) {
+            $result->resolve();
+
+            return;
+        }
+
+        // @todo in 0.11 remove below code
+        if (false == $result->hasKey('MessageId')) {
+            throw new \RuntimeException('Message was not sent');
+        }
     }
 
     /**

--- a/pkg/sqs/SqsProducer.php
+++ b/pkg/sqs/SqsProducer.php
@@ -71,11 +71,7 @@ class SqsProducer implements Producer
             $arguments['MessageGroupId'] = $message->getMessageGroupId();
         }
 
-        $result = $this->context->getSqsClient()->sendMessage($arguments);
-
-        if (false == $result->hasKey('MessageId')) {
-            throw new \RuntimeException('Message was not sent');
-        }
+        $this->context->getSqsClient()->sendMessage($arguments)->resolve();
     }
 
     /**

--- a/pkg/sqs/Tests/AsyncSqsClientTest.php
+++ b/pkg/sqs/Tests/AsyncSqsClientTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Enqueue\Sqs\Tests;
+
+use AsyncAws\Core\Result;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sqs\Result\CreateQueueResult;
+use AsyncAws\Sqs\Result\GetQueueAttributesResult;
+use AsyncAws\Sqs\Result\GetQueueUrlResult;
+use AsyncAws\Sqs\Result\ReceiveMessageResult;
+use AsyncAws\Sqs\Result\SendMessageResult;
+use AsyncAws\Sqs\SqsClient as AwsSqsClient;
+use Enqueue\Sqs\SqsAsyncClient;
+use PHPUnit\Framework\TestCase;
+
+class AsyncSqsClientTest extends TestCase
+{
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCall(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $expectedResult = ResultMockFactory::create(...$result);
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($args))
+            ->willReturn($expectedResult);
+
+        $client = new SqsAsyncClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        if ($actualResult !== null || !$expectedResult instanceof Result) {
+            $this->assertInstanceOf(Result::class, $actualResult);
+            $this->assertSame($expectedResult, $actualResult);
+        }
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $args['@region'] = 'theRegion';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $expectedResult = ResultMockFactory::create(...$result);
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($args))
+            ->willReturn($expectedResult);
+
+        $client = new SqsAsyncClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        if ($actualResult !== null || !$expectedResult instanceof Result) {
+            $this->assertInstanceOf(Result::class, $actualResult);
+            $this->assertSame($expectedResult, $actualResult);
+        }
+    }
+
+    public function provideApiCallsSingleClient()
+    {
+        yield [
+            'deleteMessage',
+            ['fooArg' => 'fooArgVal'],
+            [Result::class, []],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'receiveMessage',
+            ['fooArg' => 'fooArgVal'],
+            [ReceiveMessageResult::class, []],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'purgeQueue',
+            ['fooArg' => 'fooArgVal'],
+            [Result::class, []],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'getQueueUrl',
+            ['fooArg' => 'fooArgVal'],
+            [GetQueueUrlResult::class, []],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'getQueueAttributes',
+            ['fooArg' => 'fooArgVal'],
+            [GetQueueAttributesResult::class, []],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'createQueue',
+            ['fooArg' => 'fooArgVal'],
+            [CreateQueueResult::class, []],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'deleteQueue',
+            ['fooArg' => 'fooArgVal'],
+            [Result::class, []],
+            AwsSqsClient::class,
+        ];
+
+        yield [
+            'sendMessage',
+            ['fooArg' => 'fooArgVal'],
+            [SendMessageResult::class, []],
+            AwsSqsClient::class,
+        ];
+    }
+}

--- a/pkg/sqs/Tests/SqsClientTest.php
+++ b/pkg/sqs/Tests/SqsClientTest.php
@@ -2,10 +2,14 @@
 
 namespace Enqueue\Sqs\Tests;
 
-use Aws\MultiRegionClient;
-use Aws\Result;
-use Aws\Sdk;
-use Aws\Sqs\SqsClient as AwsSqsClient;
+use AsyncAws\Core\Result;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sqs\Result\CreateQueueResult;
+use AsyncAws\Sqs\Result\GetQueueAttributesResult;
+use AsyncAws\Sqs\Result\GetQueueUrlResult;
+use AsyncAws\Sqs\Result\ReceiveMessageResult;
+use AsyncAws\Sqs\Result\SendMessageResult;
+use AsyncAws\Sqs\SqsClient as AwsSqsClient;
 use Enqueue\Sqs\SqsClient;
 use PHPUnit\Framework\TestCase;
 
@@ -13,39 +17,17 @@ class SqsClientTest extends TestCase
 {
     public function testShouldAllowGetAwsClientIfSingleClientProvided()
     {
-        $awsClient = (new Sdk(['Sqs' => [
-            'key' => '',
-            'secret' => '',
-            'token' => '',
-            'region' => '',
-            'version' => '2012-11-05',
+        $awsClient = new AwsSqsClient([
             'endpoint' => 'http://localhost',
-        ]]))->createSqs();
+        ]);
 
         $client = new SqsClient($awsClient);
 
         $this->assertSame($awsClient, $client->getAWSClient());
     }
 
-    public function testShouldAllowGetAwsClientIfMultipleClientProvided()
-    {
-        $awsClient = (new Sdk(['Sqs' => [
-            'key' => '',
-            'secret' => '',
-            'token' => '',
-            'region' => '',
-            'version' => '2012-11-05',
-            'endpoint' => 'http://localhost',
-        ]]))->createMultiRegionSqs();
-
-        $client = new SqsClient($awsClient);
-
-        $this->assertInstanceOf(AwsSqsClient::class, $client->getAWSClient());
-    }
-
     /**
      * @dataProvider provideApiCallsSingleClient
-     * @dataProvider provideApiCallsMultipleClient
      */
     public function testApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
@@ -53,23 +35,25 @@ class SqsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
+        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn(new Result($result));
+            ->willReturn($expectedResult);
 
         $client = new SqsClient($awsClient);
 
         $actualResult = $client->{$method}($args);
 
-        $this->assertInstanceOf(Result::class, $actualResult);
-        $this->assertSame($result, $actualResult->toArray());
+        if ($actualResult !== null || !$expectedResult instanceof Result) {
+            $this->assertInstanceOf(Result::class, $actualResult);
+            $this->assertSame($expectedResult, $actualResult);
+        }
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
-     * @dataProvider provideApiCallsMultipleClient
      */
     public function testLazyApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
@@ -77,11 +61,12 @@ class SqsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
+        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn(new Result($result));
+            ->willReturn($expectedResult);
 
         $client = new SqsClient(function () use ($awsClient) {
             return $awsClient;
@@ -89,40 +74,40 @@ class SqsClientTest extends TestCase
 
         $actualResult = $client->{$method}($args);
 
-        $this->assertInstanceOf(Result::class, $actualResult);
-        $this->assertSame($result, $actualResult->toArray());
+        if ($actualResult !== null || !$expectedResult instanceof Result) {
+            $this->assertInstanceOf(Result::class, $actualResult);
+            $this->assertSame($expectedResult, $actualResult);
+        }
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
-     * @dataProvider provideApiCallsMultipleClient
      */
     public function testThrowIfInvalidInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
         $client = new SqsClient(new \stdClass());
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sqs\SqsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
+        $this->expectExceptionMessage('The input client must be an instance of "AsyncAws\Sqs\SqsClient" or a callable that returns it. Got "stdClass"');
         $client->{$method}($args);
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
-     * @dataProvider provideApiCallsMultipleClient
      */
     public function testThrowIfInvalidLazyInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
         $client = new SqsClient(function () { return new \stdClass(); });
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sqs\SqsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
+        $this->expectExceptionMessage('The input client must be an instance of "AsyncAws\Sqs\SqsClient" or a callable that returns it. Got "stdClass"');
         $client->{$method}($args);
     }
 
     /**
-     * @dataProvider provideApiCallsMultipleClient
+     * @dataProvider provideApiCallsSingleClient
      */
-    public function testApiCallWithMultiClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    public function testApiCallWithCustomRegion(string $method, array $args, array $result, string $awsClientClass)
     {
         $args['@region'] = 'theRegion';
 
@@ -130,67 +115,21 @@ class SqsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
+        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn(new Result($result));
+            ->willReturn($expectedResult);
 
         $client = new SqsClient($awsClient);
 
         $actualResult = $client->{$method}($args);
 
-        $this->assertInstanceOf(Result::class, $actualResult);
-        $this->assertSame($result, $actualResult->toArray());
-    }
-
-    /**
-     * @dataProvider provideApiCallsSingleClient
-     */
-    public function testApiCallWithSingleClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
-    {
-        $args['@region'] = 'theRegion';
-
-        $awsClient = $this->getMockBuilder($awsClientClass)
-            ->disableOriginalConstructor()
-            ->setMethods([$method])
-            ->getMock();
-        $awsClient
-            ->expects($this->never())
-            ->method($method)
-        ;
-
-        $client = new SqsClient($awsClient);
-
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot send message to another region because transport is configured with single aws client');
-        $client->{$method}($args);
-    }
-
-    /**
-     * @dataProvider provideApiCallsSingleClient
-     */
-    public function testApiCallWithMultiClientAndEmptyCustomRegion(string $method, array $args, array $result, string $awsClientClass)
-    {
-        $expectedArgs = $args;
-        $args['@region'] = '';
-
-        $awsClient = $this->getMockBuilder($awsClientClass)
-            ->disableOriginalConstructor()
-            ->setMethods([$method])
-            ->getMock();
-        $awsClient
-            ->expects($this->once())
-            ->method($method)
-            ->with($this->identicalTo($expectedArgs))
-            ->willReturn(new Result($result));
-
-        $client = new SqsClient($awsClient);
-
-        $actualResult = $client->{$method}($args);
-
-        $this->assertInstanceOf(Result::class, $actualResult);
-        $this->assertSame($result, $actualResult->toArray());
+        if ($actualResult !== null || !$expectedResult instanceof Result) {
+            $this->assertInstanceOf(Result::class, $actualResult);
+            $this->assertSame($expectedResult, $actualResult);
+        }
     }
 
     public function provideApiCallsSingleClient()
@@ -198,116 +137,57 @@ class SqsClientTest extends TestCase
         yield [
             'deleteMessage',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [Result::class, []],
             AwsSqsClient::class,
         ];
 
         yield [
             'receiveMessage',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [ReceiveMessageResult::class, []],
             AwsSqsClient::class,
         ];
 
         yield [
             'purgeQueue',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [Result::class, []],
             AwsSqsClient::class,
         ];
 
         yield [
             'getQueueUrl',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [GetQueueUrlResult::class, []],
             AwsSqsClient::class,
         ];
 
         yield [
             'getQueueAttributes',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [GetQueueAttributesResult::class, []],
             AwsSqsClient::class,
         ];
 
         yield [
             'createQueue',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [CreateQueueResult::class, []],
             AwsSqsClient::class,
         ];
 
         yield [
             'deleteQueue',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [Result::class, []],
             AwsSqsClient::class,
         ];
 
         yield [
             'sendMessage',
             ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
+            [SendMessageResult::class, []],
             AwsSqsClient::class,
-        ];
-    }
-
-    public function provideApiCallsMultipleClient()
-    {
-        yield [
-            'deleteMessage',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
-        ];
-
-        yield [
-            'receiveMessage',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
-        ];
-
-        yield [
-            'purgeQueue',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
-        ];
-
-        yield [
-            'getQueueUrl',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
-        ];
-
-        yield [
-            'getQueueAttributes',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
-        ];
-
-        yield [
-            'createQueue',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
-        ];
-
-        yield [
-            'deleteQueue',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
-        ];
-
-        yield [
-            'sendMessage',
-            ['fooArg' => 'fooArgVal'],
-            ['bar' => 'barVal'],
-            MultiRegionClient::class,
         ];
     }
 }

--- a/pkg/sqs/Tests/SqsClientTest.php
+++ b/pkg/sqs/Tests/SqsClientTest.php
@@ -2,14 +2,10 @@
 
 namespace Enqueue\Sqs\Tests;
 
-use AsyncAws\Core\Result;
-use AsyncAws\Core\Test\ResultMockFactory;
-use AsyncAws\Sqs\Result\CreateQueueResult;
-use AsyncAws\Sqs\Result\GetQueueAttributesResult;
-use AsyncAws\Sqs\Result\GetQueueUrlResult;
-use AsyncAws\Sqs\Result\ReceiveMessageResult;
-use AsyncAws\Sqs\Result\SendMessageResult;
-use AsyncAws\Sqs\SqsClient as AwsSqsClient;
+use Aws\MultiRegionClient;
+use Aws\Result;
+use Aws\Sdk;
+use Aws\Sqs\SqsClient as AwsSqsClient;
 use Enqueue\Sqs\SqsClient;
 use PHPUnit\Framework\TestCase;
 
@@ -17,17 +13,39 @@ class SqsClientTest extends TestCase
 {
     public function testShouldAllowGetAwsClientIfSingleClientProvided()
     {
-        $awsClient = new AwsSqsClient([
+        $awsClient = (new Sdk(['Sqs' => [
+            'key' => '',
+            'secret' => '',
+            'token' => '',
+            'region' => '',
+            'version' => '2012-11-05',
             'endpoint' => 'http://localhost',
-        ]);
+        ]]))->createSqs();
 
         $client = new SqsClient($awsClient);
 
         $this->assertSame($awsClient, $client->getAWSClient());
     }
 
+    public function testShouldAllowGetAwsClientIfMultipleClientProvided()
+    {
+        $awsClient = (new Sdk(['Sqs' => [
+            'key' => '',
+            'secret' => '',
+            'token' => '',
+            'region' => '',
+            'version' => '2012-11-05',
+            'endpoint' => 'http://localhost',
+        ]]))->createMultiRegionSqs();
+
+        $client = new SqsClient($awsClient);
+
+        $this->assertInstanceOf(AwsSqsClient::class, $client->getAWSClient());
+    }
+
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
@@ -35,25 +53,23 @@ class SqsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
-        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn($expectedResult);
+            ->willReturn(new Result($result));
 
         $client = new SqsClient($awsClient);
 
         $actualResult = $client->{$method}($args);
 
-        if ($actualResult !== null || !$expectedResult instanceof Result) {
-            $this->assertInstanceOf(Result::class, $actualResult);
-            $this->assertSame($expectedResult, $actualResult);
-        }
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testLazyApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
@@ -61,12 +77,11 @@ class SqsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
-        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn($expectedResult);
+            ->willReturn(new Result($result));
 
         $client = new SqsClient(function () use ($awsClient) {
             return $awsClient;
@@ -74,40 +89,40 @@ class SqsClientTest extends TestCase
 
         $actualResult = $client->{$method}($args);
 
-        if ($actualResult !== null || !$expectedResult instanceof Result) {
-            $this->assertInstanceOf(Result::class, $actualResult);
-            $this->assertSame($expectedResult, $actualResult);
-        }
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testThrowIfInvalidInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
         $client = new SqsClient(new \stdClass());
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The input client must be an instance of "AsyncAws\Sqs\SqsClient" or a callable that returns it. Got "stdClass"');
+        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sqs\SqsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
         $client->{$method}($args);
     }
 
     /**
      * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
     public function testThrowIfInvalidLazyInputClientApiCall(string $method, array $args, array $result, string $awsClientClass)
     {
         $client = new SqsClient(function () { return new \stdClass(); });
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The input client must be an instance of "AsyncAws\Sqs\SqsClient" or a callable that returns it. Got "stdClass"');
+        $this->expectExceptionMessage('The input client must be an instance of "Aws\Sqs\SqsClient" or "Aws\MultiRegionClient" or a callable that returns one of those. Got "stdClass"');
         $client->{$method}($args);
     }
 
     /**
-     * @dataProvider provideApiCallsSingleClient
+     * @dataProvider provideApiCallsMultipleClient
      */
-    public function testApiCallWithCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    public function testApiCallWithMultiClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
     {
         $args['@region'] = 'theRegion';
 
@@ -115,21 +130,67 @@ class SqsClientTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([$method])
             ->getMock();
-        $expectedResult = ResultMockFactory::create(...$result);
         $awsClient
             ->expects($this->once())
             ->method($method)
             ->with($this->identicalTo($args))
-            ->willReturn($expectedResult);
+            ->willReturn(new Result($result));
 
         $client = new SqsClient($awsClient);
 
         $actualResult = $client->{$method}($args);
 
-        if ($actualResult !== null || !$expectedResult instanceof Result) {
-            $this->assertInstanceOf(Result::class, $actualResult);
-            $this->assertSame($expectedResult, $actualResult);
-        }
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithSingleClientAndCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $args['@region'] = 'theRegion';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->never())
+            ->method($method)
+        ;
+
+        $client = new SqsClient($awsClient);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot send message to another region because transport is configured with single aws client');
+        $client->{$method}($args);
+    }
+
+    /**
+     * @dataProvider provideApiCallsSingleClient
+     */
+    public function testApiCallWithMultiClientAndEmptyCustomRegion(string $method, array $args, array $result, string $awsClientClass)
+    {
+        $expectedArgs = $args;
+        $args['@region'] = '';
+
+        $awsClient = $this->getMockBuilder($awsClientClass)
+            ->disableOriginalConstructor()
+            ->setMethods([$method])
+            ->getMock();
+        $awsClient
+            ->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($expectedArgs))
+            ->willReturn(new Result($result));
+
+        $client = new SqsClient($awsClient);
+
+        $actualResult = $client->{$method}($args);
+
+        $this->assertInstanceOf(Result::class, $actualResult);
+        $this->assertSame($result, $actualResult->toArray());
     }
 
     public function provideApiCallsSingleClient()
@@ -137,57 +198,116 @@ class SqsClientTest extends TestCase
         yield [
             'deleteMessage',
             ['fooArg' => 'fooArgVal'],
-            [Result::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
         ];
 
         yield [
             'receiveMessage',
             ['fooArg' => 'fooArgVal'],
-            [ReceiveMessageResult::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
         ];
 
         yield [
             'purgeQueue',
             ['fooArg' => 'fooArgVal'],
-            [Result::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
         ];
 
         yield [
             'getQueueUrl',
             ['fooArg' => 'fooArgVal'],
-            [GetQueueUrlResult::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
         ];
 
         yield [
             'getQueueAttributes',
             ['fooArg' => 'fooArgVal'],
-            [GetQueueAttributesResult::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
         ];
 
         yield [
             'createQueue',
             ['fooArg' => 'fooArgVal'],
-            [CreateQueueResult::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
         ];
 
         yield [
             'deleteQueue',
             ['fooArg' => 'fooArgVal'],
-            [Result::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
         ];
 
         yield [
             'sendMessage',
             ['fooArg' => 'fooArgVal'],
-            [SendMessageResult::class, []],
+            ['bar' => 'barVal'],
             AwsSqsClient::class,
+        ];
+    }
+
+    public function provideApiCallsMultipleClient()
+    {
+        yield [
+            'deleteMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'receiveMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'purgeQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'getQueueUrl',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'getQueueAttributes',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'createQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'deleteQueue',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
+        ];
+
+        yield [
+            'sendMessage',
+            ['fooArg' => 'fooArgVal'],
+            ['bar' => 'barVal'],
+            MultiRegionClient::class,
         ];
     }
 }

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -16,7 +16,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The config must be either an array of options, a DSN string, null or instance of Aws\Sqs\SqsClient');
+        $this->expectExceptionMessage('The config must be either an array of options, a DSN string, null or instance of AsyncAws\Sqs\SqsClient');
 
         new SqsConnectionFactory(new \stdClass());
     }
@@ -59,8 +59,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
@@ -75,8 +73,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
@@ -91,8 +87,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
@@ -107,8 +101,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
@@ -123,8 +115,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
@@ -139,8 +129,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => null,
                 'profile' => 'staging',
@@ -155,8 +143,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
@@ -177,8 +163,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
                 'profile' => null,
@@ -195,8 +179,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'retries' => 3,
-                'version' => '2012-11-05',
                 'lazy' => true,
                 'endpoint' => null,
                 'profile' => 'staging',

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -59,7 +59,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
@@ -73,7 +72,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
@@ -87,7 +85,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => true,
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
@@ -95,13 +92,12 @@ class SqsConnectionFactoryConfigTest extends TestCase
         ];
 
         yield [
-            'sqs:?key=theKey&secret=theSecret&token=theToken&lazy=0',
+            'sqs:?key=theKey&secret=theSecret&token=theToken',
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
@@ -109,13 +105,12 @@ class SqsConnectionFactoryConfigTest extends TestCase
         ];
 
         yield [
-            ['dsn' => 'sqs:?key=theKey&secret=theSecret&token=theToken&lazy=0'],
+            ['dsn' => 'sqs:?key=theKey&secret=theSecret&token=theToken'],
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
@@ -123,13 +118,12 @@ class SqsConnectionFactoryConfigTest extends TestCase
         ];
 
         yield [
-            ['dsn' => 'sqs:?profile=staging&lazy=0'],
+            ['dsn' => 'sqs:?profile=staging'],
             [
                 'key' => null,
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => null,
                 'profile' => 'staging',
                 'queue_owner_aws_account_id' => null,
@@ -137,13 +131,12 @@ class SqsConnectionFactoryConfigTest extends TestCase
         ];
 
         yield [
-            ['key' => 'theKey', 'secret' => 'theSecret', 'token' => 'theToken', 'lazy' => false],
+            ['key' => 'theKey', 'secret' => 'theSecret', 'token' => 'theToken'],
             [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
@@ -155,7 +148,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
-                'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
             ],
             [
@@ -163,7 +155,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => 'theSecret',
                 'token' => 'theToken',
                 'region' => null,
-                'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
@@ -179,7 +170,6 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'secret' => null,
                 'token' => null,
                 'region' => null,
-                'lazy' => true,
                 'endpoint' => null,
                 'profile' => 'staging',
                 'queue_owner_aws_account_id' => null,

--- a/pkg/sqs/Tests/SqsConnectionFactoryTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryTest.php
@@ -2,8 +2,9 @@
 
 namespace Enqueue\Sqs\Tests;
 
+use AsyncAws\Sqs\SqsClient;
 use AsyncAws\Sqs\SqsClient as AwsSqsClient;
-use Enqueue\Sqs\SqsClient;
+use Enqueue\Sqs\SqsAsyncClient;
 use Enqueue\Sqs\SqsConnectionFactory;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Test\ClassExtensionTrait;
@@ -24,7 +25,6 @@ class SqsConnectionFactoryTest extends TestCase
         $factory = new SqsConnectionFactory([]);
 
         $this->assertAttributeEquals([
-            'lazy' => true,
             'key' => null,
             'secret' => null,
             'token' => null,
@@ -40,7 +40,6 @@ class SqsConnectionFactoryTest extends TestCase
         $factory = new SqsConnectionFactory(['key' => 'theKey']);
 
         $this->assertAttributeEquals([
-            'lazy' => true,
             'key' => 'theKey',
             'secret' => null,
             'token' => null,
@@ -62,20 +61,20 @@ class SqsConnectionFactoryTest extends TestCase
         $this->assertInstanceOf(SqsContext::class, $context);
 
         $client = $this->readAttribute($context, 'client');
-        $this->assertInstanceOf(SqsClient::class, $client);
-        $this->assertAttributeSame($awsClient, 'inputClient', $client);
+        $this->assertInstanceOf(SqsAsyncClient::class, $client);
+        $this->assertAttributeSame($awsClient, 'client', $client);
     }
 
     public function testShouldCreateLazyContext()
     {
-        $factory = new SqsConnectionFactory(['lazy' => true]);
+        $factory = new SqsConnectionFactory();
 
         $context = $factory->createContext();
 
         $this->assertInstanceOf(SqsContext::class, $context);
 
         $client = $this->readAttribute($context, 'client');
-        $this->assertInstanceOf(SqsClient::class, $client);
-        $this->assertAttributeInstanceOf(\Closure::class, 'inputClient', $client);
+        $this->assertInstanceOf(SqsAsyncClient::class, $client);
+        $this->assertAttributeInstanceOf(SqsClient::class, 'client', $client);
     }
 }

--- a/pkg/sqs/Tests/SqsConnectionFactoryTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Enqueue\Sqs\Tests;
 
-use Aws\Sqs\SqsClient as AwsSqsClient;
+use AsyncAws\Sqs\SqsClient as AwsSqsClient;
 use Enqueue\Sqs\SqsClient;
 use Enqueue\Sqs\SqsConnectionFactory;
 use Enqueue\Sqs\SqsContext;
@@ -29,8 +29,6 @@ class SqsConnectionFactoryTest extends TestCase
             'secret' => null,
             'token' => null,
             'region' => null,
-            'retries' => 3,
-            'version' => '2012-11-05',
             'endpoint' => null,
             'profile' => null,
             'queue_owner_aws_account_id' => null,
@@ -47,8 +45,6 @@ class SqsConnectionFactoryTest extends TestCase
             'secret' => null,
             'token' => null,
             'region' => null,
-            'retries' => 3,
-            'version' => '2012-11-05',
             'endpoint' => null,
             'profile' => null,
             'queue_owner_aws_account_id' => null,

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -2,7 +2,10 @@
 
 namespace Enqueue\Sqs\Tests;
 
-use Aws\Result;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sqs\Result\ReceiveMessageResult;
+use AsyncAws\Sqs\Result\SendMessageResult;
+use AsyncAws\Sqs\ValueObject\Message as AwsMessage;
 use Enqueue\Sqs\SqsClient;
 use Enqueue\Sqs\SqsConsumer;
 use Enqueue\Sqs\SqsContext;
@@ -26,7 +29,9 @@ class SqsConsumerTest extends TestCase
 
     public function testCouldBeConstructedWithRequiredArguments()
     {
-        new SqsConsumer($this->createContextMock(), new SqsDestination('queue'));
+        $consumer = new SqsConsumer($this->createContextMock(), new SqsDestination('queue'));
+
+        $this->assertInstanceOf(Consumer::class, $consumer);
     }
 
     public function testShouldReturnInstanceOfDestination()
@@ -313,7 +318,7 @@ class SqsConsumerTest extends TestCase
             ->expects($this->once())
             ->method('receiveMessage')
             ->with($this->identicalTo($expectedAttributes))
-            ->willReturn(new Result(['Messages' => [$expectedSqsMessage]]))
+            ->willReturn(ResultMockFactory::create(ReceiveMessageResult::class, ['Messages' => [AwsMessage::create($expectedSqsMessage)]]));
         ;
 
         $context = $this->createContextMock();
@@ -367,7 +372,7 @@ class SqsConsumerTest extends TestCase
             ->expects($this->once())
             ->method('receiveMessage')
             ->with($this->identicalTo($expectedAttributes))
-            ->willReturn(new Result(['Messages' => [[
+            ->willReturn(ResultMockFactory::create(ReceiveMessageResult::class, ['Messages' => [AwsMessage::create([
                 'Body' => 'The Body',
                 'ReceiptHandle' => 'The Receipt',
                 'MessageId' => 'theMessageId',
@@ -380,7 +385,7 @@ class SqsConsumerTest extends TestCase
                         'DataType' => 'String',
                     ],
                 ],
-            ]]]))
+            ])]]))
         ;
 
         $context = $this->createContextMock();
@@ -425,7 +430,7 @@ class SqsConsumerTest extends TestCase
             ->expects($this->once())
             ->method('receiveMessage')
             ->with($this->identicalTo($expectedAttributes))
-            ->willReturn(new Result())
+            ->willReturn(ResultMockFactory::create(ReceiveMessageResult::class))
         ;
 
         $context = $this->createContextMock();

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -6,7 +6,7 @@ use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
 use AsyncAws\Sqs\Result\SendMessageResult;
 use AsyncAws\Sqs\ValueObject\Message as AwsMessage;
-use Enqueue\Sqs\SqsClient;
+use Enqueue\Sqs\SqsAsyncClient;
 use Enqueue\Sqs\SqsConsumer;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
@@ -464,11 +464,11 @@ class SqsConsumerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|SqsClient
+     * @return \PHPUnit\Framework\MockObject\MockObject|SqsAsyncClient
      */
-    private function createSqsClientMock(): SqsClient
+    private function createSqsClientMock(): SqsAsyncClient
     {
-        return $this->createMock(SqsClient::class);
+        return $this->createMock(SqsAsyncClient::class);
     }
 
     /**

--- a/pkg/sqs/Tests/SqsContextTest.php
+++ b/pkg/sqs/Tests/SqsContextTest.php
@@ -9,7 +9,7 @@ use AsyncAws\Sqs\Result\GetQueueAttributesResult;
 use AsyncAws\Sqs\Result\GetQueueUrlResult;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
 use AsyncAws\Sqs\Result\SendMessageResult;
-use Enqueue\Sqs\SqsClient;
+use Enqueue\Sqs\SqsAsyncClient;
 use Enqueue\Sqs\SqsConsumer;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
@@ -420,10 +420,10 @@ class SqsContextTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|SqsClient
+     * @return \PHPUnit\Framework\MockObject\MockObject|SqsAsyncClient
      */
-    private function createSqsClientMock(): SqsClient
+    private function createSqsClientMock(): SqsAsyncClient
     {
-        return $this->createMock(SqsClient::class);
+        return $this->createMock(SqsAsyncClient::class);
     }
 }

--- a/pkg/sqs/Tests/SqsContextTest.php
+++ b/pkg/sqs/Tests/SqsContextTest.php
@@ -2,7 +2,13 @@
 
 namespace Enqueue\Sqs\Tests;
 
-use Aws\Result;
+use AsyncAws\Core\Result;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sqs\Result\CreateQueueResult;
+use AsyncAws\Sqs\Result\GetQueueAttributesResult;
+use AsyncAws\Sqs\Result\GetQueueUrlResult;
+use AsyncAws\Sqs\Result\ReceiveMessageResult;
+use AsyncAws\Sqs\Result\SendMessageResult;
 use Enqueue\Sqs\SqsClient;
 use Enqueue\Sqs\SqsConsumer;
 use Enqueue\Sqs\SqsContext;
@@ -27,7 +33,9 @@ class SqsContextTest extends TestCase
 
     public function testCouldBeConstructedWithSqsClientAsFirstArgument()
     {
-        new SqsContext($this->createSqsClientMock(), []);
+        $context = new SqsContext($this->createSqsClientMock(), []);
+
+        $this->assertInstanceOf(SqsContext::class, $context);
     }
 
     public function testShouldAllowCreateEmptyMessage()
@@ -132,7 +140,7 @@ class SqsContextTest extends TestCase
                 'Attributes' => [],
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(CreateQueueResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -155,7 +163,7 @@ class SqsContextTest extends TestCase
                 'Attributes' => [],
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(CreateQueueResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -178,13 +186,13 @@ class SqsContextTest extends TestCase
                 '@region' => null,
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
         $sqsClient
             ->expects($this->once())
             ->method('deleteQueue')
             ->with($this->identicalTo(['QueueUrl' => 'theQueueUrl']))
-            ->willReturn(new Result())
+            ->willReturn(ResultMockFactory::create(Result::class))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -206,13 +214,13 @@ class SqsContextTest extends TestCase
                 '@region' => 'theRegion',
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
         $sqsClient
             ->expects($this->once())
             ->method('deleteQueue')
             ->with($this->identicalTo(['QueueUrl' => 'theQueueUrl']))
-            ->willReturn(new Result())
+            ->willReturn(ResultMockFactory::create(Result::class))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -235,7 +243,7 @@ class SqsContextTest extends TestCase
                 '@region' => null,
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
         $sqsClient
             ->expects($this->once())
@@ -244,7 +252,7 @@ class SqsContextTest extends TestCase
                 '@region' => null,
                 'QueueUrl' => 'theQueueUrl',
             ]))
-            ->willReturn(new Result())
+            ->willReturn(ResultMockFactory::create(Result::class))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -266,7 +274,7 @@ class SqsContextTest extends TestCase
                 '@region' => 'theRegion',
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
         $sqsClient
             ->expects($this->once())
@@ -275,7 +283,7 @@ class SqsContextTest extends TestCase
                 '@region' => 'theRegion',
                 'QueueUrl' => 'theQueueUrl',
             ]))
-            ->willReturn(new Result())
+            ->willReturn(ResultMockFactory::create(Result::class))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -298,7 +306,7 @@ class SqsContextTest extends TestCase
                 '@region' => null,
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -318,7 +326,7 @@ class SqsContextTest extends TestCase
                 '@region' => 'theRegion',
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
         $sqsClient
             ->expects($this->once())
@@ -328,7 +336,7 @@ class SqsContextTest extends TestCase
                 'QueueUrl' => 'theQueueUrl',
                 'AttributeNames' => ['QueueArn'],
             ]))
-            ->willReturn(new Result([
+            ->willReturn(ResultMockFactory::create(GetQueueAttributesResult::class, [
                 'Attributes' => [
                     'QueueArn' => 'theQueueArn',
                 ],
@@ -353,7 +361,7 @@ class SqsContextTest extends TestCase
                 '@region' => 'theRegion',
                 'QueueName' => 'aQueueName',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -377,7 +385,7 @@ class SqsContextTest extends TestCase
                 'QueueName' => 'aQueueName',
                 'QueueOwnerAWSAccountId' => 'anotherAWSAccountID',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -398,7 +406,7 @@ class SqsContextTest extends TestCase
                 'QueueName' => 'aQueueName',
                 'QueueOwnerAWSAccountId' => 'anotherAWSAccountID',
             ]))
-            ->willReturn(new Result(['QueueUrl' => 'theQueueUrl']))
+            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'theQueueUrl']))
         ;
 
         $context = new SqsContext($sqsClient, [
@@ -409,29 +417,6 @@ class SqsContextTest extends TestCase
         $queue->setQueueOwnerAWSAccountId('anotherAWSAccountID');
 
         $context->getQueueUrl($queue);
-    }
-
-    public function testShouldThrowExceptionIfGetQueueUrlResultHasNoQueueUrlProperty()
-    {
-        $sqsClient = $this->createSqsClientMock();
-        $sqsClient
-            ->expects($this->once())
-            ->method('getQueueUrl')
-            ->with($this->identicalTo([
-                '@region' => null,
-                'QueueName' => 'aQueueName',
-            ]))
-            ->willReturn(new Result([]))
-        ;
-
-        $context = new SqsContext($sqsClient, [
-            'queue_owner_aws_account_id' => null,
-        ]);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('QueueUrl cannot be resolved. queueName: "aQueueName"');
-
-        $context->getQueueUrl(new SqsDestination('aQueueName'));
     }
 
     /**

--- a/pkg/sqs/Tests/SqsProducerTest.php
+++ b/pkg/sqs/Tests/SqsProducerTest.php
@@ -5,7 +5,7 @@ namespace Enqueue\Sqs\Tests;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\Sqs\Result\CreateQueueResult;
 use AsyncAws\Sqs\Result\SendMessageResult;
-use Enqueue\Sqs\SqsClient;
+use Enqueue\Sqs\SqsAsyncClient;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
 use Enqueue\Sqs\SqsMessage;
@@ -233,10 +233,10 @@ class SqsProducerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|SqsClient
+     * @return \PHPUnit\Framework\MockObject\MockObject|SqsAsyncClient
      */
-    private function createSqsClientMock(): SqsClient
+    private function createSqsClientMock(): SqsAsyncClient
     {
-        return $this->createMock(SqsClient::class);
+        return $this->createMock(SqsAsyncClient::class);
     }
 }

--- a/pkg/sqs/Tests/SqsProducerTest.php
+++ b/pkg/sqs/Tests/SqsProducerTest.php
@@ -2,7 +2,9 @@
 
 namespace Enqueue\Sqs\Tests;
 
-use Aws\Result;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sqs\Result\CreateQueueResult;
+use AsyncAws\Sqs\Result\SendMessageResult;
 use Enqueue\Sqs\SqsClient;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Sqs\SqsDestination;
@@ -26,7 +28,9 @@ class SqsProducerTest extends TestCase
 
     public function testCouldBeConstructedWithRequiredArguments()
     {
-        new SqsProducer($this->createSqsContextMock());
+        $producer = new SqsProducer($this->createSqsContextMock());
+
+        $this->assertInstanceOf(SqsProducer::class, $producer);
     }
 
     public function testShouldThrowIfBodyOfInvalidType()
@@ -57,7 +61,7 @@ class SqsProducerTest extends TestCase
         $client
             ->expects($this->once())
             ->method('sendMessage')
-            ->willReturn(new Result())
+            ->willReturn(ResultMockFactory::createFailing(SendMessageResult::class, 400))
         ;
 
         $context = $this->createSqsContextMock();
@@ -76,7 +80,7 @@ class SqsProducerTest extends TestCase
         $message = new SqsMessage('foo');
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Message was not sent');
+        $this->expectExceptionMessageRegExp('/HTTP 400 returned/');
 
         $producer = new SqsProducer($context);
         $producer->send($destination, $message);
@@ -104,7 +108,7 @@ class SqsProducerTest extends TestCase
             ->expects($this->once())
             ->method('sendMessage')
             ->with($this->identicalTo($expectedArguments))
-            ->willReturn(new Result(['MessageId' => 'theMessageId']))
+            ->willReturn(ResultMockFactory::create(SendMessageResult::class, ['MessageId' => 'theMessageId']))
         ;
 
         $context = $this->createSqsContextMock();
@@ -148,7 +152,7 @@ class SqsProducerTest extends TestCase
             ->expects($this->once())
             ->method('sendMessage')
             ->with($this->identicalTo($expectedArguments))
-            ->willReturn(new Result(['MessageId' => 'theMessageId']))
+            ->willReturn(ResultMockFactory::create(SendMessageResult::class, ['MessageId' => 'theMessageId']))
         ;
 
         $context = $this->createSqsContextMock();
@@ -194,7 +198,7 @@ class SqsProducerTest extends TestCase
             ->expects($this->once())
             ->method('sendMessage')
             ->with($this->identicalTo($expectedArguments))
-            ->willReturn(new Result(['MessageId' => 'theMessageId']))
+            ->willReturn(ResultMockFactory::create(SendMessageResult::class, ['MessageId' => 'theMessageId']))
         ;
 
         $context = $this->createSqsContextMock();

--- a/pkg/sqs/composer.json
+++ b/pkg/sqs/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
-        "aws/aws-sdk-php": "~3.26"
+        "async-aws/sqs": "^0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5",

--- a/pkg/sqs/composer.json
+++ b/pkg/sqs/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
-        "async-aws/sqs": "^0.4"
+        "async-aws/sqs": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5",


### PR DESCRIPTION
This PR replaces the Official AWS Sdk by AsyncAws

The main benefit is the vendor weight (AWS sdk is more than 20Mb) and less memory footprint.
See other benefit on the documentation: https://async-aws.com/compare.html

It also simplify enqueue, by provising typehint on results, and natively handling pagination (see getSubscriptions for instance).
See the diff of this PR: ![Screenshot from 2020-04-12 15-45-05](https://user-images.githubusercontent.com/578547/79070223-a61c3980-7cd4-11ea-82da-62c787aa0df0.png)


this Lib is used in several well known projects:
- Bref (lambda): https://github.com/brefphp/bref/pull/575
- Flysystem (s3): https://github.com/thephpleague/flysystem-bundle/pull/43

soon
- Symfony Mailer (ses): https://github.com/symfony/symfony/pull/35992
- Symfony Messenger (sqs): https://github.com/symfony/symfony/pull/36094

This PR is WIP because need:
* [x] new release of AsyncAws to add support of needed methods (see https://github.com/async-aws/aws/pull/484)

This PR may be a BC Break if people inject their own AwsClient, please tell me how you suggest to deal with it?