### PR TITLE
Add first pass for Apache ActiveMQ Artemis support

### DIFF
--- a/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
@@ -12,6 +12,7 @@ use Enqueue\Client\Message;
 use Enqueue\Client\MessagePriority;
 use Enqueue\Client\Route;
 use Enqueue\Client\RouteCollection;
+use Enqueue\Stomp\ExtensionType;
 use Enqueue\Stomp\StompContext;
 use Enqueue\Stomp\StompDestination;
 use Enqueue\Stomp\StompMessage;
@@ -47,7 +48,7 @@ class RabbitMqStompDriverTest extends TestCase
 
     public function testShouldCreateAndReturnStompQueueInstance()
     {
-        $expectedQueue = new StompDestination();
+        $expectedQueue = new StompDestination(ExtensionType::RABBITMQ);
 
         $context = $this->createContextMock();
         $context
@@ -185,10 +186,10 @@ class RabbitMqStompDriverTest extends TestCase
 
     public function shouldSendMessageToDelayExchangeIfDelaySet()
     {
-        $queue = new StompDestination();
+        $queue = new StompDestination(ExtensionType::RABBITMQ);
         $queue->setStompName('queueName');
 
-        $delayTopic = new StompDestination();
+        $delayTopic = new StompDestination(ExtensionType::RABBITMQ);
         $delayTopic->setStompName('delayTopic');
 
         $transportMessage = new StompMessage();
@@ -339,7 +340,7 @@ class RabbitMqStompDriverTest extends TestCase
             ->expects($this->any())
             ->method('createQueue')
             ->willReturnCallback(function (string $name) {
-                $destination = new StompDestination();
+                $destination = new StompDestination(ExtensionType::RABBITMQ);
                 $destination->setType(StompDestination::TYPE_QUEUE);
                 $destination->setStompName($name);
 
@@ -431,7 +432,7 @@ class RabbitMqStompDriverTest extends TestCase
             ->expects($this->any())
             ->method('createQueue')
             ->willReturnCallback(function (string $name) {
-                $destination = new StompDestination();
+                $destination = new StompDestination(ExtensionType::RABBITMQ);
                 $destination->setType(StompDestination::TYPE_QUEUE);
                 $destination->setStompName($name);
 
@@ -442,7 +443,7 @@ class RabbitMqStompDriverTest extends TestCase
             ->expects($this->any())
             ->method('createTopic')
             ->willReturnCallback(function (string $name) {
-                $destination = new StompDestination();
+                $destination = new StompDestination(ExtensionType::RABBITMQ);
                 $destination->setType(StompDestination::TYPE_TOPIC);
                 $destination->setStompName($name);
 
@@ -503,7 +504,7 @@ class RabbitMqStompDriverTest extends TestCase
      */
     protected function createQueue(string $name): InteropQueue
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_QUEUE);
         $destination->setStompName($name);
 
@@ -515,7 +516,7 @@ class RabbitMqStompDriverTest extends TestCase
      */
     protected function createTopic(string $name): InteropTopic
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_TOPIC);
         $destination->setStompName($name);
 

--- a/pkg/enqueue/Tests/Client/Driver/StompDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/StompDriverTest.php
@@ -9,6 +9,7 @@ use Enqueue\Client\DriverInterface;
 use Enqueue\Client\Message;
 use Enqueue\Client\MessagePriority;
 use Enqueue\Client\RouteCollection;
+use Enqueue\Stomp\ExtensionType;
 use Enqueue\Stomp\StompContext;
 use Enqueue\Stomp\StompDestination;
 use Enqueue\Stomp\StompMessage;
@@ -127,7 +128,7 @@ class StompDriverTest extends TestCase
      */
     protected function createQueue(string $name): InteropQueue
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_QUEUE);
         $destination->setStompName($name);
 
@@ -139,7 +140,7 @@ class StompDriverTest extends TestCase
      */
     protected function createTopic(string $name): InteropTopic
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_TOPIC);
         $destination->setStompName($name);
 

--- a/pkg/stomp/ExtensionType.php
+++ b/pkg/stomp/ExtensionType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enqueue\Stomp;
+
+class ExtensionType
+{
+    const ACTIVEMQ = 'activemq';
+    const RABBITMQ = 'rabbitmq';
+    const ARTEMIS = 'artemis';
+}

--- a/pkg/stomp/StompConnectionFactory.php
+++ b/pkg/stomp/StompConnectionFactory.php
@@ -76,7 +76,7 @@ class StompConnectionFactory implements ConnectionFactory
     {
         if ($this->config['lazy']) {
             return new StompContext(
-                fn () => $this->establishConnection(),
+                function () { return $this->establishConnection(); },
                 $this->config['target']
             );
         }
@@ -128,7 +128,7 @@ class StompConnectionFactory implements ConnectionFactory
             $schemeExtension = ExtensionType::RABBITMQ;
         }
 
-        if (false === in_array($schemeExtension, self::SUPPORTED_SCHEMES)) {
+        if (false === in_array($schemeExtension, self::SUPPORTED_SCHEMES, true)) {
             throw new \LogicException(sprintf('The given DSN is not supported. The scheme extension "%s" provided is not supported. It must be one of %s.', $schemeExtension, implode(', ', self::SUPPORTED_SCHEMES)));
         }
 

--- a/pkg/stomp/StompContext.php
+++ b/pkg/stomp/StompContext.php
@@ -52,7 +52,7 @@ class StompContext implements Context
         }
 
         $this->extensionType = $extensionType;
-        $this->useExchangePrefix = true;
+        $this->useExchangePrefix = ExtensionType::RABBITMQ === $extensionType ? true : false;
     }
 
     /**

--- a/pkg/stomp/StompContext.php
+++ b/pkg/stomp/StompContext.php
@@ -52,7 +52,7 @@ class StompContext implements Context
         }
 
         $this->extensionType = $extensionType;
-        $this->useExchangePrefix = ExtensionType::RABBITMQ === $extensionType ? true : false;
+        $this->useExchangePrefix = ExtensionType::RABBITMQ === $extensionType;
     }
 
     /**

--- a/pkg/stomp/StompContext.php
+++ b/pkg/stomp/StompContext.php
@@ -40,7 +40,6 @@ class StompContext implements Context
 
     /**
      * @param BufferedStompClient|callable $stomp
-     * @param string                       $extensionType
      */
     public function __construct($stomp, string $extensionType)
     {
@@ -205,10 +204,7 @@ class StompContext implements Context
         if (false == $this->stomp) {
             $stomp = call_user_func($this->stompFactory);
             if (false == $stomp instanceof BufferedStompClient) {
-                throw new \LogicException(sprintf(
-                    'The factory must return instance of BufferedStompClient. It returns %s',
-                    is_object($stomp) ? get_class($stomp) : gettype($stomp)
-                ));
+                throw new \LogicException(sprintf('The factory must return instance of BufferedStompClient. It returns %s', is_object($stomp) ? get_class($stomp) : gettype($stomp)));
             }
 
             $this->stomp = $stomp;

--- a/pkg/stomp/StompContext.php
+++ b/pkg/stomp/StompContext.php
@@ -24,6 +24,11 @@ class StompContext implements Context
     private $stomp;
 
     /**
+     * @var string
+     */
+    private $extensionType;
+
+    /**
      * @var bool
      */
     private $useExchangePrefix;
@@ -35,9 +40,9 @@ class StompContext implements Context
 
     /**
      * @param BufferedStompClient|callable $stomp
-     * @param bool                         $useExchangePrefix
+     * @param string                       $extensionType
      */
-    public function __construct($stomp, $useExchangePrefix = true)
+    public function __construct($stomp, string $extensionType)
     {
         if ($stomp instanceof BufferedStompClient) {
             $this->stomp = $stomp;
@@ -47,7 +52,8 @@ class StompContext implements Context
             throw new \InvalidArgumentException('The stomp argument must be either BufferedStompClient or callable that return BufferedStompClient.');
         }
 
-        $this->useExchangePrefix = $useExchangePrefix;
+        $this->extensionType = $extensionType;
+        $this->useExchangePrefix = true;
     }
 
     /**
@@ -64,7 +70,7 @@ class StompContext implements Context
     public function createQueue(string $name): Queue
     {
         if (0 !== strpos($name, '/')) {
-            $destination = new StompDestination();
+            $destination = new StompDestination($this->extensionType);
             $destination->setType(StompDestination::TYPE_QUEUE);
             $destination->setStompName($name);
 
@@ -91,7 +97,7 @@ class StompContext implements Context
     public function createTopic(string $name): Topic
     {
         if (0 !== strpos($name, '/')) {
-            $destination = new StompDestination();
+            $destination = new StompDestination($this->extensionType);
             $destination->setType($this->useExchangePrefix ? StompDestination::TYPE_EXCHANGE : StompDestination::TYPE_TOPIC);
             $destination->setStompName($name);
 
@@ -151,7 +157,7 @@ class StompContext implements Context
             $routingKey = $pieces[1];
         }
 
-        $destination = new StompDestination();
+        $destination = new StompDestination($this->extensionType);
         $destination->setType($type);
         $destination->setStompName($name);
         $destination->setRoutingKey($routingKey);

--- a/pkg/stomp/StompDestination.php
+++ b/pkg/stomp/StompDestination.php
@@ -39,14 +39,25 @@ class StompDestination implements Topic, Queue
      * @var array
      */
     private $headers;
+    /**
+     * @var string
+     */
+    private string $extensionType;
 
-    public function __construct()
+    public function __construct(string $extensionType)
     {
         $this->headers = [
             self::HEADER_DURABLE => false,
             self::HEADER_AUTO_DELETE => true,
             self::HEADER_EXCLUSIVE => false,
         ];
+
+        $this->extensionType = $extensionType;
+    }
+
+    public function getExtensionType(): string
+    {
+        return $this->extensionType;
     }
 
     public function getStompName(): string
@@ -63,6 +74,10 @@ class StompDestination implements Topic, Queue
     {
         if (empty($this->getStompName())) {
             throw new \LogicException('Destination name is not set');
+        }
+
+        if ($this->extensionType === ExtensionType::ARTEMIS) {
+            return $this->getStompName();
         }
 
         $name = '/'.$this->getType().'/'.$this->getStompName();

--- a/pkg/stomp/StompDestination.php
+++ b/pkg/stomp/StompDestination.php
@@ -42,7 +42,7 @@ class StompDestination implements Topic, Queue
     /**
      * @var string
      */
-    private string $extensionType;
+    private $extensionType;
 
     public function __construct(string $extensionType)
     {
@@ -76,7 +76,7 @@ class StompDestination implements Topic, Queue
             throw new \LogicException('Destination name is not set');
         }
 
-        if ($this->extensionType === ExtensionType::ARTEMIS) {
+        if (ExtensionType::ARTEMIS === $this->extensionType) {
             return $this->getStompName();
         }
 

--- a/pkg/stomp/Tests/StompConsumerTest.php
+++ b/pkg/stomp/Tests/StompConsumerTest.php
@@ -3,6 +3,7 @@
 namespace Enqueue\Stomp\Tests;
 
 use Enqueue\Stomp\BufferedStompClient;
+use Enqueue\Stomp\ExtensionType;
 use Enqueue\Stomp\StompConsumer;
 use Enqueue\Stomp\StompDestination;
 use Enqueue\Stomp\StompMessage;
@@ -557,7 +558,7 @@ class StompConsumerTest extends \PHPUnit\Framework\TestCase
 
     private function createDummyDestination(): StompDestination
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setStompName('aName');
         $destination->setType(StompDestination::TYPE_QUEUE);
 

--- a/pkg/stomp/Tests/StompContextTest.php
+++ b/pkg/stomp/Tests/StompContextTest.php
@@ -94,7 +94,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateTopicInstanceWithTopicPrefix()
     {
-        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::ARTEMIS);
 
         $topic = $context->createTopic('the name');
 

--- a/pkg/stomp/Tests/StompContextTest.php
+++ b/pkg/stomp/Tests/StompContextTest.php
@@ -3,6 +3,7 @@
 namespace Enqueue\Stomp\Tests;
 
 use Enqueue\Stomp\BufferedStompClient;
+use Enqueue\Stomp\ExtensionType;
 use Enqueue\Stomp\StompConsumer;
 use Enqueue\Stomp\StompContext;
 use Enqueue\Stomp\StompDestination;
@@ -24,14 +25,14 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testCouldBeCreatedWithRequiredArguments()
     {
-        new StompContext($this->createStompClientMock());
+        new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
     }
 
     public function testCouldBeConstructedWithExtChannelCallbackFactoryAsFirstArgument()
     {
         new StompContext(function () {
             return $this->createStompClientMock();
-        });
+        }, ExtensionType::RABBITMQ);
     }
 
     public function testThrowIfNeitherCallbackNorExtChannelAsFirstArgument()
@@ -39,12 +40,12 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The stomp argument must be either BufferedStompClient or callable that return BufferedStompClient.');
 
-        new StompContext(new \stdClass());
+        new StompContext(new \stdClass(), ExtensionType::RABBITMQ);
     }
 
     public function testShouldCreateMessageInstance()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $message = $context->createMessage('the body', ['key' => 'value'], ['hkey' => 'hvalue']);
 
@@ -56,7 +57,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateQueueInstance()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $queue = $context->createQueue('the name');
 
@@ -68,7 +69,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateQueueShouldCreateDestinationIfNameIsFullDestinationString()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $destination = $context->createQueue('/amq/queue/name/routing-key');
 
@@ -81,7 +82,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateTopicInstanceWithExchangePrefix()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $topic = $context->createTopic('the name');
 
@@ -93,7 +94,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateTopicInstanceWithTopicPrefix()
     {
-        $context = new StompContext($this->createStompClientMock(), false);
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $topic = $context->createTopic('the name');
 
@@ -105,7 +106,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateTopicShouldCreateDestinationIfNameIsFullDestinationString()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $destination = $context->createTopic('/amq/queue/name/routing-key');
 
@@ -121,20 +122,20 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidDestinationException::class);
         $this->expectExceptionMessage('The destination must be an instance of');
 
-        $session = new StompContext($this->createStompClientMock());
+        $session = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $session->createConsumer($this->createMock(Queue::class));
     }
 
     public function testShouldCreateMessageConsumerInstance()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $this->assertInstanceOf(StompConsumer::class, $context->createConsumer($this->createDummyDestination()));
     }
 
     public function testShouldCreateMessageProducerInstance()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $this->assertInstanceOf(StompProducer::class, $context->createProducer());
     }
@@ -147,7 +148,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
             ->method('disconnect')
         ;
 
-        $context = new StompContext($client);
+        $context = new StompContext($client, ExtensionType::RABBITMQ);
 
         $context->createProducer();
         $context->createConsumer($this->createDummyDestination());
@@ -160,7 +161,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Destination name is invalid, cant find type: "/invalid-type/name"');
 
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $context->createDestination('/invalid-type/name');
     }
 
