### PR TITLE
Allow false-y values for unsupported options

### DIFF
--- a/pkg/stomp/StompProducer.php
+++ b/pkg/stomp/StompProducer.php
@@ -47,7 +47,7 @@ class StompProducer implements Producer
 
     public function setDeliveryDelay(int $deliveryDelay = null): Producer
     {
-        if (null === $deliveryDelay) {
+        if (empty($deliveryDelay)) {
             return $this;
         }
 
@@ -61,7 +61,7 @@ class StompProducer implements Producer
 
     public function setPriority(int $priority = null): Producer
     {
-        if (null === $priority) {
+        if (empty($priority)) {
             return $this;
         }
 
@@ -75,7 +75,7 @@ class StompProducer implements Producer
 
     public function setTimeToLive(int $timeToLive = null): Producer
     {
-        if (null === $timeToLive) {
+        if (empty($timeToLive)) {
             return $this;
         }
 

--- a/pkg/stomp/StompProducer.php
+++ b/pkg/stomp/StompProducer.php
@@ -20,9 +20,6 @@ class StompProducer implements Producer
      */
     private $stomp;
 
-    /**
-     * @param Client $stomp
-     */
     public function __construct(Client $stomp)
     {
         $this->stomp = $stomp;
@@ -45,6 +42,9 @@ class StompProducer implements Producer
         $this->stomp->send($destination->getQueueName(), $stompMessage);
     }
 
+    /**
+     * @return $this|Producer
+     */
     public function setDeliveryDelay(int $deliveryDelay = null): Producer
     {
         if (empty($deliveryDelay)) {
@@ -59,6 +59,11 @@ class StompProducer implements Producer
         return null;
     }
 
+    /**
+     * @throws PriorityNotSupportedException
+     *
+     * @return $this|Producer
+     */
     public function setPriority(int $priority = null): Producer
     {
         if (empty($priority)) {
@@ -73,6 +78,9 @@ class StompProducer implements Producer
         return null;
     }
 
+    /**
+     * @return $this|Producer
+     */
     public function setTimeToLive(int $timeToLive = null): Producer
     {
         if (empty($timeToLive)) {


### PR DESCRIPTION
This is to accommodate any situations where `0` is passed via configuration or even defaults from other layers (in my case, laravel).