### PR TITLE
Added: additional parameter for redelivery delay

### DIFF
--- a/pkg/redis/RedisConsumer.php
+++ b/pkg/redis/RedisConsumer.php
@@ -28,6 +28,11 @@ class RedisConsumer implements Consumer
      */
     private $redeliveryDelay = 300;
 
+    /**
+     * @var int
+     */
+    private $initialDelay = 300;
+
     public function __construct(RedisContext $context, RedisDestination $queue)
     {
         $this->context = $context;
@@ -42,12 +47,22 @@ class RedisConsumer implements Consumer
         return $this->redeliveryDelay;
     }
 
-    /**
-     * @param int $delay
-     */
     public function setRedeliveryDelay(int $delay): void
     {
         $this->redeliveryDelay = $delay;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInitialDelay(): ?int
+    {
+        return $this->initialDelay;
+    }
+
+    public function setInitialDelay(int $initialDelay): void
+    {
+        $this->initialDelay = $initialDelay;
     }
 
     /**
@@ -73,7 +88,7 @@ class RedisConsumer implements Consumer
             }
         }
 
-        return $this->receiveMessage([$this->queue], $timeout, $this->redeliveryDelay);
+        return $this->receiveMessage([$this->queue], $timeout, $this->initialDelay, $this->redeliveryDelay);
     }
 
     /**
@@ -81,7 +96,7 @@ class RedisConsumer implements Consumer
      */
     public function receiveNoWait(): ?Message
     {
-        return $this->receiveMessageNoWait($this->queue, $this->redeliveryDelay);
+        return $this->receiveMessageNoWait($this->queue, $this->initialDelay, $this->redeliveryDelay);
     }
 
     /**

--- a/pkg/redis/RedisSubscriptionConsumer.php
+++ b/pkg/redis/RedisSubscriptionConsumer.php
@@ -29,8 +29,10 @@ class RedisSubscriptionConsumer implements SubscriptionConsumer
     private $redeliveryDelay = 300;
 
     /**
-     * @param RedisContext $context
+     * @var int|null
      */
+    private $initialDelay;
+
     public function __construct(RedisContext $context)
     {
         $this->context = $context;
@@ -45,12 +47,22 @@ class RedisSubscriptionConsumer implements SubscriptionConsumer
         return $this->redeliveryDelay;
     }
 
-    /**
-     * @param int $delay
-     */
     public function setRedeliveryDelay(int $delay): void
     {
         $this->redeliveryDelay = $delay;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInitialDelay(): ?int
+    {
+        return $this->initialDelay;
+    }
+
+    public function setInitialDelay(int $initialDelay): void
+    {
+        $this->initialDelay = $initialDelay;
     }
 
     public function consume(int $timeout = 0): void
@@ -69,7 +81,7 @@ class RedisSubscriptionConsumer implements SubscriptionConsumer
         }
 
         while (true) {
-            if ($message = $this->receiveMessage($queues, $timeout ?: 5, $this->redeliveryDelay)) {
+            if ($message = $this->receiveMessage($queues, $timeout ?: 5, $this->initialDelay, $this->redeliveryDelay)) {
                 list($consumer, $callback) = $this->subscribers[$message->getKey()];
 
                 if (false === call_user_func($callback, $message, $consumer)) {

--- a/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
+++ b/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
@@ -91,6 +91,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'predis_options' => null,
                 'ssl' => null,
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -112,6 +113,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'predis_options' => null,
                 'ssl' => null,
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -133,6 +135,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'predis_options' => null,
                 'ssl' => null,
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -155,6 +158,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'ssl' => null,
                 'foo' => 'bar',
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -177,6 +181,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'ssl' => null,
                 'foo' => 'bar',
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -199,6 +204,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'ssl' => null,
                 'foo' => 'bar',
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -222,6 +228,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'ssl' => null,
                 'foo' => 'bar',
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -245,6 +252,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'ssl' => null,
                 'foo' => 'bar',
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -268,6 +276,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'ssl' => null,
                 'foo' => 'bar',
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -290,6 +299,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'ssl' => null,
                 'foo' => 'bar',
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -312,6 +322,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'predis_options' => null,
                 'ssl' => null,
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -334,6 +345,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'predis_options' => null,
                 'ssl' => null,
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -356,6 +368,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'predis_options' => null,
                 'ssl' => null,
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
 
@@ -382,6 +395,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
                     'verify_peer' => '1',
                 ],
                 'redelivery_delay' => 300,
+                'initial_delay' => null,
             ],
         ];
     }

--- a/pkg/redis/Tests/RedisContextTest.php
+++ b/pkg/redis/Tests/RedisContextTest.php
@@ -27,26 +27,26 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testCouldBeConstructedWithRedisAsFirstArgument()
     {
-        new RedisContext($this->createRedisMock(), 300);
+        new RedisContext($this->createRedisMock(), 300, 300);
     }
 
     public function testCouldBeConstructedWithRedisFactoryAsFirstArgument()
     {
         new RedisContext(function () {
             return $this->createRedisMock();
-        }, 300);
+        }, 300, 300);
     }
 
     public function testThrowIfNeitherRedisNorFactoryGiven()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The $redis argument must be either Enqueue\Redis\Redis or callable that returns Enqueue\Redis\Redis once called.');
