### PR TITLE
Docs: update Supported Brokers

### DIFF
--- a/docs/client/supported_brokers.md
+++ b/docs/client/supported_brokers.md
@@ -12,20 +12,20 @@ Here's the list of transports supported by Enqueue Client:
 
 | Transport             | Package                                                    |  DSN                            |
 |:---------------------:|:----------------------------------------------------------:|:-------------------------------:|
+| AMQP, RabbitMQ        | [enqueue/amqp-ext](../transport/amqp.md)                   | amqp: amqp+ext:                 |
 | AMQP, RabbitMQ        | [enqueue/amqp-bunny](../transport/amqp_bunny.md)           | amqp: amqp+bunny:               |
 | AMQP, RabbitMQ        | [enqueue/amqp-lib](../transport/amqp_lib.md)               | amqp: amqp+lib: amqp+rabbitmq:  |
-| AMQP, RabbitMQ        | [enqueue/amqp-ext](../transport/amqp.md)                   | amqp: amqp+ext:                 |
 | Doctrine DBAL         | [enqueue/dbal](../transport/dbal.md)                       | mysql: pgsql: pdo_pgsql etc     |
 | Filesystem            | [enqueue/fs](../transport/fs.md)                           | file:///foo/bar                 |
 | Gearman               | [enqueue/gearman](../transport/gearman.md)                 | gearman:                        |
 | GPS, Google PubSub    | [enqueue/gps](../transport/gps.md)                         | gps:                            |
+| Kafka                 | [enqueue/rdkafka](../transport/kafka.md)                   | kafka:                          |
 | MongoDB               | [enqueue/mongodb](../transport/mongodb.md)                 | mongodb:                        |
+| Null                  | [enqueue/null](../transport/null.md)                       | null:                           |
 | Pheanstalk, Beanstalk | [enqueue/pheanstalk](../transport/pheanstalk.md)           | beanstalk:                      |
 | Redis                 | [enqueue/redis](../transport/redis.md)                     | redis:                          |
 | Amazon SQS            | [enqueue/sqs](../transport/sqs.md)                         | sqs:                            |
 | STOMP, RabbitMQ       | [enqueue/stomp](../transport/stomp.md)                     | stomp:                          |
-| Kafka                 | [enqueue/rdkafka](../transport/kafka.md)                   | kafka:                          |
-| Null                  | [enqueue/null](../transport/null.md)                       | null:                           |
 | WAMP                  | [enqueue/wamp](../transport/wamp.md)                       | wamp:                           |
 
 Here's the list of protocols and Client features supported by them
@@ -34,17 +34,17 @@ Here's the list of protocols and Client features supported by them
 |:--------------:|:--------:|:--------:|:----------:|:------------:|:-----------:|:---------:|
 | AMQP           |   No     |    No    |    Yes     |     Yes      |     Yes     |    No     |
 | RabbitMQ AMQP  |   Yes    |    Yes   |    Yes     |     Yes      |     Yes     |    Yes    |
-| STOMP          |   No     |    No    |    Yes     |     No       |     Yes**   |    No     |
-| RabbitMQ STOMP |   Yes    |    Yes   |    Yes     |     Yes***   |     Yes**   |    Yes    |
-| Filesystem     |   No     |    No    |    Yes     |     Yes      |     No      |    No     |
-| Redis          |   No     |    Yes   |    Yes     |  Not needed  |     No      |    No     |
 | Doctrine DBAL  |   Yes    |    Yes   |    No      |     Yes      |     No      |    No     |
-| Amazon SQS     |   No     |    Yes   |    No      |     Yes      |   Not impl  |    No     |
+| Filesystem     |   No     |    No    |    Yes     |     Yes      |     No      |    No     |
 | Gearman        |   No     |    No    |    No      |     No       |     No      |    No     |
-| Kafka          |   No     |    No    |    No      |     Yes      |     No      |    No     |
 | Google PubSub  | Not impl | Not impl |  Not impl  |     Yes      |   Not impl  |    No     |
+| Kafka          |   No     |    No    |    No      |     Yes      |     No      |    No     |
 | MongoDB        |   Yes    |    Yes   |    Yes     |     Yes      |     No      |    No     |
 | Pheanstalk     |   Yes    |    Yes   |    Yes     |     No       |     No      |    No     |