@@ -169,7 +170,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Destination name is invalid, found extra / char: "/queue/name/routing-key/extra');
 
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $context->createDestination('/queue/name/routing-key/extra');
     }
 
@@ -178,7 +179,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Destination name is invalid, name is empty: "/queue/"');
 
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $context->createDestination('/queue/');
     }
 
@@ -187,13 +188,13 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Destination name is invalid, routing key is empty: "/queue/name/"');
 
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $context->createDestination('/queue/name/');
     }
 
     public function testCreateDestinationShouldParseStringAndCreateDestination()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $destination = $context->createDestination('/amq/queue/name/routing-key');
 
         $this->assertEquals('amq/queue', $destination->getType());
@@ -204,7 +205,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateTemporaryQueue()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $tempQueue = $context->createTemporaryQueue();
 
         $this->assertEquals('temp-queue', $tempQueue->getType());
@@ -215,7 +216,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateTemporaryQueuesWithUniqueNames()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
         $fooTempQueue = $context->createTemporaryQueue();
         $barTempQueue = $context->createTemporaryQueue();
 
@@ -227,7 +228,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldGetBufferedStompClient()
     {
-        $context = new StompContext($this->createStompClientMock());
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::RABBITMQ);
 
         $this->assertInstanceOf(BufferedStompClient::class, $context->getStomp());
     }