-        new RedisContext(new \stdClass(), 300);
+        new RedisContext(new \stdClass(), 300, 300);
     }
 
     public function testShouldAllowCreateEmptyMessage()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $message = $context->createMessage();
 
@@ -59,7 +59,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldAllowCreateCustomMessage()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $message = $context->createMessage('theBody', ['aProp' => 'aPropVal'], ['aHeader' => 'aHeaderVal']);
 
@@ -72,7 +72,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateQueue()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $queue = $context->createQueue('aQueue');
 
@@ -82,7 +82,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldAllowCreateTopic()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $topic = $context->createTopic('aTopic');
 
@@ -92,7 +92,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testThrowNotImplementedOnCreateTmpQueueCall()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $this->expectException(TemporaryQueueNotSupportedException::class);
 
@@ -101,7 +101,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateProducer()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $producer = $context->createProducer();
 
@@ -110,7 +110,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldThrowIfNotRedisDestinationGivenOnCreateConsumer()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $this->expectException(InvalidDestinationException::class);
         $this->expectExceptionMessage('The destination must be an instance of Enqueue\Redis\RedisDestination but got Enqueue\Null\NullQueue.');
@@ -121,7 +121,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateConsumer()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $queue = $context->createQueue('aQueue');
 
@@ -138,7 +138,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
             ->method('disconnect')
         ;
 
-        $context = new RedisContext($redisMock, 300);
+        $context = new RedisContext($redisMock, 300, 300);
 
         $context->close();
     }
@@ -151,7 +151,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
             ->method('del')
         ;
 
-        $context = new RedisContext($redisMock, 300);
+        $context = new RedisContext($redisMock, 300, 300);
 
         $this->expectException(InvalidDestinationException::class);
         $context->deleteQueue(new NullQueue('aQueue'));
@@ -176,7 +176,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
             ->with('aQueueName:reserved')
         ;
 
-        $context = new RedisContext($redisMock, 300);
+        $context = new RedisContext($redisMock, 300, 300);
 
         $queue = $context->createQueue('aQueueName');
 
@@ -191,7 +191,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
             ->method('del')
         ;
 
-        $context = new RedisContext($redisMock, 300);
+        $context = new RedisContext($redisMock, 300, 300);
 
         $this->expectException(InvalidDestinationException::class);
         $context->deleteTopic(new NullTopic('aTopic'));
@@ -216,7 +216,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
             ->with('aTopicName:reserved')
         ;
 
-        $context = new RedisContext($redisMock, 300);
+        $context = new RedisContext($redisMock, 300, 300);
 
         $topic = $context->createTopic('aTopicName');
 
@@ -225,7 +225,7 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldReturnExpectedSubscriptionConsumerInstance()
     {
-        $context = new RedisContext($this->createRedisMock(), 300);
+        $context = new RedisContext($this->createRedisMock(), 300, 300);
 
         $this->assertInstanceOf(RedisSubscriptionConsumer::class, $context->createSubscriptionConsumer());
     }


### PR DESCRIPTION
This feature would introduce some more flexibility manipulating redelivery delays. For example, you know some messages might be slower to process than usual, but it can happen rarely so you don't want to increase the redelivery time for all the retries. By having this parameter you could set an initial redelivery time to be later, but also keep the regular `redelivery_delay` lower so it wouldn't affect all the retries.