### PR TITLE
Fix - Bad parameter for exception

### DIFF
--- a/pkg/stomp/StompConsumer.php
+++ b/pkg/stomp/StompConsumer.php
@@ -111,7 +111,7 @@ class StompConsumer implements Consumer
                 }
             }
         } catch (ErrorFrameException $e) {
-            throw new Exception($e->getMessage()."\n".$e->getFrame()->getBody(), null, $e);
+            throw new Exception($e->getMessage()."\n".$e->getFrame()->getBody(), 0, $e);
         }
 
         return null;


### PR DESCRIPTION
I noticed some errors earlier when this line gets hit for exceptions.  I believe the issue is the `null` instead of a `0` to match the default parameter.