+| Redis          |   No     |    Yes   |    Yes     |  Not needed  |     No      |    No     |
+| Amazon SQS     |   No     |    Yes   |    No      |     Yes      |   Not impl  |    No     |
+| STOMP          |   No     |    No    |    Yes     |     No       |     Yes**   |    No     |
+| RabbitMQ STOMP |   Yes    |    Yes   |    Yes     |     Yes***   |     Yes**   |    Yes    |
 | WAMP           |   No     |    No    |    No      |     No       |     No      |    No     |
 
 * \*\* Possible if topics (exchanges) are configured on broker side manually.

--- a/docs/client/supported_brokers.md
+++ b/docs/client/supported_brokers.md
@@ -6,38 +6,46 @@ nav_order: 3
 ---
 {% include support.md %}
 
-# Client. Supported brokers
+# Client Supported brokers
 
 Here's the list of transports supported by Enqueue Client:
 
-| Transport           | Package                                                    |  DSN                            |
-|:-------------------:|:----------------------------------------------------------:|:-------------------------------:|
-| AMQP, RabbitMQ      | [enqueue/amqp-bunny](../transport/amqp_bunny.md)           | amqp: amqp+bunny:               |
-| AMQP, RabbitMQ      | [enqueue/amqp-lib](../transport/amqp_lib.md)               | amqp: amqp+lib: amqp+rabbitmq:  |
-| AMQP, RabbitMQ      | [enqueue/amqp-ext](../transport/amqp.md)                   | amqp: amqp+ext:                 |
-| Doctrine DBAL       | [enqueue/dbal](../transport/dbal.md)                       | mysql: pgsql: pdo_pgsql etc     |
-| Filesystem          | [enqueue/fs](../transport/fs.md)                           | file:///foo/bar                 |
-| Google PubSub       | [enqueue/gps](../transport/gps.md)                         | gps:                            |
-| Redis               | [enqueue/redis](../transport/redis.md)                     | redis:                          |
-| Amazon SQS          | [enqueue/sqs](../transport/sqs.md)                         | sqs:                            |
-| STOMP, RabbitMQ     | [enqueue/stomp](../transport/stomp.md)                     | stomp:                          |
-| Kafka               | [enqueue/rdkafka](../transport/kafka.md)                   | kafka:                          |
-| Null                | [enqueue/null](../transport/null.md)                       | null:                           |
+| Transport             | Package                                                    |  DSN                            |
+|:---------------------:|:----------------------------------------------------------:|:-------------------------------:|
+| AMQP, RabbitMQ        | [enqueue/amqp-bunny](../transport/amqp_bunny.md)           | amqp: amqp+bunny:               |
+| AMQP, RabbitMQ        | [enqueue/amqp-lib](../transport/amqp_lib.md)               | amqp: amqp+lib: amqp+rabbitmq:  |
+| AMQP, RabbitMQ        | [enqueue/amqp-ext](../transport/amqp.md)                   | amqp: amqp+ext:                 |
+| Doctrine DBAL         | [enqueue/dbal](../transport/dbal.md)                       | mysql: pgsql: pdo_pgsql etc     |
+| Filesystem            | [enqueue/fs](../transport/fs.md)                           | file:///foo/bar                 |
+| Gearman               | [enqueue/gearman](../transport/gearman.md)                 | gearman:                        |
+| GPS, Google PubSub    | [enqueue/gps](../transport/gps.md)                         | gps:                            |
+| MongoDB               | [enqueue/mongodb](../transport/mongodb.md)                 | mongodb:                        |
+| Pheanstalk, Beanstalk | [enqueue/pheanstalk](../transport/pheanstalk.md)           | beanstalk:                      |
+| Redis                 | [enqueue/redis](../transport/redis.md)                     | redis:                          |
+| Amazon SQS            | [enqueue/sqs](../transport/sqs.md)                         | sqs:                            |
+| STOMP, RabbitMQ       | [enqueue/stomp](../transport/stomp.md)                     | stomp:                          |
+| Kafka                 | [enqueue/rdkafka](../transport/kafka.md)                   | kafka:                          |
+| Null                  | [enqueue/null](../transport/null.md)                       | null:                           |
+| WAMP                  | [enqueue/wamp](../transport/wamp.md)                       | wamp:                           |
 
 Here's the list of protocols and Client features supported by them
 
