### PR TITLE
[rdkafka] add non-blocking poll call to serve cb's

### DIFF
--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -56,12 +56,14 @@ class RdKafkaProducer implements Producer
                 );
             } else {
                 $topic->producev($partition, 0 /* must be 0 */, $payload, $key, $message->getHeaders());
+                $this->producer->poll(0);
 
                 return;
             }
         }
 
         $topic->produce($partition, 0 /* must be 0 */, $payload, $key);
+        $this->producer->poll(0);
     }
 
     /**

--- a/pkg/rdkafka/Tests/RdKafkaProducerTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaProducerTest.php
@@ -69,6 +69,11 @@ class RdKafkaProducerTest extends TestCase
             ->with('theQueueName')
             ->willReturn($kafkaTopic)
         ;
+        $kafkaProducer
+            ->expects($this->once())
+            ->method('poll')
+            ->with(0)
+        ;
 
         $serializer = $this->createSerializerMock();
         $serializer
@@ -98,6 +103,11 @@ class RdKafkaProducerTest extends TestCase
             ->method('newTopic')
             ->with('theQueueName', null)
             ->willReturn($kafkaTopic)
+        ;
+        $kafkaProducer
+            ->expects($this->once())
+            ->method('poll')
+            ->with(0)
         ;
 
         $serializer = $this->createSerializerMock();
@@ -134,6 +144,11 @@ class RdKafkaProducerTest extends TestCase
             ->method('newTopic')
             ->with('theQueueName', $this->identicalTo($conf))
             ->willReturn($kafkaTopic)
+        ;
+        $kafkaProducer
+            ->expects($this->once())
+            ->method('poll')
+            ->with(0)
         ;
 
         $serializer = $this->createSerializerMock();
@@ -188,6 +203,11 @@ class RdKafkaProducerTest extends TestCase
             ->expects($this->once())
             ->method('newTopic')
             ->willReturn($kafkaTopic)
+        ;
+        $kafkaProducer
+            ->expects($this->once())
+            ->method('poll')
+            ->with(0)
         ;
 
         $serializer = $this->createSerializerMock();


### PR DESCRIPTION
Should fix #749, calling `poll(0)` is non-blocking and poses minimal overhead. This way callbacks can be triggered, which is important to receive errors, delivery reports, etc. when producing a message.