### PR TITLE
use supported librdkafka version of ext

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x && \
     mkdir -p $HOME/librdkafka && \
     cd $HOME/librdkafka && \
     git clone https://github.com/edenhill/librdkafka.git . && \
-    git checkout v0.11.1 && \
+    git checkout v0.11.6 && \
     ./configure && make && make install && \
     pecl install rdkafka && \
     echo "extension=rdkafka.so" > /etc/php/7.2/cli/conf.d/10-rdkafka.ini && \


### PR DESCRIPTION
So `php-rdkafka:4.x` only supports `librdkafka:0.11.6` and up. I would strongly suggest though, that you force your users to use `librdkafka:1.x` and up. If you guys agree, i can create a PR to enforce this and adjust this one to use at least `librdkafka:1.0`
FYI: `php-rdkafka:5.0` will drop support for anything lower than `librdkafka:1.2`