### PR TITLE
Ramsey dependency removed in favor to \Enqueue\Util\UUID::generate

### DIFF
--- a/pkg/monitoring/ConsumerMonitoringExtension.php
+++ b/pkg/monitoring/ConsumerMonitoringExtension.php
@@ -19,8 +19,8 @@ use Enqueue\Consumption\PreSubscribeExtensionInterface;
 use Enqueue\Consumption\ProcessorExceptionExtensionInterface;
 use Enqueue\Consumption\Result;
 use Enqueue\Consumption\StartExtensionInterface;
+use Enqueue\Util\UUID;
 use Psr\Log\LoggerInterface;
-use Ramsey\Uuid\Uuid;
 
 class ConsumerMonitoringExtension implements StartExtensionInterface, PreSubscribeExtensionInterface, PreConsumeExtensionInterface, EndExtensionInterface, ProcessorExceptionExtensionInterface, MessageReceivedExtensionInterface, MessageResultExtensionInterface
 {
@@ -82,7 +82,7 @@ class ConsumerMonitoringExtension implements StartExtensionInterface, PreSubscri
 
     public function onStart(Start $context): void
     {
-        $this->consumerId = Uuid::uuid4()->toString();
+        $this->consumerId = UUID::generate();
 
         $this->queues = [];
 

--- a/pkg/monitoring/composer.json
+++ b/pkg/monitoring/composer.json
@@ -8,7 +8,6 @@
     "require": {
         "php": "^7.1.3",
         "enqueue/enqueue": "^0.10",
-        "ramsey/uuid": "^3|^4",
         "enqueue/dsn": "^0.10"
     },
     "require-dev": {


### PR DESCRIPTION
A correct copy of https://github.com/php-enqueue/monitoring/pull/2