-| Protocol       | Priority | Delay    | Expiration | Setup broker | Message bus |
-|:--------------:|:--------:|:--------:|:----------:|:------------:|:-----------:|
-| AMQP           |   No     |    No    |    Yes     |     Yes      |     Yes     |
-| RabbitMQ AMQP  |   Yes    |    Yes   |    Yes     |     Yes      |     Yes     |
-| STOMP          |   No     |    No    |    Yes     |     No       |     Yes**   |
-| RabbitMQ STOMP |   Yes    |    Yes   |    Yes     |     Yes***   |     Yes**   |
-| Filesystem     |   No     |    No    |    No      |     Yes      |     No      |
-| Redis          |   No     |    No    |    No      |  Not needed  |     No      |
-| Doctrine DBAL  |   Yes    |    Yes   |    No      |     Yes      |     No      |
-| Amazon SQS     |   No     |    Yes   |    No      |     Yes      |   Not impl  |
-| Kafka          |   No     |    No    |    No      |     Yes      |     No      |
-| Google PubSub  | Not impl | Not impl |  Not impl  |     Yes      |   Not impl  |
+| Protocol       | Priority | Delay    | Expiration | Setup broker | Message bus | Heartbeat |
+|:--------------:|:--------:|:--------:|:----------:|:------------:|:-----------:|:---------:|
+| AMQP           |   No     |    No    |    Yes     |     Yes      |     Yes     |    No     |
+| RabbitMQ AMQP  |   Yes    |    Yes   |    Yes     |     Yes      |     Yes     |    Yes    |
+| STOMP          |   No     |    No    |    Yes     |     No       |     Yes**   |    No     |
+| RabbitMQ STOMP |   Yes    |    Yes   |    Yes     |     Yes***   |     Yes**   |    Yes    |
+| Filesystem     |   No     |    No    |    Yes     |     Yes      |     No      |    No     |
+| Redis          |   No     |    Yes   |    Yes     |  Not needed  |     No      |    No     |
+| Doctrine DBAL  |   Yes    |    Yes   |    No      |     Yes      |     No      |    No     |
+| Amazon SQS     |   No     |    Yes   |    No      |     Yes      |   Not impl  |    No     |
+| Gearman        |   No     |    No    |    No      |     No       |     No      |    No     |
+| Kafka          |   No     |    No    |    No      |     Yes      |     No      |    No     |
+| Google PubSub  | Not impl | Not impl |  Not impl  |     Yes      |   Not impl  |    No     |
+| MongoDB        |   Yes    |    Yes   |    Yes     |     Yes      |     No      |    No     |
+| Pheanstalk     |   Yes    |    Yes   |    Yes     |     No       |     No      |    No     |
+| WAMP           |   No     |    No    |    No      |     No       |     No      |    No     |
 
 * \*\* Possible if topics (exchanges) are configured on broker side manually.
 * \*\*\* Possible if RabbitMQ Management Plugin is installed.

--- a/docs/client/supported_brokers.md
+++ b/docs/client/supported_brokers.md
@@ -28,7 +28,7 @@ Here's the list of transports supported by Enqueue Client:
 | STOMP, RabbitMQ       | [enqueue/stomp](../transport/stomp.md)                     | stomp:                          |
 | WAMP                  | [enqueue/wamp](../transport/wamp.md)                       | wamp:                           |
 
-Here's the list of protocols and Client features supported by them
+## Transport Features
 
 | Protocol       | Priority | Delay    | Expiration | Setup broker | Message bus | Heartbeat |
 |:--------------:|:--------:|:--------:|:----------:|:------------:|:-----------:|:---------:|

--- a/docs/transport/index.md
+++ b/docs/transport/index.md
@@ -7,3 +7,5 @@ permalink: /transport
 ---
 
 {:toc}
+
+[Feature Comparison Table](../client/supported_brokers.md#transport-features)


### PR DESCRIPTION
Added several missing ones, corrected Redis/FS's missing features, and added a Heartbeat column.
Also reordered them to match the navigation's alphabetical order (in a separate commit so the first's diff is clearer).