### PR TITLE
php 8 Support [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,57 @@ dist: bionic
 
 matrix:
   include:
+    - php: 7.1
+      sudo: false
+      env: SYMFONY_VERSION=4.3.* PHPSTAN=true
+    - php: 7.1
+      sudo: false
+      env: SYMFONY_VERSION=4.3.* PHP_CS_FIXER=true
+    - php: 7.1
+      sudo: false
+      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
+    - php: 7.2
+      sudo: false
+      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
+    - php: 7.2
+      sudo: false
+      env: SYMFONY_VERSION=5.0.* UNIT_TESTS=true
+    - php: 7.3
+      sudo: false
+      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
+    - php: 7.3
+      sudo: false
+      env: SYMFONY_VERSION=4.4.* UNIT_TESTS=true
+    - php: 7.3
+      sudo: false
+      env: SYMFONY_VERSION=5.0.* UNIT_TESTS=true
+    - php: 7.4
+      sudo: false
+      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
+    - php: 7.4
+      sudo: false
+      env: SYMFONY_VERSION=4.4.* UNIT_TESTS=true
+    - php: 7.4
+      sudo: false
+      env: SYMFONY_VERSION=5.0.* UNIT_TESTS=true
+    - php: 7.1
+      sudo: required
+      services: docker
+      env: SYMFONY_VERSION=4.3.* FUNCTIONAL_TESTS=true PREPARE_CONTAINER=true
+    - php: 7.3
+      sudo: required
+      services: docker
+      env: SYMFONY_VERSION=5.0.* FUNCTIONAL_TESTS=true PREPARE_CONTAINER=true
+    - php: 7.1
+      sudo: required
+      services: docker
+      env: SYMFONY_VERSION=4.3.* RDKAFKA_TESTS=true PREPARE_CONTAINER=true
     - php: 8.0
       sudo: false
       services: docker
       env: SYMFONY_VERSION=5.2.* UNIT_TESTS=true
+  allow_failures:
+    - env: SYMFONY_VERSION=4.3.* RDKAFKA_TESTS=true PREPARE_CONTAINER=true
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,53 +6,10 @@ dist: bionic
 
 matrix:
   include:
-    - php: 7.1
+    - php: 8.0
       sudo: false
-      env: SYMFONY_VERSION=4.3.* PHPSTAN=true
-    - php: 7.1
-      sudo: false
-      env: SYMFONY_VERSION=4.3.* PHP_CS_FIXER=true
-    - php: 7.1
-      sudo: false
-      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
-    - php: 7.2
-      sudo: false
-      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
-    - php: 7.2
-      sudo: false
-      env: SYMFONY_VERSION=5.0.* UNIT_TESTS=true
-    - php: 7.3
-      sudo: false
-      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
-    - php: 7.3
-      sudo: false
-      env: SYMFONY_VERSION=4.4.* UNIT_TESTS=true
-    - php: 7.3
-      sudo: false
-      env: SYMFONY_VERSION=5.0.* UNIT_TESTS=true
-    - php: 7.4
-      sudo: false
-      env: SYMFONY_VERSION=4.3.* UNIT_TESTS=true
-    - php: 7.4
-      sudo: false
-      env: SYMFONY_VERSION=4.4.* UNIT_TESTS=true
-    - php: 7.4
-      sudo: false
-      env: SYMFONY_VERSION=5.0.* UNIT_TESTS=true
-    - php: 7.1
-      sudo: required
       services: docker
-      env: SYMFONY_VERSION=4.3.* FUNCTIONAL_TESTS=true PREPARE_CONTAINER=true
-    - php: 7.3
-      sudo: required
-      services: docker
-      env: SYMFONY_VERSION=5.0.* FUNCTIONAL_TESTS=true PREPARE_CONTAINER=true
-    - php: 7.1
-      sudo: required
-      services: docker
-      env: SYMFONY_VERSION=4.3.* RDKAFKA_TESTS=true PREPARE_CONTAINER=true
-  allow_failures:
-    - env: SYMFONY_VERSION=4.3.* RDKAFKA_TESTS=true PREPARE_CONTAINER=true
+      env: SYMFONY_VERSION=5.2.* UNIT_TESTS=true
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "phpstan": "bin/phpstan analyse --memory-limit=512M -c phpstan.neon"
   },
   "require": {
-    "php": "^7.1.3",
+    "php": "^8.0",
 
     "ext-amqp": "^1.9.3",
     "ext-gearman": "^2.0",
@@ -41,7 +41,7 @@
     "datadog/php-datadogstatsd": "^1.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5",
+    "phpunit/phpunit": "^9.5",
     "phpstan/phpstan": "^0.12",
     "queue-interop/queue-spec": "^0.6",
     "symfony/browser-kit": "^3.4|^4",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     "doctrine/mongodb-odm-bundle": "^3.5|^4",
     "alcaeus/mongo-php-adapter": "^1.0",
     "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
-    "friendsofphp/php-cs-fixer": "^2"
+    "friendsofphp/php-cs-fixer": "^2",
+    "dms/phpunit-arraysubset-asserts": "^0.2.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "phpstan": "bin/phpstan analyse --memory-limit=512M -c phpstan.neon"
   },
   "require": {
-    "php": "^8.0",
+    "php": ">=7.3",
 
     "ext-amqp": "^1.9.3",
     "ext-gearman": "^2.0",

--- a/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
@@ -22,7 +22,7 @@ class AmqpCommonUseCasesTest extends TestCase
      */
     private $amqpContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 

--- a/pkg/amqp-ext/Tests/Functional/AmqpConsumptionUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpConsumptionUseCasesTest.php
@@ -29,7 +29,7 @@ class AmqpConsumptionUseCasesTest extends TestCase
      */
     private $amqpContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 

--- a/pkg/amqp-ext/Tests/Functional/AmqpRpcUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpRpcUseCasesTest.php
@@ -23,7 +23,7 @@ class AmqpRpcUseCasesTest extends TestCase
      */
     private $amqpContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 

--- a/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
+++ b/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
@@ -16,7 +16,7 @@ class SignalSocketHelperTest extends TestCase
 
     private $backupSigIntHandler;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
+++ b/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
@@ -76,7 +76,7 @@ class SignalSocketHelperTest extends TestCase
 
         $handlers = $this->readAttribute($this->signalHelper, 'handlers');
 
-        $this->assertInternalType('array', $handlers);
+        $this->assertIsArray($handlers);
         $this->assertArrayHasKey(SIGTERM, $handlers);
         $this->assertSame($handler, $handlers[SIGTERM]);
     }

