### PR TITLE
[SQS] Fallback to SentTimestamp attribute for getTimestamp()

### DIFF
--- a/pkg/sqs/SqsMessage.php
+++ b/pkg/sqs/SqsMessage.php
@@ -176,9 +176,15 @@ class SqsMessage implements Message
 
     public function getTimestamp(): ?int
     {
-        $value = $this->getHeader('timestamp');
+        if (null !== $value = $this->getHeader('timestamp')) {
+            return (int) $value;
+        }
 
-        return null === $value ? null : (int) $value;
+        if (null !== $value = $this->getAttribute('SentTimestamp')) {
+            return (int) $value;
+        }
+
+        return null;
     }
 
     public function setTimestamp(int $timestamp = null): void

--- a/pkg/sqs/Tests/SqsMessageTest.php
+++ b/pkg/sqs/Tests/SqsMessageTest.php
@@ -104,5 +104,7 @@ class SqsMessageTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($attributes, $message->getAttributes());
         $this->assertSame($attributes['SenderId'], $message->getAttribute('SenderId'));
+        $this->assertSame($attributes['SentTimestamp'], $message->getAttribute('SentTimestamp'));
+        $this->assertSame((int) $attributes['SentTimestamp'], $message->getTimestamp());
     }
 }


### PR DESCRIPTION
Currently `getTimestamp()` returns null when a timestamp was not added to headers.
I'm proposing here to fallback to SQS auto provisionned attributes `SentTimestamp` if available when timestamp header is not present.