@@ -242,7 +243,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     private function createDummyDestination(): StompDestination
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setStompName('aName');
         $destination->setType(StompDestination::TYPE_QUEUE);
 

--- a/pkg/stomp/Tests/StompContextTest.php
+++ b/pkg/stomp/Tests/StompContextTest.php
@@ -94,7 +94,7 @@ class StompContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldCreateTopicInstanceWithTopicPrefix()
     {
-        $context = new StompContext($this->createStompClientMock(), ExtensionType::ARTEMIS);
+        $context = new StompContext($this->createStompClientMock(), ExtensionType::ACTIVEMQ);
 
         $topic = $context->createTopic('the name');
 

--- a/pkg/stomp/Tests/StompDestinationTest.php
+++ b/pkg/stomp/Tests/StompDestinationTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Stomp\Tests;
 
+use Enqueue\Stomp\ExtensionType;
 use Enqueue\Stomp\StompDestination;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Queue;
@@ -19,7 +20,7 @@ class StompDestinationTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldReturnDestinationStringWithRoutingKey()
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_AMQ_QUEUE);
         $destination->setStompName('name');
         $destination->setRoutingKey('routing-key');
@@ -32,7 +33,7 @@ class StompDestinationTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldReturnDestinationStringWithoutRoutingKey()
     {
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_TOPIC);
         $destination->setStompName('name');
 