--- a/pkg/async-event-dispatcher/Tests/Functional/UseCasesTest.php
+++ b/pkg/async-event-dispatcher/Tests/Functional/UseCasesTest.php
@@ -53,7 +53,7 @@ class UseCasesTest extends TestCase
      */
     protected $asyncProcessor;
 
-    public function setUp()
+    public function setUp(): void
     {
         (new Filesystem())->remove(__DIR__.'/queues/');
 

--- a/pkg/dbal/Tests/DbalConnectionFactoryConfigTest.php
+++ b/pkg/dbal/Tests/DbalConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Dbal\Tests;
 
 use Enqueue\Dbal\DbalConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class DbalConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/dbal/Tests/Functional/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/Functional/DbalConsumerTest.php
@@ -21,7 +21,7 @@ class DbalConsumerTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->createDbalContext();
     }

--- a/pkg/dbal/Tests/Spec/Mysql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/dbal/Tests/Spec/Mysql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
@@ -16,7 +16,7 @@ class DbalSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceivePrio
 
     private $publishedAt;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/dbal/Tests/Spec/Postgresql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/dbal/Tests/Spec/Postgresql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
@@ -16,7 +16,7 @@ class DbalSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceivePrio
 
     private $publishedAt;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncListenerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncListenerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncListenerTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncProcessorTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncProcessorTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncProcessorTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncSubscriberTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncSubscriberTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncSubscriberTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/LazyProducerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/LazyProducerTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class LazyProducerTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // do not call parent::setUp.
         // parent::setUp();

