### PR TITLE
chore: add typehint to RdKafkaConsumer#getQueue

### DIFF
--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -75,6 +75,9 @@ class RdKafkaConsumer implements Consumer
         $this->offset = $offset;
     }
 
+    /**
+     * @return RdKafkaTopic
+     */
     public function getQueue(): Queue
     {
         return $this->topic;


### PR DESCRIPTION
Prevent the vscode intelephense error : "Undefined method 'getPartition'."