### PR TITLE
Allow ext-rdkafka 5

### DIFF
--- a/pkg/rdkafka/composer.json
+++ b/pkg/rdkafka/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
-        "ext-rdkafka": "^3.0.3|^4.0",
+        "ext-rdkafka": "^3.0.3|^4.0|^5.0",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {


### PR DESCRIPTION
ext-rdkafka v5.0 is out! As per the [release notes](https://github.com/arnaud-lb/php-rdkafka/releases/tag/5.0.0), there is no impact on enqueue.