--- a/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
@@ -20,7 +20,7 @@ class UseCasesTest extends WebTestCase
 {
     const RECEIVE_TIMEOUT = 500;
 
-    public function setUp()
+    public function setUp(): void
     {
         // do not call parent::setUp.
         // parent::setUp();

--- a/pkg/enqueue-bundle/Tests/Functional/WebTestCase.php
+++ b/pkg/enqueue-bundle/Tests/Functional/WebTestCase.php
@@ -20,7 +20,7 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected static $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\Tests\Unit\DependencyInjection;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Bundle\DependencyInjection\Configuration;
 use Enqueue\Test\ClassExtensionTrait;
 use PHPUnit\Framework\TestCase;
@@ -222,7 +223,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'job' => [
                     'enabled' => false,
@@ -243,7 +244,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'job' => true,
             ],
@@ -261,7 +262,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_ping_connection_extension' => false,
@@ -284,7 +285,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_ping_connection_extension' => true,
@@ -304,7 +305,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_clear_identity_map_extension' => false,
@@ -327,7 +328,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_clear_identity_map_extension' => true,
@@ -347,7 +348,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_odm_clear_identity_map_extension' => false,
@@ -370,7 +371,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_odm_clear_identity_map_extension' => true,
@@ -390,7 +391,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_closed_entity_manager_extension' => false,
@@ -413,7 +414,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_closed_entity_manager_extension' => true,
@@ -433,7 +434,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reset_services_extension' => false,
@@ -456,7 +457,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reset_services_extension' => true,
@@ -478,7 +479,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'signal_extension' => $isLoaded,
@@ -501,7 +502,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'signal_extension' => false,
@@ -521,7 +522,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reply_extension' => true,
@@ -544,7 +545,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reply_extension' => false,
@@ -564,7 +565,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'async_events' => [
                     'enabled' => false,
@@ -586,7 +587,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'async_events' => [
                     'enabled' => true,
@@ -603,7 +604,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'async_events' => [
                     'enabled' => true,
@@ -623,7 +624,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'consumption' => [
                     'receive_timeout' => 10000,
@@ -646,7 +647,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'consumption' => [
                     'receive_timeout' => 456,
@@ -657,6 +658,6 @@ class ConfigurationTest extends TestCase
 
     private function assertConfigEquals(array $expected, array $actual): void
     {
-        $this->assertArraySubset($expected, $actual, false, var_export($actual, true));
+        Assert::assertArraySubset($expected, $actual, false, var_export($actual, true));
     }
 }

--- a/pkg/enqueue-bundle/Tests/Unit/Profiler/MessageQueueCollectorTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/Profiler/MessageQueueCollectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\Tests\Unit\Profiler;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Bundle\Profiler\MessageQueueCollector;
 use Enqueue\Client\MessagePriority;
 use Enqueue\Client\ProducerInterface;
@@ -59,7 +60,7 @@ class MessageQueueCollectorTest extends TestCase
 
         $collector->collect(new Request(), new Response());
 
-        $this->assertArraySubset(
+        Assert::assertArraySubset(
             [
                 'foo' => [
                     [

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
@@ -15,6 +15,7 @@ use Interop\Queue\Context as InteropContext;
 use Interop\Queue\Destination;
 use Interop\Queue\Message as TransportMessage;
 use Interop\Queue\Processor;
+use Interop\Queue\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -173,13 +174,13 @@ class DelayRedeliveredMessageExtensionTest extends TestCase
      *
      * @return MockObject
      */
-    private function createConsumerStub($queue): Consumer
+    private function createConsumerStub(?Queue $queue = null): Consumer
     {
         $consumerMock = $this->createMock(Consumer::class);
         $consumerMock
             ->expects($this->any())
             ->method('getQueue')
-            ->willReturn($queue)
+            ->willReturn($queue ?? new NullQueue('queue'))
         ;
 
         return $consumerMock;

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
@@ -106,7 +106,7 @@ class DelayRedeliveredMessageExtensionTest extends TestCase
 
         $messageReceived = new MessageReceived(
             $this->createContextMock(),
-            $this->createConsumerStub(null),
+            $this->createConsumerStub(new NullQueue('queue')),
             $message,
             $this->createProcessorMock(),
             1,
@@ -132,7 +132,7 @@ class DelayRedeliveredMessageExtensionTest extends TestCase
 
         $messageReceived = new MessageReceived(
             $this->createContextMock(),
-            $this->createConsumerStub(null),
+            $this->createConsumerStub(new NullQueue('queue')),
             $message,
             $this->createProcessorMock(),
             1,

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/ExclusiveCommandExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/ExclusiveCommandExtensionTest.php
@@ -15,6 +15,7 @@ use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Context as InteropContext;
 use Interop\Queue\Processor;
+use Interop\Queue\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -51,7 +52,7 @@ class ExclusiveCommandExtensionTest extends TestCase
 
         $messageReceived = new MessageReceived(
             $this->createContextMock(),
-            $this->createConsumerStub(null),
+            $this->createConsumerStub(),
             $message,
             $this->createProcessorMock(),
             1,
@@ -245,13 +246,13 @@ class ExclusiveCommandExtensionTest extends TestCase
     /**
      * @return MockObject
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driver = $this->createMock(DriverInterface::class);
         $driver
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         return $driver;
@@ -278,13 +279,13 @@ class ExclusiveCommandExtensionTest extends TestCase
      *
      * @return MockObject
      */
-    private function createConsumerStub($queue): Consumer
+    private function createConsumerStub(?Queue $queue = null): Consumer
     {
         $consumerMock = $this->createMock(Consumer::class);
         $consumerMock
             ->expects($this->any())
             ->method('getQueue')
-            ->willReturn($queue)
+            ->willReturn($queue ?? new NullQueue('queue'))
         ;
 
         return $consumerMock;

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/SetRouterPropertiesExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/SetRouterPropertiesExtensionTest.php
@@ -13,6 +13,7 @@ use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Context as InteropContext;
 use Interop\Queue\Processor;
+use Interop\Queue\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -190,13 +191,13 @@ class SetRouterPropertiesExtensionTest extends TestCase
      *
      * @return MockObject
      */
-    private function createConsumerStub($queue): Consumer
+    private function createConsumerStub(?Queue $queue = null): Consumer
     {
         $consumerMock = $this->createMock(Consumer::class);
         $consumerMock
             ->expects($this->any())
             ->method('getQueue')
-            ->willReturn($queue)
+            ->willReturn($queue ?? new NullQueue('queue'))
         ;
 
         return $consumerMock;

--- a/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client\Driver;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Config;
 use Enqueue\Client\Driver\AmqpDriver;
 use Enqueue\Client\Driver\GenericDriver;
@@ -336,7 +337,7 @@ class AmqpDriverTest extends TestCase
     protected function assertTransportMessage(InteropMessage $transportMessage): void
     {
         $this->assertSame('body', $transportMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
             'delivery_mode' => AmqpMessage::DELIVERY_MODE_PERSISTENT,
             'content_type' => 'ContentType',

--- a/pkg/enqueue/Tests/Client/Driver/GenericDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/GenericDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client\Driver;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Config;
 use Enqueue\Client\Driver\GenericDriver;
 use Enqueue\Client\DriverInterface;
@@ -60,7 +61,7 @@ class GenericDriverTest extends TestCase
     protected function assertTransportMessage(InteropMessage $transportMessage): void
     {
         $this->assertSame('body', $transportMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
             'message_id' => 'theMessageId',
             'timestamp' => 1000,

--- a/pkg/enqueue/Tests/Client/Driver/GenericDriverTestsTrait.php
+++ b/pkg/enqueue/Tests/Client/Driver/GenericDriverTestsTrait.php
@@ -14,6 +14,7 @@ use Interop\Queue\Message as InteropMessage;
 use Interop\Queue\Producer as InteropProducer;
 use Interop\Queue\Queue as InteropQueue;
 use Interop\Queue\Topic as InteropTopic;
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 
 trait GenericDriverTestsTrait
 {
@@ -1191,10 +1192,10 @@ trait GenericDriverTestsTrait
     protected function assertClientMessage(Message $clientMessage): void
     {
         $this->assertSame('body', $clientMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
         ], $clientMessage->getHeaders());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'pkey' => 'pval',
             Config::CONTENT_TYPE => 'theContentType',
             Config::EXPIRE => '22',

--- a/pkg/enqueue/Tests/Client/Driver/RabbitMqDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RabbitMqDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client\Driver;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Config;
 use Enqueue\Client\Driver\AmqpDriver;
 use Enqueue\Client\Driver\GenericDriver;
@@ -115,7 +116,7 @@ class RabbitMqDriverTest extends TestCase
     protected function assertTransportMessage(InteropMessage $transportMessage): void
     {
         $this->assertSame('body', $transportMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
             'delivery_mode' => AmqpMessage::DELIVERY_MODE_PERSISTENT,
             'content_type' => 'ContentType',

--- a/pkg/enqueue/Tests/Client/ResourcesTest.php
+++ b/pkg/enqueue/Tests/Client/ResourcesTest.php
@@ -28,7 +28,7 @@ class ResourcesTest extends TestCase
     {
         $availableDrivers = Resources::getAvailableDrivers();
 
-        $this->assertInternalType('array', $availableDrivers);
+        $this->assertIsArray($availableDrivers);
         $this->assertGreaterThan(0, count($availableDrivers));
 
         $driverInfo = $availableDrivers[0];
@@ -50,7 +50,7 @@ class ResourcesTest extends TestCase
     {
         $availableDrivers = Resources::getAvailableDrivers();
 
-        $this->assertInternalType('array', $availableDrivers);
+        $this->assertIsArray($availableDrivers);
         $this->assertGreaterThan(0, count($availableDrivers));
 
         $driverInfo = $availableDrivers[1];
@@ -72,7 +72,7 @@ class ResourcesTest extends TestCase
     {
         $knownDrivers = Resources::getAvailableDrivers();
 
-        $this->assertInternalType('array', $knownDrivers);
+        $this->assertIsArray($knownDrivers);
         $this->assertGreaterThan(0, count($knownDrivers));
 
         $driverInfo = $knownDrivers[0];

--- a/pkg/enqueue/Tests/Client/RouterProcessorTest.php
+++ b/pkg/enqueue/Tests/Client/RouterProcessorTest.php
@@ -32,15 +32,6 @@ class RouterProcessorTest extends TestCase
         $this->assertClassFinal(RouterProcessor::class);
     }
 
-    public function testCouldBeConstructedWithDriver()
-    {
-        $driver = $this->createDriverStub();
-
-        $processor = new RouterProcessor($driver);
-
-        $this->assertAttributeSame($driver, 'driver', $processor);
-    }
-
     public function testShouldRejectIfTopicNotSet()
     {
         $router = new RouterProcessor($this->createDriverStub());
@@ -197,13 +188,13 @@ class RouterProcessorTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driver = $this->createMock(DriverInterface::class);
         $driver
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         return $driver;

--- a/pkg/enqueue/Tests/Client/TraceableProducerTest.php
+++ b/pkg/enqueue/Tests/Client/TraceableProducerTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Message;
 use Enqueue\Client\ProducerInterface;
 use Enqueue\Client\TraceableProducer;
@@ -45,7 +46,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendEvent('aFooTopic', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => 'aFooTopic',
                 'command' => null,
@@ -70,7 +71,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendEvent('aFooTopic', ['foo' => 'fooVal', 'bar' => 'barVal']);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => 'aFooTopic',
                 'command' => null,
@@ -106,7 +107,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendEvent('aFooTopic', $message);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => 'aFooTopic',
                 'command' => null,
@@ -168,7 +169,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendCommand('aFooCommand', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => null,
                 'command' => 'aFooCommand',
@@ -193,7 +194,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendCommand('aFooCommand', ['foo' => 'fooVal', 'bar' => 'barVal']);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => null,
                 'command' => 'aFooCommand',
@@ -229,7 +230,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendCommand('aFooCommand', $message);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => null,
                 'command' => 'aFooCommand',
@@ -275,7 +276,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendEvent('aFooTopic', 'aFooBody');
         $producer->sendEvent('aFooTopic', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
                 ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
                 ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
         ], $producer->getTraces());
@@ -288,7 +289,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendEvent('aFooTopic', 'aFooBody');
         $producer->sendEvent('aBarTopic', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
             ['topic' => 'aBarTopic', 'body' => 'aBarBody'],
         ], $producer->getTraces());
@@ -301,11 +302,11 @@ class TraceableProducerTest extends TestCase
         $producer->sendEvent('aFooTopic', 'aFooBody');
         $producer->sendEvent('aBarTopic', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
         ], $producer->getTopicTraces('aFooTopic'));
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['topic' => 'aBarTopic', 'body' => 'aBarBody'],
         ], $producer->getTopicTraces('aBarTopic'));
     }
@@ -317,7 +318,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendCommand('aFooCommand', 'aFooBody');
         $producer->sendCommand('aFooCommand', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
         ], $producer->getTraces());
@@ -330,7 +331,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendCommand('aFooCommand', 'aFooBody');
         $producer->sendCommand('aBarCommand', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
             ['command' => 'aBarCommand', 'body' => 'aBarBody'],
         ], $producer->getTraces());
@@ -343,11 +344,11 @@ class TraceableProducerTest extends TestCase
         $producer->sendCommand('aFooCommand', 'aFooBody');
         $producer->sendCommand('aBarCommand', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
         ], $producer->getCommandTraces('aFooCommand'));
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aBarCommand', 'body' => 'aBarBody'],
         ], $producer->getCommandTraces('aBarCommand'));
     }

--- a/pkg/enqueue/Tests/DoctrineConnectionFactoryFactoryTest.php
+++ b/pkg/enqueue/Tests/DoctrineConnectionFactoryFactoryTest.php
@@ -25,7 +25,7 @@ class DoctrineConnectionFactoryFactoryTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->registry = $this->prophesize(ManagerRegistry::class);
         $this->fallbackFactory = $this->prophesize(ConnectionFactoryFactoryInterface::class);

--- a/pkg/enqueue/Tests/ResourcesTest.php
+++ b/pkg/enqueue/Tests/ResourcesTest.php
@@ -28,7 +28,7 @@ class ResourcesTest extends TestCase
     {
         $availableConnections = Resources::getAvailableConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        $this->assertIsArray($availableConnections);
         $this->assertArrayHasKey(RedisConnectionFactory::class, $availableConnections);
 
         $connectionInfo = $availableConnections[RedisConnectionFactory::class];
@@ -46,7 +46,7 @@ class ResourcesTest extends TestCase
     {
         $availableConnections = Resources::getKnownConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        $this->assertIsArray($availableConnections);
         $this->assertArrayHasKey(RedisConnectionFactory::class, $availableConnections);
 
         $connectionInfo = $availableConnections[RedisConnectionFactory::class];
@@ -93,12 +93,12 @@ class ResourcesTest extends TestCase
         Resources::addConnection('theConnectionClass', ['foo'], [], 'foo');
 
         $knownConnections = Resources::getKnownConnections();
-        $this->assertInternalType('array', $knownConnections);
+        $this->assertIsArray($knownConnections);
         $this->assertArrayHasKey('theConnectionClass', $knownConnections);
 
         $availableConnections = Resources::getAvailableConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        $this->assertIsArray($availableConnections);
         $this->assertArrayNotHasKey('theConnectionClass', $availableConnections);
     }
 
@@ -115,7 +115,7 @@ class ResourcesTest extends TestCase
 
         $availableConnections = Resources::getAvailableConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        $this->assertIsArray($availableConnections);
         $this->assertArrayHasKey($connectionClass, $availableConnections);
 
         $connectionInfo = $availableConnections[$connectionClass];
@@ -133,7 +133,7 @@ class ResourcesTest extends TestCase
     {
         $availableConnections = Resources::getKnownConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        $this->assertIsArray($availableConnections);
         $this->assertArrayHasKey(WampConnectionFactory::class, $availableConnections);
 
         $connectionInfo = $availableConnections[WampConnectionFactory::class];

--- a/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
@@ -605,13 +605,13 @@ class ConsumeCommandTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|DriverInterface
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driverMock = $this->createMock(DriverInterface::class);
         $driverMock
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         $driverMock

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildClientExtensionsPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildClientExtensionsPassTest.php
@@ -72,7 +72,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -99,7 +99,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -125,7 +125,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -151,7 +151,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -247,7 +247,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertCount(4, $extensions->getArgument(0));
     }
 
@@ -275,12 +275,12 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $fooExtensions->getArgument(0));
+        $this->assertIsArray($fooExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $fooExtensions->getArgument(0));
 
-        $this->assertInternalType('array', $barExtensions->getArgument(0));
+        $this->assertIsArray($barExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aBarExtension'),
         ], $barExtensions->getArgument(0));

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildCommandSubscriberRoutesPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildCommandSubscriberRoutesPassTest.php
@@ -96,7 +96,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -120,7 +120,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -144,7 +144,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -166,7 +166,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -222,7 +222,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -266,7 +266,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
 
         $this->assertCount(1, $routeCollection->getArgument(0));
 
@@ -305,7 +305,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -372,7 +372,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(3, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -422,7 +422,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildConsumptionExtensionsPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildConsumptionExtensionsPassTest.php
@@ -72,7 +72,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -99,7 +99,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -125,7 +125,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -151,7 +151,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -247,7 +247,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertCount(4, $extensions->getArgument(0));
     }
 
@@ -275,12 +275,12 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $fooExtensions->getArgument(0));
+        $this->assertIsArray($fooExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $fooExtensions->getArgument(0));
 
-        $this->assertInternalType('array', $barExtensions->getArgument(0));
+        $this->assertIsArray($barExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aBarExtension'),
         ], $barExtensions->getArgument(0));

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildProcessorRoutesPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildProcessorRoutesPassTest.php
@@ -112,7 +112,7 @@ class BuildProcessorRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -136,7 +136,7 @@ class BuildProcessorRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -160,7 +160,7 @@ class BuildProcessorRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -180,7 +180,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -212,7 +212,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -244,7 +244,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -279,7 +279,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(3, $routeCollection->getArgument(0));
 
         $this->assertEquals(

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildTopicSubscriberRoutesPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildTopicSubscriberRoutesPassTest.php
@@ -96,7 +96,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -120,7 +120,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -144,7 +144,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -166,7 +166,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -222,7 +222,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -265,7 +265,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -332,7 +332,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(3, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -379,7 +379,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        $this->assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(

--- a/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
@@ -23,7 +23,7 @@ class FlushSpoolProducerListenerTest extends TestCase
     {
         $events = FlushSpoolProducerListener::getSubscribedEvents();
 
-        $this->assertInternalType('array', $events);
+        $this->assertIsArray($events);
         $this->assertArrayHasKey(KernelEvents::TERMINATE, $events);
 
         $this->assertEquals('flushMessages', $events[KernelEvents::TERMINATE]);
@@ -33,7 +33,7 @@ class FlushSpoolProducerListenerTest extends TestCase
     {
         $events = FlushSpoolProducerListener::getSubscribedEvents();
 
-        $this->assertInternalType('array', $events);
+        $this->assertIsArray($events);
         $this->assertArrayHasKey(ConsoleEvents::TERMINATE, $events);
 
         $this->assertEquals('flushMessages', $events[ConsoleEvents::TERMINATE]);

--- a/pkg/enqueue/Tests/Symfony/Client/RoutesCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/RoutesCommandTest.php
@@ -116,7 +116,7 @@ OUTPUT;
             '--client' => 'foo',
         ]);
 
-        $this->assertContains('Found 1 routes', $tester->getDisplay());
+        $this->assertStringContainsString('Found 1 routes', $tester->getDisplay());
     }
 
     public function testThrowIfClientNotFound()

--- a/pkg/enqueue/Tests/Symfony/Client/SetupBrokerCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/SetupBrokerCommandTest.php
@@ -78,7 +78,7 @@ class SetupBrokerCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
 
-        $this->assertContains('Broker set up', $tester->getDisplay());
+        $this->assertStringContainsString('Broker set up', $tester->getDisplay());
     }
 
     public function testShouldCallRequestedClientDriverSetupBrokerMethod()
@@ -105,7 +105,7 @@ class SetupBrokerCommandTest extends TestCase
             '--client' => 'foo',
         ]);
 
-        $this->assertContains('Broker set up', $tester->getDisplay());
+        $this->assertStringContainsString('Broker set up', $tester->getDisplay());
     }
 
     public function testShouldThrowIfClientNotFound()

--- a/pkg/enqueue/Tests/Symfony/Client/SimpleConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/SimpleConsumeCommandTest.php
@@ -122,13 +122,13 @@ class SimpleConsumeCommandTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|DriverInterface
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driverMock = $this->createMock(DriverInterface::class);
         $driverMock
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         $driverMock

--- a/pkg/enqueue/Tests/Symfony/Client/SimpleSetupBrokerCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/SimpleSetupBrokerCommandTest.php
@@ -74,7 +74,7 @@ class SimpleSetupBrokerCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
 
-        $this->assertContains('Broker set up', $tester->getDisplay());
+        $this->assertStringContainsString('Broker set up', $tester->getDisplay());
     }
 
     /**

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildConsumptionExtensionsPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildConsumptionExtensionsPassTest.php
@@ -72,7 +72,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -99,7 +99,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -125,7 +125,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -151,7 +151,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -247,7 +247,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        $this->assertIsArray($extensions->getArgument(0));
         $this->assertCount(4, $extensions->getArgument(0));
     }
 
@@ -275,12 +275,12 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $fooExtensions->getArgument(0));
+        $this->assertIsArray($fooExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $fooExtensions->getArgument(0));
 
-        $this->assertInternalType('array', $barExtensions->getArgument(0));
+        $this->assertIsArray($barExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aBarExtension'),
         ], $barExtensions->getArgument(0));

--- a/pkg/enqueue/Tests/Util/UUIDTest.php
+++ b/pkg/enqueue/Tests/Util/UUIDTest.php
@@ -11,7 +11,7 @@ class UUIDTest extends TestCase
     {
         $uuid = UUID::generate();
 
-        $this->assertInternalType('string', $uuid);
+        $this->assertIsString($uuid);
         $this->assertEquals(36, strlen($uuid));
     }
 

--- a/pkg/fs/Tests/Functional/FsCommonUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsCommonUseCasesTest.php
@@ -17,7 +17,7 @@ class FsCommonUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsConsumerTest.php
+++ b/pkg/fs/Tests/Functional/FsConsumerTest.php
@@ -15,7 +15,7 @@ class FsConsumerTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsConsumptionUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsConsumptionUseCasesTest.php
@@ -25,7 +25,7 @@ class FsConsumptionUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsProducerTest.php
+++ b/pkg/fs/Tests/Functional/FsProducerTest.php
@@ -14,7 +14,7 @@ class FsProducerTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsRpcUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsRpcUseCasesTest.php
@@ -20,7 +20,7 @@ class FsRpcUseCasesTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/gearman/Tests/SkipIfGearmanExtensionIsNotInstalledTrait.php
+++ b/pkg/gearman/Tests/SkipIfGearmanExtensionIsNotInstalledTrait.php
@@ -4,7 +4,7 @@ namespace Enqueue\Gearman\Tests;
 
 trait SkipIfGearmanExtensionIsNotInstalledTrait
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (false == class_exists(\GearmanClient::class)) {
             $this->markTestSkipped('The gearman extension is not installed');

--- a/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveFromQueueTest.php
+++ b/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveFromQueueTest.php
@@ -13,7 +13,7 @@ class GearmanSendToTopicAndReceiveFromQueueTest extends SendToTopicAndReceiveFro
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveNoWaitFromQueueTest.php
@@ -13,7 +13,7 @@ class GearmanSendToTopicAndReceiveNoWaitFromQueueTest extends SendToTopicAndRece
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/gps/Tests/GpsConnectionFactoryConfigTest.php
+++ b/pkg/gps/Tests/GpsConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Gps\Tests;
 
 use Enqueue\Gps\GpsConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class GpsConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {
@@ -47,7 +49,7 @@ class GpsConnectionFactoryConfigTest extends TestCase
     {
         $factory = new GpsConnectionFactory($config);
 
-        $this->assertAttributeEquals($expectedConfig, 'config', $factory);
+        self::assertEquals($expectedConfig, $this->readAttribute($factory, 'config'));
     }
 
     public static function provideConfigs()

--- a/pkg/job-queue/Tests/Functional/WebTestCase.php
+++ b/pkg/job-queue/Tests/Functional/WebTestCase.php
@@ -18,7 +18,7 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected static $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/mongodb/Tests/Functional/MongodbConsumerTest.php
+++ b/pkg/mongodb/Tests/Functional/MongodbConsumerTest.php
@@ -19,7 +19,7 @@ class MongodbConsumerTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildMongodbContext();
     }

--- a/pkg/mongodb/Tests/Spec/MongodbSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/mongodb/Tests/Spec/MongodbSendAndReceivePriorityMessagesFromQueueTest.php
@@ -18,7 +18,7 @@ class MongodbSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceiveP
 
     private $publishedAt;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveFromQueueTest.php
+++ b/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveFromQueueTest.php
@@ -13,7 +13,7 @@ class PheanstalkSendToTopicAndReceiveFromQueueTest extends SendToTopicAndReceive
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest.php
@@ -13,7 +13,7 @@ class PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest extends SendToTopicAndR
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/rdkafka/Tests/JsonSerializerTest.php
+++ b/pkg/rdkafka/Tests/JsonSerializerTest.php
@@ -43,7 +43,7 @@ class JsonSerializerTest extends TestCase
         $resource = fopen(__FILE__, 'r');
 
         //guard
-        $this->assertInternalType('resource', $resource);
+        $this->assertIsResource($resource);
 
         $message = new RdKafkaMessage('theBody', ['aProp' => $resource]);
 

--- a/pkg/redis/Tests/Functional/PRedisCommonUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PRedisCommonUseCasesTest.php
@@ -19,7 +19,7 @@ class PRedisCommonUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPRedisContext();
 

--- a/pkg/redis/Tests/Functional/PRedisConsumptionUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PRedisConsumptionUseCasesTest.php
@@ -19,7 +19,7 @@ class PRedisConsumptionUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPRedisContext();
 

--- a/pkg/redis/Tests/Functional/PhpRedisCommonUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PhpRedisCommonUseCasesTest.php
@@ -19,7 +19,7 @@ class PhpRedisCommonUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPhpRedisContext();
 

--- a/pkg/redis/Tests/Functional/PhpRedisConsumptionUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PhpRedisConsumptionUseCasesTest.php
@@ -19,7 +19,7 @@ class PhpRedisConsumptionUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPhpRedisContext();
 

--- a/pkg/redis/Tests/Spec/JsonSerializerTest.php
+++ b/pkg/redis/Tests/Spec/JsonSerializerTest.php
@@ -43,7 +43,7 @@ class JsonSerializerTest extends TestCase
         $resource = fopen(__FILE__, 'r');
 
         //guard
-        $this->assertInternalType('resource', $resource);
+        $this->assertIsResource($resource);
 
         $message = new RedisMessage('theBody', ['aProp' => $resource]);
 

--- a/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
@@ -27,7 +27,7 @@ class SqsCommonUseCasesTest extends TestCase
      */
     private $queueName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/sqs/Tests/Functional/SqsConsumptionUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsConsumptionUseCasesTest.php
@@ -26,7 +26,7 @@ class SqsConsumptionUseCasesTest extends TestCase
      */
     private $context;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
@@ -20,7 +20,7 @@ class StompCommonUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $stompContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 

--- a/pkg/stomp/Tests/Functional/StompConsumptionUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompConsumptionUseCasesTest.php
@@ -28,7 +28,7 @@ class StompConsumptionUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $stompContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 

--- a/pkg/stomp/Tests/Functional/StompRpcUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompRpcUseCasesTest.php
@@ -22,7 +22,7 @@ class StompRpcUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $stompContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 

--- a/pkg/test/ReadAttributeTrait.php
+++ b/pkg/test/ReadAttributeTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enqueue\Test;
+
+trait ReadAttributeTrait
+{
+    public function readAttribute(object $object, string $attribute)
+    {
+        $refProperty = new \ReflectionProperty(get_class($object), $attribute);
+        $refProperty->setAccessible(true);
+        $value = $refProperty->getValue($object);
+        $refProperty->setAccessible(false);
+        return $value;
+    }
+}

--- a/pkg/wamp/Tests/Functional/WampConsumerTest.php
+++ b/pkg/wamp/Tests/Functional/WampConsumerTest.php
@@ -19,7 +19,7 @@ class WampConsumerTest extends TestCase
     use WampExtension;
     use RetryTrait;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Logger::set(new NullLogger());
     }

--- a/pkg/wamp/Tests/Functional/WampSubscriptionConsumerTest.php
+++ b/pkg/wamp/Tests/Functional/WampSubscriptionConsumerTest.php
@@ -16,7 +16,7 @@ class WampSubscriptionConsumerTest extends TestCase
 {
     use WampExtension;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Logger::set(new NullLogger());
     }

--- a/pkg/wamp/Tests/Spec/JsonSerializerTest.php
+++ b/pkg/wamp/Tests/Spec/JsonSerializerTest.php
@@ -43,7 +43,7 @@ class JsonSerializerTest extends TestCase
         $resource = fopen(__FILE__, 'r');
 
         //guard
-        $this->assertInternalType('resource', $resource);
+        $this->assertIsResource($resource);
 
         $message = new WampMessage('theBody', ['aProp' => $resource]);
 


### PR DESCRIPTION
Hello, I will try to update tests to support php 8, just started with bumping versions in composer.json and cleaning up travis builds, but need help from maintainers to keep going, I have couple of questions:

1. Can someone please create a new branch for php8 as it will be not backward compatible with enq 0.10.x, so next major version (0.11.x) will be merged there?

2. What's the best possible way to update docker, as I need php8 but docker images that used in this project do not support php 8 yet (https://github.com/makasim/docker-nginx-php-fpm - latest is 7.3 pushed more than year ago) so what would you suggest - create PR to https://github.com/makasim/docker-nginx-php-fpm with php8 image and wait till it will be pushed to registry or better to put local Dockerfile right into this repository?

Roadmap:

- [ ] Add docker php 8 image
- [ ] Check that composer dependencies installing without issues
- [ ] Update packages if needed to support php 8
- [ ] Update codebase to comply with new packages requirements
- [ ] Update tests, make sure everything works