@@ -47,7 +48,7 @@ class StompDestinationTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Destination name is not set');
 
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_QUEUE);
         $destination->setStompName('');
 
@@ -59,7 +60,7 @@ class StompDestinationTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Invalid destination type: "invalid-type"');
 
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType('invalid-type');
     }
 }

--- a/pkg/stomp/Tests/StompProducerTest.php
+++ b/pkg/stomp/Tests/StompProducerTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Stomp\Tests;
 
+use Enqueue\Stomp\ExtensionType;
 use Enqueue\Stomp\StompDestination;
 use Enqueue\Stomp\StompMessage;
 use Enqueue\Stomp\StompProducer;
@@ -40,7 +41,7 @@ class StompProducerTest extends \PHPUnit\Framework\TestCase
 
         $producer = new StompProducer($this->createStompClientMock());
 
-        $producer->send(new StompDestination(), $this->createMock(Message::class));
+        $producer->send(new StompDestination(ExtensionType::RABBITMQ), $this->createMock(Message::class));
     }
 
     public function testShouldSendMessage()
@@ -54,7 +55,7 @@ class StompProducerTest extends \PHPUnit\Framework\TestCase
 
         $producer = new StompProducer($client);
 
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_QUEUE);
         $destination->setStompName('name');
 
@@ -77,7 +78,7 @@ class StompProducerTest extends \PHPUnit\Framework\TestCase
 
         $message = new StompMessage('', ['key' => 'value'], ['hkey' => false]);
 
-        $destination = new StompDestination();
+        $destination = new StompDestination(ExtensionType::RABBITMQ);
         $destination->setType(StompDestination::TYPE_QUEUE);
         $destination->setStompName('name');
 


### PR DESCRIPTION
Hey @makasim! :wave:

I've managed to put together a first draft for supporting ActiveMQ Artemis using the Enqueue STOMP driver. I have this working locally and I've done my best to stick to your code style, giving in to the odd improvement.

The biggest change I've made is to plumb the notion of broker extensions a bit further into the hierarchy of objects. I noticed in quite a few places, RabbitMQ preferences are hard-coded because there wasn't any way to check which set of extensions are desired for the connection. I'll make further notes on the code in the PR to help you scan through things.

Let me know what you think and note any changes or improvements you're after. I have not added tests as I am hoping to get help from you on that if it's something you want done.

Closes: php-enqueue/enqueue-dev#1067