### PR TITLE
[fix] queue consumption: catch throwable for processing errors

### DIFF
--- a/pkg/enqueue/Consumption/Context/ProcessorException.php
+++ b/pkg/enqueue/Consumption/Context/ProcessorException.php
@@ -26,7 +26,7 @@ final class ProcessorException
     private $message;
 
     /**
-     * @var \Exception
+     * @var \Throwable
      */
     private $exception;
 
@@ -44,7 +44,7 @@ final class ProcessorException
      */
     private $logger;
 
-    public function __construct(Context $context, Consumer $consumer, Message $message, \Exception $exception, int $receivedAt, LoggerInterface $logger)
+    public function __construct(Context $context, Consumer $consumer, Message $message, \Throwable $exception, int $receivedAt, LoggerInterface $logger)
     {
         $this->context = $context;
         $this->consumer = $consumer;
@@ -69,7 +69,7 @@ final class ProcessorException
         return $this->message;
     }
 
-    public function getException(): \Exception
+    public function getException(): \Throwable
     {
         return $this->exception;
     }

--- a/pkg/enqueue/Consumption/QueueConsumer.php
+++ b/pkg/enqueue/Consumption/QueueConsumer.php
@@ -195,7 +195,7 @@ final class QueueConsumer implements QueueConsumerInterface
             if (null === $result) {
                 try {
                     $result = $processor->process($message, $this->interopContext);
-                } catch (\Exception $e) {
+                } catch (\Exception | \Throwable $e) {
                     $result = $this->onProcessorException($extension, $consumer, $message, $e, $receivedAt);
                 }
             }
@@ -303,7 +303,7 @@ final class QueueConsumer implements QueueConsumerInterface
      *
      * https://github.com/symfony/symfony/blob/cbe289517470eeea27162fd2d523eb29c95f775f/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php#L77
      */
-    private function onProcessorException(ExtensionInterface $extension, Consumer $consumer, Message $message, \Exception $exception, int $receivedAt)
+    private function onProcessorException(ExtensionInterface $extension, Consumer $consumer, Message $message, \Throwable $exception, int $receivedAt)
     {
         $processorException = new ProcessorException($this->interopContext, $consumer, $message, $exception, $receivedAt, $this->logger);
 


### PR DESCRIPTION
This fixes the issue with unhandled Errors described in #1113

tbd. if this might be considered breaking backward compatibility or if I missed any important place.
Actually it should not, since \Exception extends from \Throwable. But feel free to comment & object.