### PR TITLE
feat(dbal): add the dropDataBaseTable() method to the context

### DIFF
--- a/pkg/dbal/DbalContext.php
+++ b/pkg/dbal/DbalContext.php
@@ -245,4 +245,14 @@ class DbalContext implements Context
 
         $sm->createTable($table);
     }
+
+    public function dropDataBaseTable(): void
+    {
+        $sm = $this->getDbalConnection()->getSchemaManager();
+        if (!$sm->tablesExist([$tableName = $this->getTableName()])) {
+            return;
+        }
+
+        $sm->dropTable($tableName);
+    }
 }

--- a/pkg/dbal/Tests/Functional/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/Functional/DbalConsumerTest.php
@@ -169,6 +169,20 @@ class DbalConsumerTest extends TestCase
         $this->assertSame(1, $this->getQuerySize());
     }
 
+    public function testShouldCreateAndDropTable(): void
+    {
+        $sm = $this->context->getDbalConnection()->getSchemaManager();
+
+        // The table initially exists (see setUp() and createDbalContext()).
+        $this->assertTrue($sm->tablesExist($tableNames = [$this->context->getTableName()]));
+
+        $this->context->dropDataBaseTable();
+        $this->assertFalse($sm->tablesExist($tableNames));
+
+        $this->context->createDataBaseTable();
+        $this->assertTrue($sm->tablesExist($tableNames));
+    }
+
     private function getQuerySize(): int
     {
         return (int) $this->context->getDbalConnection()

--- a/pkg/dbal/Tests/Spec/Mysql/CreateDbalContextTrait.php
+++ b/pkg/dbal/Tests/Spec/Mysql/CreateDbalContextTrait.php
@@ -16,9 +16,7 @@ trait CreateDbalContextTrait
 
         $context = $factory->createContext();
 
-        if ($context->getDbalConnection()->getSchemaManager()->tablesExist([$context->getTableName()])) {
-            $context->getDbalConnection()->getSchemaManager()->dropTable($context->getTableName());
-        }
+        $context->dropDataBaseTable();
 
         $context->createDataBaseTable();
 

--- a/pkg/dbal/Tests/Spec/Postgresql/CreateDbalContextTrait.php
+++ b/pkg/dbal/Tests/Spec/Postgresql/CreateDbalContextTrait.php
@@ -16,9 +16,7 @@ trait CreateDbalContextTrait
 
         $context = $factory->createContext();
 
-        if ($context->getDbalConnection()->getSchemaManager()->tablesExist([$context->getTableName()])) {
-            $context->getDbalConnection()->getSchemaManager()->dropTable($context->getTableName());
-        }
+        $context->dropDataBaseTable();
 
         $context->createDataBaseTable();
 


### PR DESCRIPTION
`DbalContext` has an helper method to create the database table. Having the reverse method to drop the database table would be helpful for DX when the table is created / dropped programmatically.