### PR TITLE
PHPUnit 9.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.4'
           coverage: none
           extensions: mongodb, redis, :xdebug
           ini-values: memory_limit=2048M
@@ -63,7 +63,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.4'
           coverage: none
           extensions: mongodb, redis, :xdebug
           ini-values: memory_limit=2048M
@@ -81,24 +81,6 @@ jobs:
       matrix:
         php: ['7.4']
         include:
-          - php: 7.1
-            symfony_version: 4.3.*
-            unit_tests: true
-            functional_tests: false
-            rdkafka_tests: false
-            prepare_container: false
-          - php: 7.2
-            symfony_version: 4.3.*
-            unit_tests: true
-            functional_tests: false
-            rdkafka_tests: false
-            prepare_container: false
-          - php: 7.2
-            symfony_version: 5.0.*
-            unit_tests: true
-            functional_tests: false
-            rdkafka_tests: false
-            prepare_container: false
           - php: 7.3
             symfony_version: 4.3.*
             unit_tests: true
@@ -151,6 +133,23 @@ jobs:
             symfony_version: 4.3.*
             unit_tests: false
             functional_tests: false
+            rdkafka_tests: true
+            prepare_container: true
+          - php: 8.0
+            symfony_version: 5.2.*
+            unit_tests: true
+            functional_tests: false
+            rdkafka_tests: false
+            prepare_container: false
+          - php: 8.0
+            symfony_version: 5.2.*
+            unit_tests: false
+            functional_tests: true
+            rdkafka_tests: false
+            prepare_container: true
+          - php: 8.0
+            symfony_version: 5.2.*
+            unit_tests: false
             rdkafka_tests: true
             prepare_container: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,23 +136,6 @@ jobs:
             functional_tests: false
             rdkafka_tests: true
             prepare_container: true
-          - php: 8.0
-            symfony_version: 5.2.*
-            unit_tests: true
-            functional_tests: false
-            rdkafka_tests: false
-            prepare_container: false
-          - php: 8.0
-            symfony_version: 5.2.*
-            unit_tests: false
-            functional_tests: true
-            rdkafka_tests: false
-            prepare_container: true
-          - php: 8.0
-            symfony_version: 5.2.*
-            unit_tests: false
-            rdkafka_tests: true
-            prepare_container: true
 
     name: PHP ${{ matrix.php }} tests on Sf ${{ matrix.symfony_version }}, unit=${{ matrix.unit_tests }}, func=${{ matrix.functional_tests }}, rdkafka=${{ matrix.rdkafka_tests }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php: ['7.4']
         include:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ var
 .php_cs
 .php_cs.cache
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
     "alcaeus/mongo-php-adapter": "^1.0",
     "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
     "friendsofphp/php-cs-fixer": "^2",
-    "dms/phpunit-arraysubset-asserts": "^0.2.1"
+    "dms/phpunit-arraysubset-asserts": "^0.2.1",
+    "phpspec/prophecy-phpunit": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "datadog/php-datadogstatsd": "^1.3"
   },
   "require-dev": {
+    "ext-pcntl": "*",
     "phpunit/phpunit": "^9.5",
     "phpstan/phpstan": "^0.12",
     "queue-interop/queue-spec": "^0.6",
@@ -60,7 +61,8 @@
     "doctrine/mongodb-odm-bundle": "^3.5|^4",
     "alcaeus/mongo-php-adapter": "^1.0",
     "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
-    "friendsofphp/php-cs-fixer": "^2"
+    "friendsofphp/php-cs-fixer": "^2",
+    "dms/phpunit-arraysubset-asserts": "^0.2.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
     "phpstan": "bin/phpstan analyse --memory-limit=512M -c phpstan.neon"
   },
   "require": {
-    "php": "^7.3|^8.0",
+    "php": "^7.3",
 
     "ext-amqp": "^1.9.3",
     "ext-gearman": "^2.0",
     "ext-mongodb": "^1.5",
-    "ext-rdkafka": "^3.0.3",
+    "ext-rdkafka": "^3.0.3|^4.0|^5.0",
 
     "queue-interop/amqp-interop": "^0.8",
     "queue-interop/queue-interop": "^0.7|^0.8",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "phpstan": "bin/phpstan analyse --memory-limit=512M -c phpstan.neon"
   },
   "require": {
-    "php": "^7.1.3",
+    "php": "^7.3|^8.0",
 
     "ext-amqp": "^1.9.3",
     "ext-gearman": "^2.0",
@@ -41,7 +41,7 @@
     "datadog/php-datadogstatsd": "^1.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5",
+    "phpunit/phpunit": "^9.5",
     "phpstan/phpstan": "^0.12",
     "queue-interop/queue-spec": "^0.6",
     "symfony/browser-kit": "^3.4|^4",

--- a/docs/bundle/functional_testing.md
+++ b/docs/bundle/functional_testing.md
@@ -57,7 +57,7 @@ class FooTest extends WebTestCase
     /** @var  \Symfony\Bundle\FrameworkBundle\Client */
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = static::createClient();
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"
@@ -129,12 +129,12 @@
         <env name="SHELL_VERBOSITY" value="-1"/>
     </php>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">.</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/pkg/amqp-bunny/Tests/AmqpConnectionFactoryTest.php
+++ b/pkg/amqp-bunny/Tests/AmqpConnectionFactoryTest.php
@@ -5,12 +5,14 @@ namespace Enqueue\AmqpBunny\Tests;
 use Enqueue\AmqpBunny\AmqpConnectionFactory;
 use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
 class AmqpConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/amqp-bunny/composer.json
+++ b/pkg/amqp-bunny/composer.json
@@ -6,14 +6,14 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "bunny/bunny": "^0.4",
         "enqueue/amqp-tools": "^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"

--- a/pkg/amqp-ext/Tests/AmqpConnectionFactoryTest.php
+++ b/pkg/amqp-ext/Tests/AmqpConnectionFactoryTest.php
@@ -6,12 +6,14 @@ use Enqueue\AmqpExt\AmqpConnectionFactory;
 use Enqueue\AmqpExt\AmqpContext;
 use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
 class AmqpConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {
@@ -34,6 +36,6 @@ class AmqpConnectionFactoryTest extends TestCase
         $this->assertInstanceOf(AmqpContext::class, $context);
 
         $this->assertAttributeEquals(null, 'extChannel', $context);
-        $this->assertInternalType('callable', $this->readAttribute($context, 'extChannelFactory'));
+        self::assertIsCallable($this->readAttribute($context, 'extChannelFactory'));
     }
 }

--- a/pkg/amqp-ext/Tests/AmqpContextTest.php
+++ b/pkg/amqp-ext/Tests/AmqpContextTest.php
@@ -9,6 +9,7 @@ use Enqueue\AmqpExt\AmqpSubscriptionConsumer;
 use Enqueue\Null\NullQueue;
 use Enqueue\Null\NullTopic;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Amqp\Impl\AmqpMessage;
 use Interop\Amqp\Impl\AmqpQueue;
 use Interop\Amqp\Impl\AmqpTopic;
@@ -20,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 class AmqpContextTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementQueueInteropContextInterface()
     {

--- a/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
@@ -14,15 +14,15 @@ use PHPUnit\Framework\TestCase;
  */
 class AmqpCommonUseCasesTest extends TestCase
 {
-    use RabbitmqAmqpExtension;
     use RabbitManagementExtensionTrait;
+    use RabbitmqAmqpExtension;
 
     /**
      * @var AmqpContext
      */
     private $amqpContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 
@@ -30,7 +30,7 @@ class AmqpCommonUseCasesTest extends TestCase
         $this->removeExchange('amqp_ext.test_exchange');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->amqpContext->close();
     }

--- a/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
@@ -128,7 +128,7 @@ class AmqpCommonUseCasesTest extends TestCase
     public function testProduceAndReceiveOneMessageSentDirectlyToTopic()
     {
         $topic = $this->amqpContext->createTopic('amqp_ext.test_exchange');
-        $topic->setType(AMQP_EX_TYPE_FANOUT);
+        $topic->setType(\AMQP_EX_TYPE_FANOUT);
         $this->amqpContext->declareTopic($topic);
 
         $queue = $this->amqpContext->createQueue('amqp_ext.test');
@@ -153,7 +153,7 @@ class AmqpCommonUseCasesTest extends TestCase
     public function testConsumerReceiveMessageFromTopicDirectly()
     {
         $topic = $this->amqpContext->createTopic('amqp_ext.test_exchange');
-        $topic->setType(AMQP_EX_TYPE_FANOUT);
+        $topic->setType(\AMQP_EX_TYPE_FANOUT);
 
         $this->amqpContext->declareTopic($topic);
 
@@ -176,7 +176,7 @@ class AmqpCommonUseCasesTest extends TestCase
     public function testConsumerReceiveMessageWithZeroTimeout()
     {
         $topic = $this->amqpContext->createTopic('amqp_ext.test_exchange');
-        $topic->setType(AMQP_EX_TYPE_FANOUT);
+        $topic->setType(\AMQP_EX_TYPE_FANOUT);
 
         $this->amqpContext->declareTopic($topic);
 

--- a/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
@@ -22,7 +22,7 @@ class AmqpCommonUseCasesTest extends TestCase
      */
     private $amqpContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 

--- a/pkg/amqp-ext/Tests/Functional/AmqpConsumptionUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpConsumptionUseCasesTest.php
@@ -21,22 +21,22 @@ use PHPUnit\Framework\TestCase;
  */
 class AmqpConsumptionUseCasesTest extends TestCase
 {
-    use RabbitmqAmqpExtension;
     use RabbitManagementExtensionTrait;
+    use RabbitmqAmqpExtension;
 
     /**
      * @var AmqpContext
      */
     private $amqpContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 
         $this->removeQueue('amqp_ext.test');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->amqpContext->close();
     }

--- a/pkg/amqp-ext/Tests/Functional/AmqpConsumptionUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpConsumptionUseCasesTest.php
@@ -29,7 +29,7 @@ class AmqpConsumptionUseCasesTest extends TestCase
      */
     private $amqpContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 

--- a/pkg/amqp-ext/Tests/Functional/AmqpRpcUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpRpcUseCasesTest.php
@@ -15,15 +15,15 @@ use PHPUnit\Framework\TestCase;
  */
 class AmqpRpcUseCasesTest extends TestCase
 {
-    use RabbitmqAmqpExtension;
     use RabbitManagementExtensionTrait;
+    use RabbitmqAmqpExtension;
 
     /**
      * @var AmqpContext
      */
     private $amqpContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 
@@ -31,7 +31,7 @@ class AmqpRpcUseCasesTest extends TestCase
         $this->removeQueue('rpc.reply_test');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->amqpContext->close();
     }

--- a/pkg/amqp-ext/Tests/Functional/AmqpRpcUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpRpcUseCasesTest.php
@@ -23,7 +23,7 @@ class AmqpRpcUseCasesTest extends TestCase
      */
     private $amqpContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->amqpContext = $this->buildAmqpContext();
 

--- a/pkg/amqp-ext/composer.json
+++ b/pkg/amqp-ext/composer.json
@@ -6,14 +6,14 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "ext-amqp": "^1.9.3",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/amqp-tools": "^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6",

--- a/pkg/amqp-lib/Tests/AmqpConnectionFactoryTest.php
+++ b/pkg/amqp-lib/Tests/AmqpConnectionFactoryTest.php
@@ -5,12 +5,14 @@ namespace Enqueue\AmqpLib\Tests;
 use Enqueue\AmqpLib\AmqpConnectionFactory;
 use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
 class AmqpConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/amqp-lib/Tests/AmqpContextTest.php
+++ b/pkg/amqp-lib/Tests/AmqpContextTest.php
@@ -322,12 +322,12 @@ class AmqpContextTest extends TestCase
     {
         $channel = $this->createChannelMock();
         $channel
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('basic_qos')
             ->with($this->identicalTo(0), $this->identicalTo(1), $this->isFalse())
         ;
         $channel
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('basic_qos')
             ->with($this->identicalTo(123), $this->identicalTo(456), $this->isTrue())
         ;

--- a/pkg/amqp-lib/Tests/AmqpContextTest.php
+++ b/pkg/amqp-lib/Tests/AmqpContextTest.php
@@ -322,12 +322,12 @@ class AmqpContextTest extends TestCase
     {
         $channel = $this->createChannelMock();
         $channel
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('basic_qos')
             ->with($this->identicalTo(0), $this->identicalTo(1), $this->isFalse())
         ;
         $channel
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('basic_qos')
             ->with($this->identicalTo(123), $this->identicalTo(456), $this->isTrue())
         ;

--- a/pkg/amqp-lib/composer.json
+++ b/pkg/amqp-lib/composer.json
@@ -6,14 +6,14 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "php-amqplib/php-amqplib": "^2.10",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/amqp-tools": "^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"

--- a/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
+++ b/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
@@ -3,10 +3,13 @@
 namespace Enqueue\AmqpTools\Tests;
 
 use Enqueue\AmqpTools\SignalSocketHelper;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 class SignalSocketHelperTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     /**
      * @var SignalSocketHelper
      */
@@ -76,7 +79,7 @@ class SignalSocketHelperTest extends TestCase
 
         $handlers = $this->readAttribute($this->signalHelper, 'handlers');
 
-        $this->assertInternalType('array', $handlers);
+        self::assertIsArray($handlers);
         $this->assertArrayHasKey(SIGTERM, $handlers);
         $this->assertSame($handler, $handlers[SIGTERM]);
     }

--- a/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
+++ b/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
@@ -16,7 +16,7 @@ class SignalSocketHelperTest extends TestCase
 
     private $backupSigIntHandler;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
+++ b/pkg/amqp-tools/Tests/SignalSocketHelperTest.php
@@ -19,7 +19,7 @@ class SignalSocketHelperTest extends TestCase
 
     private $backupSigIntHandler;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -28,16 +28,16 @@ class SignalSocketHelperTest extends TestCase
             $this->markTestSkipped('PHP 7.1+ needed');
         }
 
-        $this->backupSigTermHandler = pcntl_signal_get_handler(SIGTERM);
-        $this->backupSigIntHandler = pcntl_signal_get_handler(SIGINT);
+        $this->backupSigTermHandler = pcntl_signal_get_handler(\SIGTERM);
+        $this->backupSigIntHandler = pcntl_signal_get_handler(\SIGINT);
 
-        pcntl_signal(SIGTERM, SIG_DFL);
-        pcntl_signal(SIGINT, SIG_DFL);
+        pcntl_signal(\SIGTERM, \SIG_DFL);
+        pcntl_signal(\SIGINT, \SIG_DFL);
 
         $this->signalHelper = new SignalSocketHelper();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -46,11 +46,11 @@ class SignalSocketHelperTest extends TestCase
         }
 
         if ($this->backupSigTermHandler) {
-            pcntl_signal(SIGTERM, $this->backupSigTermHandler);
+            pcntl_signal(\SIGTERM, $this->backupSigTermHandler);
         }
 
         if ($this->backupSigIntHandler) {
-            pcntl_signal(SIGINT, $this->backupSigIntHandler);
+            pcntl_signal(\SIGINT, $this->backupSigIntHandler);
         }
     }
 
@@ -71,7 +71,7 @@ class SignalSocketHelperTest extends TestCase
     {
         $handler = function () {};
 
-        pcntl_signal(SIGTERM, $handler);
+        pcntl_signal(\SIGTERM, $handler);
 
         $this->signalHelper->beforeSocket();
 
@@ -80,8 +80,8 @@ class SignalSocketHelperTest extends TestCase
         $handlers = $this->readAttribute($this->signalHelper, 'handlers');
 
         self::assertIsArray($handlers);
-        $this->assertArrayHasKey(SIGTERM, $handlers);
-        $this->assertSame($handler, $handlers[SIGTERM]);
+        $this->assertArrayHasKey(\SIGTERM, $handlers);
+        $this->assertSame($handler, $handlers[\SIGTERM]);
     }
 
     public function testRestoreDefaultPropertiesOnAfterSocket()
@@ -97,12 +97,12 @@ class SignalSocketHelperTest extends TestCase
     {
         $handler = function () {};
 
-        pcntl_signal(SIGTERM, $handler);
+        pcntl_signal(\SIGTERM, $handler);
 
         $this->signalHelper->beforeSocket();
         $this->signalHelper->afterSocket();
 
-        $this->assertSame($handler, pcntl_signal_get_handler(SIGTERM));
+        $this->assertSame($handler, pcntl_signal_get_handler(\SIGTERM));
     }
 
     public function testThrowsIfBeforeSocketCalledSecondTime()
@@ -118,7 +118,7 @@ class SignalSocketHelperTest extends TestCase
     {
         $this->signalHelper->beforeSocket();
 
-        posix_kill(getmypid(), SIGINT);
+        posix_kill(getmypid(), \SIGINT);
         pcntl_signal_dispatch();
 
         $this->assertTrue($this->signalHelper->wasThereSignal());

--- a/pkg/amqp-tools/composer.json
+++ b/pkg/amqp-tools/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev"
     },

--- a/pkg/async-command/Tests/RunCommandProcessorTest.php
+++ b/pkg/async-command/Tests/RunCommandProcessorTest.php
@@ -3,11 +3,14 @@
 namespace Enqueue\AsyncCommand\Tests;
 
 use Enqueue\AsyncCommand\RunCommandProcessor;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Processor;
 use PHPUnit\Framework\TestCase;
 
 class RunCommandProcessorTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     public function testShouldImplementProcessorInterface()
     {
         $rc = new \ReflectionClass(RunCommandProcessor::class);

--- a/pkg/async-command/composer.json
+++ b/pkg/async-command/composer.json
@@ -13,7 +13,7 @@
         "symfony/process": "^4.3|^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^4.3|^5",
         "symfony/config": "^4.3|^5",
         "symfony/http-kernel": "^4.3|^5",

--- a/pkg/async-event-dispatcher/Tests/AsyncListenerTest.php
+++ b/pkg/async-event-dispatcher/Tests/AsyncListenerTest.php
@@ -8,6 +8,7 @@ use Enqueue\AsyncEventDispatcher\Registry;
 use Enqueue\Null\NullMessage;
 use Enqueue\Null\NullQueue;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Context;
 use Interop\Queue\Producer;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -20,6 +21,7 @@ use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 class AsyncListenerTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testCouldBeConstructedWithContextAndRegistryAndEventQueueAsString()
     {

--- a/pkg/async-event-dispatcher/Tests/ContainerAwareRegistryTest.php
+++ b/pkg/async-event-dispatcher/Tests/ContainerAwareRegistryTest.php
@@ -6,12 +6,14 @@ use Enqueue\AsyncEventDispatcher\ContainerAwareRegistry;
 use Enqueue\AsyncEventDispatcher\EventTransformer;
 use Enqueue\AsyncEventDispatcher\Registry;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 
 class ContainerAwareRegistryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementRegistryInterface()
     {

--- a/pkg/async-event-dispatcher/Tests/Functional/UseCasesTest.php
+++ b/pkg/async-event-dispatcher/Tests/Functional/UseCasesTest.php
@@ -53,7 +53,7 @@ class UseCasesTest extends TestCase
      */
     protected $asyncProcessor;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         (new Filesystem())->remove(__DIR__.'/queues/');
 

--- a/pkg/async-event-dispatcher/Tests/Functional/UseCasesTest.php
+++ b/pkg/async-event-dispatcher/Tests/Functional/UseCasesTest.php
@@ -53,7 +53,7 @@ class UseCasesTest extends TestCase
      */
     protected $asyncProcessor;
 
-    public function setUp()
+    public function setUp(): void
     {
         (new Filesystem())->remove(__DIR__.'/queues/');
 

--- a/pkg/async-event-dispatcher/composer.json
+++ b/pkg/async-event-dispatcher/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "enqueue/enqueue": "^0.10",
         "queue-interop/queue-interop": "^0.8",
         "symfony/event-dispatcher": "^4.3|^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^4.3|^5",
         "symfony/config": "^4.3|^5",
         "symfony/http-kernel": "^4.3|^5",

--- a/pkg/dbal/Tests/DbalConnectionFactoryConfigTest.php
+++ b/pkg/dbal/Tests/DbalConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Dbal\Tests;
 
 use Enqueue\Dbal\DbalConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class DbalConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/dbal/Tests/DbalConnectionFactoryTest.php
+++ b/pkg/dbal/Tests/DbalConnectionFactoryTest.php
@@ -28,7 +28,7 @@ class DbalConnectionFactoryTest extends TestCase
         $this->assertInstanceOf(DbalContext::class, $context);
 
         $this->assertAttributeEquals(null, 'connection', $context);
-        $this->assertAttributeInternalType('callable', 'connectionFactory', $context);
+        $this->assertIsCallable($this->readAttribute($context, 'connectionFactory'));
     }
 
     public function testShouldParseGenericDSN()

--- a/pkg/dbal/Tests/DbalConnectionFactoryTest.php
+++ b/pkg/dbal/Tests/DbalConnectionFactoryTest.php
@@ -5,12 +5,14 @@ namespace Enqueue\Dbal\Tests;
 use Enqueue\Dbal\DbalConnectionFactory;
 use Enqueue\Dbal\DbalContext;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
 class DbalConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/dbal/Tests/DbalContextTest.php
+++ b/pkg/dbal/Tests/DbalContextTest.php
@@ -9,6 +9,7 @@ use Enqueue\Dbal\DbalDestination;
 use Enqueue\Dbal\DbalMessage;
 use Enqueue\Dbal\DbalProducer;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Context;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
@@ -19,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 class DbalContextTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementContextInterface()
     {

--- a/pkg/dbal/Tests/DbalSubscriptionConsumerTest.php
+++ b/pkg/dbal/Tests/DbalSubscriptionConsumerTest.php
@@ -7,6 +7,7 @@ namespace Enqueue\Dbal\Tests;
 use Enqueue\Dbal\DbalConsumer;
 use Enqueue\Dbal\DbalContext;
 use Enqueue\Dbal\DbalSubscriptionConsumer;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Queue;
 use Interop\Queue\SubscriptionConsumer;
@@ -15,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 
 class DbalSubscriptionConsumerTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     public function testShouldImplementSubscriptionConsumerInterface()
     {
         $rc = new \ReflectionClass(DbalSubscriptionConsumer::class);

--- a/pkg/dbal/Tests/Functional/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/Functional/DbalConsumerTest.php
@@ -21,7 +21,7 @@ class DbalConsumerTest extends TestCase
      */
     private $context;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->context = $this->createDbalContext();
     }

--- a/pkg/dbal/Tests/Functional/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/Functional/DbalConsumerTest.php
@@ -21,7 +21,7 @@ class DbalConsumerTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->createDbalContext();
     }

--- a/pkg/dbal/Tests/ManagerRegistryConnectionFactoryTest.php
+++ b/pkg/dbal/Tests/ManagerRegistryConnectionFactoryTest.php
@@ -7,6 +7,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Enqueue\Dbal\DbalContext;
 use Enqueue\Dbal\ManagerRegistryConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 class ManagerRegistryConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/dbal/Tests/ManagerRegistryConnectionFactoryTest.php
+++ b/pkg/dbal/Tests/ManagerRegistryConnectionFactoryTest.php
@@ -73,7 +73,7 @@ class ManagerRegistryConnectionFactoryTest extends TestCase
         $this->assertInstanceOf(DbalContext::class, $context);
 
         $this->assertAttributeEquals(null, 'connection', $context);
-        $this->assertAttributeInternalType('callable', 'connectionFactory', $context);
+        $this->assertIsCallable($this->readAttribute($context, 'connectionFactory'));
     }
 
     /**

--- a/pkg/dbal/Tests/Spec/Mysql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/dbal/Tests/Spec/Mysql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
@@ -16,7 +16,7 @@ class DbalSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceivePrio
 
     private $publishedAt;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/dbal/Tests/Spec/Mysql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/dbal/Tests/Spec/Mysql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
@@ -16,7 +16,7 @@ class DbalSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceivePrio
 
     private $publishedAt;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/dbal/Tests/Spec/Postgresql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/dbal/Tests/Spec/Postgresql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
@@ -16,7 +16,7 @@ class DbalSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceivePrio
 
     private $publishedAt;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/dbal/Tests/Spec/Postgresql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/dbal/Tests/Spec/Postgresql/DbalSendAndReceivePriorityMessagesFromQueueTest.php
@@ -16,7 +16,7 @@ class DbalSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceivePrio
 
     private $publishedAt;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/dbal/composer.json
+++ b/pkg/dbal/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "doctrine/dbal": "^2.6",
         "ramsey/uuid": "^3|^4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncListenerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncListenerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncListenerTest extends WebTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncListenerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncListenerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncListenerTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncProcessorTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncProcessorTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncProcessorTest extends WebTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncProcessorTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncProcessorTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncProcessorTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncSubscriberTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncSubscriberTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncSubscriberTest extends WebTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/Events/AsyncSubscriberTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/Events/AsyncSubscriberTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AsyncSubscriberTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Functional/LazyProducerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/LazyProducerTest.php
@@ -11,13 +11,13 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class LazyProducerTest extends WebTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         // do not call parent::setUp.
         // parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (static::$kernel) {
             $fs = new Filesystem();

--- a/pkg/enqueue-bundle/Tests/Functional/LazyProducerTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/LazyProducerTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class LazyProducerTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // do not call parent::setUp.
         // parent::setUp();

--- a/pkg/enqueue-bundle/Tests/Functional/RoutesCommandTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/RoutesCommandTest.php
@@ -26,11 +26,11 @@ class RoutesCommandTest extends WebTestCase
         $tester->execute([]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('| topic', $tester->getDisplay());
-        $this->assertContains('| theTopic', $tester->getDisplay());
-        $this->assertContains('| default (prefixed)', $tester->getDisplay());
-        $this->assertContains('| test_topic_subscriber_processor', $tester->getDisplay());
-        $this->assertContains('| (hidden)', $tester->getDisplay());
+        $this->assertStringContainsString('| topic', $tester->getDisplay());
+        $this->assertStringContainsString('| theTopic', $tester->getDisplay());
+        $this->assertStringContainsString('| default (prefixed)', $tester->getDisplay());
+        $this->assertStringContainsString('| test_topic_subscriber_processor', $tester->getDisplay());
+        $this->assertStringContainsString('| (hidden)', $tester->getDisplay());
     }
 
     public function testShouldDisplayCommands()
@@ -42,10 +42,10 @@ class RoutesCommandTest extends WebTestCase
         $tester->execute([]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('| command', $tester->getDisplay());
-        $this->assertContains('| theCommand', $tester->getDisplay());
-        $this->assertContains('| test_command_subscriber_processor', $tester->getDisplay());
-        $this->assertContains('| default (prefixed)', $tester->getDisplay());
-        $this->assertContains('| (hidden)', $tester->getDisplay());
+        $this->assertStringContainsString('| command', $tester->getDisplay());
+        $this->assertStringContainsString('| theCommand', $tester->getDisplay());
+        $this->assertStringContainsString('| test_command_subscriber_processor', $tester->getDisplay());
+        $this->assertStringContainsString('| default (prefixed)', $tester->getDisplay());
+        $this->assertStringContainsString('| (hidden)', $tester->getDisplay());
     }
 }

--- a/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
@@ -20,13 +20,13 @@ class UseCasesTest extends WebTestCase
 {
     const RECEIVE_TIMEOUT = 500;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         // do not call parent::setUp.
         // parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if ($this->getContext()) {
             $this->getContext()->close();

--- a/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
+++ b/pkg/enqueue-bundle/Tests/Functional/UseCasesTest.php
@@ -20,7 +20,7 @@ class UseCasesTest extends WebTestCase
 {
     const RECEIVE_TIMEOUT = 500;
 
-    public function setUp()
+    public function setUp(): void
     {
         // do not call parent::setUp.
         // parent::setUp();

--- a/pkg/enqueue-bundle/Tests/Functional/WebTestCase.php
+++ b/pkg/enqueue-bundle/Tests/Functional/WebTestCase.php
@@ -20,7 +20,7 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected static $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/DoctrinePingConnectionExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/DoctrinePingConnectionExtensionTest.php
@@ -135,10 +135,6 @@ class DoctrinePingConnectionExtensionTest extends TestCase
         ;
 
         $context = $this->createContext();
-        $context->getLogger()
-            ->expects($this->never())
-            ->method('debug')
-        ;
 
         $registry = $this->createRegistryMock();
         $registry
@@ -149,6 +145,10 @@ class DoctrinePingConnectionExtensionTest extends TestCase
 
         $extension = new DoctrinePingConnectionExtension($registry);
         $extension->onMessageReceived($context);
+
+        /** @var TestLogger $logger */
+        $logger = $context->getLogger();
+        $this->assertFalse($logger->hasDebugRecords());
     }
 
     protected function createContext(): MessageReceived

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\Tests\Unit\DependencyInjection;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Bundle\DependencyInjection\Configuration;
 use Enqueue\Test\ClassExtensionTrait;
 use PHPUnit\Framework\TestCase;
@@ -222,7 +223,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'job' => [
                     'enabled' => false,
@@ -243,7 +244,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'job' => true,
             ],
@@ -261,7 +262,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_ping_connection_extension' => false,
@@ -284,7 +285,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_ping_connection_extension' => true,
@@ -304,7 +305,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_clear_identity_map_extension' => false,
@@ -327,7 +328,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_clear_identity_map_extension' => true,
@@ -347,7 +348,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_odm_clear_identity_map_extension' => false,
@@ -370,7 +371,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_odm_clear_identity_map_extension' => true,
@@ -390,7 +391,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_closed_entity_manager_extension' => false,
@@ -413,7 +414,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'doctrine_closed_entity_manager_extension' => true,
@@ -433,7 +434,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reset_services_extension' => false,
@@ -456,7 +457,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reset_services_extension' => true,
@@ -478,7 +479,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'signal_extension' => $isLoaded,
@@ -501,7 +502,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'signal_extension' => false,
@@ -521,7 +522,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reply_extension' => true,
@@ -544,7 +545,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'extensions' => [
                     'reply_extension' => false,
@@ -564,7 +565,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'async_events' => [
                     'enabled' => false,
@@ -586,7 +587,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'async_events' => [
                     'enabled' => true,
@@ -603,7 +604,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'async_events' => [
                     'enabled' => true,
@@ -623,7 +624,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'consumption' => [
                     'receive_timeout' => 10000,
@@ -646,7 +647,7 @@ class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'default' => [
                 'consumption' => [
                     'receive_timeout' => 456,
@@ -657,6 +658,6 @@ class ConfigurationTest extends TestCase
 
     private function assertConfigEquals(array $expected, array $actual): void
     {
-        $this->assertArraySubset($expected, $actual, false, var_export($actual, true));
+        Assert::assertArraySubset($expected, $actual, false, var_export($actual, true));
     }
 }

--- a/pkg/enqueue-bundle/Tests/Unit/Profiler/MessageQueueCollectorTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/Profiler/MessageQueueCollectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Bundle\Tests\Unit\Profiler;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Bundle\Profiler\MessageQueueCollector;
 use Enqueue\Client\MessagePriority;
 use Enqueue\Client\ProducerInterface;
@@ -59,7 +60,7 @@ class MessageQueueCollectorTest extends TestCase
 
         $collector->collect(new Request(), new Response());
 
-        $this->assertArraySubset(
+        Assert::assertArraySubset(
             [
                 'foo' => [
                     [

--- a/pkg/enqueue-bundle/composer.json
+++ b/pkg/enqueue-bundle/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "symfony/framework-bundle": "^4.3|^5",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
@@ -21,7 +21,7 @@
         "docs": "https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/stomp": "0.10.x-dev",
         "enqueue/amqp-ext": "0.10.x-dev",
         "enqueue/amqp-lib": "0.10.x-dev",

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
@@ -15,6 +15,7 @@ use Interop\Queue\Context as InteropContext;
 use Interop\Queue\Destination;
 use Interop\Queue\Message as TransportMessage;
 use Interop\Queue\Processor;
+use Interop\Queue\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -169,17 +170,15 @@ class DelayRedeliveredMessageExtensionTest extends TestCase
     }
 
     /**
-     * @param mixed $queue
-     *
-     * @return MockObject
+     * @return MockObject|Consumer
      */
-    private function createConsumerStub($queue): Consumer
+    private function createConsumerStub(?Queue $queue): Consumer
     {
         $consumerMock = $this->createMock(Consumer::class);
         $consumerMock
             ->expects($this->any())
             ->method('getQueue')
-            ->willReturn($queue)
+            ->willReturn($queue ?? new NullQueue('queue'))
         ;
 
         return $consumerMock;

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/DelayRedeliveredMessageExtensionTest.php
@@ -18,8 +18,8 @@ use Interop\Queue\Processor;
 use Interop\Queue\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Psr\Log\Test\TestLogger;
 
 class DelayRedeliveredMessageExtensionTest extends TestCase
 {
@@ -55,20 +55,7 @@ class DelayRedeliveredMessageExtensionTest extends TestCase
             ->willReturn($delayedMessage)
         ;
 
-        $logger = $this->createLoggerMock();
-        $logger
-            ->expects(self::at(0))
-            ->method('debug')
-            ->with('[DelayRedeliveredMessageExtension] Send delayed message')
-        ;
-        $logger
-            ->expects(self::at(1))
-            ->method('debug')
-            ->with(
-                '[DelayRedeliveredMessageExtension] '.
-                'Reject redelivered original message by setting reject status to context.'
-            )
-        ;
+        $logger = new TestLogger();
 
         $messageReceived = new MessageReceived(
             $this->createContextMock(),
@@ -93,6 +80,16 @@ class DelayRedeliveredMessageExtensionTest extends TestCase
         $this->assertEquals([
             'enqueue.redelivery_count' => 1,
         ], $delayedMessage->getProperties());
+
+        self::assertTrue(
+            $logger->hasDebugThatContains('[DelayRedeliveredMessageExtension] Send delayed message')
+        );
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[DelayRedeliveredMessageExtension] '.
+                'Reject redelivered original message by setting reject status to context.'
+            )
+        );
     }
 
     public function testShouldDoNothingIfMessageIsNotRedelivered()
@@ -182,14 +179,6 @@ class DelayRedeliveredMessageExtensionTest extends TestCase
         ;
 
         return $consumerMock;
-    }
-
-    /**
-     * @return MockObject
-     */
-    private function createLoggerMock(): LoggerInterface
-    {
-        return $this->createMock(LoggerInterface::class);
     }
 
     private function createDriverSendResult(): DriverSendResult

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/ExclusiveCommandExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/ExclusiveCommandExtensionTest.php
@@ -15,6 +15,7 @@ use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Context as InteropContext;
 use Interop\Queue\Processor;
+use Interop\Queue\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -243,15 +244,15 @@ class ExclusiveCommandExtensionTest extends TestCase
     }
 
     /**
-     * @return MockObject
+     * @return MockObject|DriverInterface
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driver = $this->createMock(DriverInterface::class);
         $driver
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection())
         ;
 
         return $driver;
@@ -274,17 +275,15 @@ class ExclusiveCommandExtensionTest extends TestCase
     }
 
     /**
-     * @param mixed $queue
-     *
-     * @return MockObject
+     * @return MockObject|Consumer
      */
-    private function createConsumerStub($queue): Consumer
+    private function createConsumerStub(?Queue $queue): Consumer
     {
         $consumerMock = $this->createMock(Consumer::class);
         $consumerMock
             ->expects($this->any())
             ->method('getQueue')
-            ->willReturn($queue)
+            ->willReturn($queue ?? new NullQueue('queue'))
         ;
 
         return $consumerMock;

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/ExclusiveCommandExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/ExclusiveCommandExtensionTest.php
@@ -252,7 +252,7 @@ class ExclusiveCommandExtensionTest extends TestCase
         $driver
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection ?? new RouteCollection())
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         return $driver;

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/SetRouterPropertiesExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/SetRouterPropertiesExtensionTest.php
@@ -13,6 +13,7 @@ use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Context as InteropContext;
 use Interop\Queue\Processor;
+use Interop\Queue\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -186,17 +187,15 @@ class SetRouterPropertiesExtensionTest extends TestCase
     }
 
     /**
-     * @param mixed $queue
-     *
-     * @return MockObject
+     * @return MockObject|Consumer
      */
-    private function createConsumerStub($queue): Consumer
+    private function createConsumerStub(?Queue $queue): Consumer
     {
         $consumerMock = $this->createMock(Consumer::class);
         $consumerMock
             ->expects($this->any())
             ->method('getQueue')
-            ->willReturn($queue)
+            ->willReturn($queue ?? new NullQueue('queue'))
         ;
 
         return $consumerMock;

--- a/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
@@ -22,7 +22,6 @@ use Interop\Queue\Context;
 use Interop\Queue\Message as InteropMessage;
 use Interop\Queue\Producer as InteropProducer;
 use Interop\Queue\Queue as InteropQueue;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AmqpDriverTest extends TestCase
@@ -191,54 +190,54 @@ class AmqpDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('createTopic')
             ->willReturn($routerTopic)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('declareTopic')
             ->with($this->identicalTo($routerTopic))
         ;
 
         $context
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('declareQueue')
             ->with($this->identicalTo($routerQueue))
         ;
 
         $context
-            ->expects(self::once())
+            ->expects($this->at(4))
             ->method('bind')
             ->with($this->isInstanceOf(AmqpBind::class))
         ;
 
         // setup processor with default queue
         $context
-            ->expects(self::once())
+            ->expects($this->at(5))
             ->method('createQueue')
             ->with($this->getDefaultQueueTransportName())
             ->willReturn($processorWithDefaultQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(6))
             ->method('declareQueue')
             ->with($this->identicalTo($processorWithDefaultQueue))
         ;
 
         $context
-            ->expects(self::once())
+            ->expects($this->at(7))
             ->method('createQueue')
             ->with($this->getCustomQueueTransportName())
             ->willReturn($processorWithCustomQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(8))
             ->method('declareQueue')
             ->with($this->identicalTo($processorWithCustomQueue))
         ;
@@ -291,7 +290,7 @@ class AmqpDriverTest extends TestCase
     }
 
     /**
-     * @return AmqpContext|MockObject
+     * @return AmqpContext
      */
     protected function createContextMock(): Context
     {
@@ -299,7 +298,7 @@ class AmqpDriverTest extends TestCase
     }
 
     /**
-     * @return AmqpProducer|MockObject
+     * @return AmqpProducer
      */
     protected function createProducerMock(): InteropProducer
     {

--- a/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
@@ -22,6 +22,7 @@ use Interop\Queue\Context;
 use Interop\Queue\Message as InteropMessage;
 use Interop\Queue\Producer as InteropProducer;
 use Interop\Queue\Queue as InteropQueue;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AmqpDriverTest extends TestCase
@@ -190,54 +191,54 @@ class AmqpDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('createTopic')
             ->willReturn($routerTopic)
         ;
         $context
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('declareTopic')
             ->with($this->identicalTo($routerTopic))
         ;
 
         $context
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('declareQueue')
             ->with($this->identicalTo($routerQueue))
         ;
 
         $context
-            ->expects($this->at(4))
+            ->expects(self::once())
             ->method('bind')
             ->with($this->isInstanceOf(AmqpBind::class))
         ;
 
         // setup processor with default queue
         $context
-            ->expects($this->at(5))
+            ->expects(self::once())
             ->method('createQueue')
             ->with($this->getDefaultQueueTransportName())
             ->willReturn($processorWithDefaultQueue)
         ;
         $context
-            ->expects($this->at(6))
+            ->expects(self::once())
             ->method('declareQueue')
             ->with($this->identicalTo($processorWithDefaultQueue))
         ;
 
         $context
-            ->expects($this->at(7))
+            ->expects(self::once())
             ->method('createQueue')
             ->with($this->getCustomQueueTransportName())
             ->willReturn($processorWithCustomQueue)
         ;
         $context
-            ->expects($this->at(8))
+            ->expects(self::once())
             ->method('declareQueue')
             ->with($this->identicalTo($processorWithCustomQueue))
         ;
@@ -290,7 +291,7 @@ class AmqpDriverTest extends TestCase
     }
 
     /**
-     * @return AmqpContext
+     * @return AmqpContext|MockObject
      */
     protected function createContextMock(): Context
     {
@@ -298,7 +299,7 @@ class AmqpDriverTest extends TestCase
     }
 
     /**
-     * @return AmqpProducer
+     * @return AmqpProducer|MockObject
      */
     protected function createProducerMock(): InteropProducer
     {

--- a/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
@@ -313,9 +313,6 @@ class AmqpDriverTest extends TestCase
         return new AmqpQueue($name);
     }
 
-    /**
-     * @return AmqpTopic
-     */
     protected function createTopic(string $name): AmqpTopic
     {
         return new AmqpTopic($name);

--- a/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/AmqpDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client\Driver;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Config;
 use Enqueue\Client\Driver\AmqpDriver;
 use Enqueue\Client\Driver\GenericDriver;
@@ -336,7 +337,7 @@ class AmqpDriverTest extends TestCase
     protected function assertTransportMessage(InteropMessage $transportMessage): void
     {
         $this->assertSame('body', $transportMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
             'delivery_mode' => AmqpMessage::DELIVERY_MODE_PERSISTENT,
             'content_type' => 'ContentType',

--- a/pkg/enqueue/Tests/Client/Driver/FsDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/FsDriverTest.php
@@ -44,23 +44,23 @@ class FsDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('declareDestination')
             ->with($this->identicalTo($routerQueue))
         ;
         // setup processor queue
         $context
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('createQueue')
             ->willReturn($processorQueue)
         ;
         $context
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('declareDestination')
             ->with($this->identicalTo($processorQueue))
         ;

--- a/pkg/enqueue/Tests/Client/Driver/FsDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/FsDriverTest.php
@@ -44,23 +44,23 @@ class FsDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('declareDestination')
             ->with($this->identicalTo($routerQueue))
         ;
         // setup processor queue
         $context
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('createQueue')
             ->willReturn($processorQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('declareDestination')
             ->with($this->identicalTo($processorQueue))
         ;

--- a/pkg/enqueue/Tests/Client/Driver/GenericDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/GenericDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client\Driver;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Config;
 use Enqueue\Client\Driver\GenericDriver;
 use Enqueue\Client\DriverInterface;
@@ -60,7 +61,7 @@ class GenericDriverTest extends TestCase
     protected function assertTransportMessage(InteropMessage $transportMessage): void
     {
         $this->assertSame('body', $transportMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
             'message_id' => 'theMessageId',
             'timestamp' => 1000,

--- a/pkg/enqueue/Tests/Client/Driver/GenericDriverTestsTrait.php
+++ b/pkg/enqueue/Tests/Client/Driver/GenericDriverTestsTrait.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client\Driver;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Config;
 use Enqueue\Client\DriverInterface;
 use Enqueue\Client\Message;
@@ -1191,10 +1192,10 @@ trait GenericDriverTestsTrait
     protected function assertClientMessage(Message $clientMessage): void
     {
         $this->assertSame('body', $clientMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
         ], $clientMessage->getHeaders());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'pkey' => 'pval',
             Config::CONTENT_TYPE => 'theContentType',
             Config::EXPIRE => '22',

--- a/pkg/enqueue/Tests/Client/Driver/GpsDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/GpsDriverTest.php
@@ -46,35 +46,35 @@ class GpsDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('createTopic')
             ->willReturn($routerTopic)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('subscribe')
             ->with($this->identicalTo($routerTopic), $this->identicalTo($routerQueue))
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('createQueue')
             ->with($this->getDefaultQueueTransportName())
             ->willReturn($processorQueue)
         ;
         // setup processor queue
         $context
-            ->expects(self::once())
+            ->expects($this->at(4))
             ->method('createTopic')
             ->with($this->getDefaultQueueTransportName())
             ->willReturn($processorTopic)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(5))
             ->method('subscribe')
             ->with($this->identicalTo($processorTopic), $this->identicalTo($processorQueue))
         ;

--- a/pkg/enqueue/Tests/Client/Driver/GpsDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/GpsDriverTest.php
@@ -46,35 +46,35 @@ class GpsDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('createTopic')
             ->willReturn($routerTopic)
         ;
         $context
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('subscribe')
             ->with($this->identicalTo($routerTopic), $this->identicalTo($routerQueue))
         ;
         $context
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('createQueue')
             ->with($this->getDefaultQueueTransportName())
             ->willReturn($processorQueue)
         ;
         // setup processor queue
         $context
-            ->expects($this->at(4))
+            ->expects(self::once())
             ->method('createTopic')
             ->with($this->getDefaultQueueTransportName())
             ->willReturn($processorTopic)
         ;
         $context
-            ->expects($this->at(5))
+            ->expects(self::once())
             ->method('subscribe')
             ->with($this->identicalTo($processorTopic), $this->identicalTo($processorQueue))
         ;

--- a/pkg/enqueue/Tests/Client/Driver/RabbitMqDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RabbitMqDriverTest.php
@@ -92,9 +92,6 @@ class RabbitMqDriverTest extends TestCase
         return new AmqpQueue($name);
     }
 
-    /**
-     * @return AmqpTopic
-     */
     protected function createTopic(string $name): AmqpTopic
     {
         return new AmqpTopic($name);

--- a/pkg/enqueue/Tests/Client/Driver/RabbitMqDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RabbitMqDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client\Driver;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Config;
 use Enqueue\Client\Driver\AmqpDriver;
 use Enqueue\Client\Driver\GenericDriver;
@@ -115,7 +116,7 @@ class RabbitMqDriverTest extends TestCase
     protected function assertTransportMessage(InteropMessage $transportMessage): void
     {
         $this->assertSame('body', $transportMessage->getBody());
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'hkey' => 'hval',
             'delivery_mode' => AmqpMessage::DELIVERY_MODE_PERSISTENT,
             'content_type' => 'ContentType',

--- a/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
@@ -196,12 +196,12 @@ class RabbitMqStompDriverTest extends TestCase
 
         $producer = $this->createProducerMock();
         $producer
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('setDeliveryDelay')
             ->with(10000)
         ;
         $producer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('setDeliveryDelay')
             ->with(null)
         ;
@@ -300,7 +300,7 @@ class RabbitMqStompDriverTest extends TestCase
 
         $managementClient = $this->createManagementClientMock();
         $managementClient
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('declareExchange')
             ->with('aprefix.router', [
                 'type' => 'fanout',
@@ -309,7 +309,7 @@ class RabbitMqStompDriverTest extends TestCase
             ])
         ;
         $managementClient
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('declareQueue')
             ->with('aprefix.default', [
                 'durable' => true,
@@ -320,12 +320,12 @@ class RabbitMqStompDriverTest extends TestCase
             ])
         ;
         $managementClient
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('bind')
             ->with('aprefix.router', 'aprefix.default', 'aprefix.default')
         ;
         $managementClient
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('declareQueue')
             ->with('aprefix.default', [
                 'durable' => true,
@@ -401,7 +401,7 @@ class RabbitMqStompDriverTest extends TestCase
 
         $managementClient = $this->createManagementClientMock();
         $managementClient
-            ->expects(self::once())
+            ->expects($this->at(4))
             ->method('declareExchange')
             ->with('aprefix.default.delayed', [
                 'type' => 'x-delayed-message',
@@ -413,7 +413,7 @@ class RabbitMqStompDriverTest extends TestCase
             ])
         ;
         $managementClient
-            ->expects(self::once())
+            ->expects($this->at(5))
             ->method('bind')
             ->with('aprefix.default.delayed', 'aprefix.default', 'aprefix.default')
         ;

--- a/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
@@ -196,12 +196,12 @@ class RabbitMqStompDriverTest extends TestCase
 
         $producer = $this->createProducerMock();
         $producer
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('setDeliveryDelay')
             ->with(10000)
         ;
         $producer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('setDeliveryDelay')
             ->with(null)
         ;
@@ -299,7 +299,7 @@ class RabbitMqStompDriverTest extends TestCase
 
         $managementClient = $this->createManagementClientMock();
         $managementClient
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('declareExchange')
             ->with('aprefix.router', [
                 'type' => 'fanout',
@@ -308,7 +308,7 @@ class RabbitMqStompDriverTest extends TestCase
             ])
         ;
         $managementClient
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('declareQueue')
             ->with('aprefix.default', [
                 'durable' => true,
@@ -319,12 +319,12 @@ class RabbitMqStompDriverTest extends TestCase
             ])
         ;
         $managementClient
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('bind')
             ->with('aprefix.router', 'aprefix.default', 'aprefix.default')
         ;
         $managementClient
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('declareQueue')
             ->with('aprefix.default', [
                 'durable' => true,
@@ -399,7 +399,7 @@ class RabbitMqStompDriverTest extends TestCase
 
         $managementClient = $this->createManagementClientMock();
         $managementClient
-            ->expects($this->at(4))
+            ->expects(self::once())
             ->method('declareExchange')
             ->with('aprefix.default.delayed', [
                 'type' => 'x-delayed-message',
@@ -411,7 +411,7 @@ class RabbitMqStompDriverTest extends TestCase
             ])
         ;
         $managementClient
-            ->expects($this->at(5))
+            ->expects(self::once())
             ->method('bind')
             ->with('aprefix.default.delayed', 'aprefix.default', 'aprefix.default')
         ;

--- a/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RabbitMqStompDriverTest.php
@@ -24,7 +24,7 @@ use Interop\Queue\Producer as InteropProducer;
 use Interop\Queue\Queue as InteropQueue;
 use Interop\Queue\Topic as InteropTopic;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
+use Psr\Log\Test\TestLogger;
 
 class RabbitMqStompDriverTest extends TestCase
 {
@@ -281,14 +281,15 @@ class RabbitMqStompDriverTest extends TestCase
             $this->createManagementClientMock()
         );
 
-        $logger = $this->createLoggerMock();
-        $logger
-            ->expects($this->once())
-            ->method('debug')
-            ->with('[RabbitMqStompDriver] Could not setup broker. The option `management_plugin_installed` is not enabled. Please enable that option and install rabbit management plugin')
-        ;
+        $logger = new TestLogger();
 
         $driver->setupBroker($logger);
+
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[RabbitMqStompDriver] Could not setup broker. The option `management_plugin_installed` is not enabled. Please enable that option and install rabbit management plugin'
+            )
+        );
     }
 
     public function testShouldSetupBroker()
@@ -366,29 +367,30 @@ class RabbitMqStompDriverTest extends TestCase
             $managementClient
         );
 
-        $logger = $this->createLoggerMock();
-        $logger
-            ->expects($this->at(0))
-            ->method('debug')
-            ->with('[RabbitMqStompDriver] Declare router exchange: aprefix.router')
-        ;
-        $logger
-            ->expects($this->at(1))
-            ->method('debug')
-            ->with('[RabbitMqStompDriver] Declare router queue: aprefix.default')
-        ;
-        $logger
-            ->expects($this->at(2))
-            ->method('debug')
-            ->with('[RabbitMqStompDriver] Bind router queue to exchange: aprefix.default -> aprefix.router')
-        ;
-        $logger
-            ->expects($this->at(3))
-            ->method('debug')
-            ->with('[RabbitMqStompDriver] Declare processor queue: aprefix.default')
-        ;
+        $logger = new TestLogger();
 
         $driver->setupBroker($logger);
+
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[RabbitMqStompDriver] Declare router exchange: aprefix.router'
+            )
+        );
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[RabbitMqStompDriver] Declare router queue: aprefix.default'
+            )
+        );
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[RabbitMqStompDriver] Bind router queue to exchange: aprefix.default -> aprefix.router'
+            )
+        );
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[RabbitMqStompDriver] Declare processor queue: aprefix.default'
+            )
+        );
     }
 
     public function testSetupBrokerShouldCreateDelayExchangeIfEnabled()
@@ -458,19 +460,20 @@ class RabbitMqStompDriverTest extends TestCase
             $managementClient
         );
 
-        $logger = $this->createLoggerMock();
-        $logger
-            ->expects($this->at(4))
-            ->method('debug')
-            ->with('[RabbitMqStompDriver] Declare delay exchange: aprefix.default.delayed')
-        ;
-        $logger
-            ->expects($this->at(5))
-            ->method('debug')
-            ->with('[RabbitMqStompDriver] Bind processor queue to delay exchange: aprefix.default -> aprefix.default.delayed')
-        ;
+        $logger = new TestLogger();
 
         $driver->setupBroker($logger);
+
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[RabbitMqStompDriver] Declare delay exchange: aprefix.default.delayed'
+            )
+        );
+        self::assertTrue(
+            $logger->hasDebugThatContains(
+                '[RabbitMqStompDriver] Bind processor queue to delay exchange: aprefix.default -> aprefix.default.delayed'
+            )
+        );
     }
 
     protected function createDriver(...$args): DriverInterface
@@ -583,13 +586,5 @@ class RabbitMqStompDriverTest extends TestCase
     private function createManagementClientMock(): StompManagementClient
     {
         return $this->createMock(StompManagementClient::class);
-    }
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|LoggerInterface
-     */
-    private function createLoggerMock()
-    {
-        return $this->createMock(LoggerInterface::class);
     }
 }

--- a/pkg/enqueue/Tests/Client/Driver/RdKafkaDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RdKafkaDriverTest.php
@@ -47,17 +47,17 @@ class RdKafkaDriverTest extends TestCase
         $context = $this->createContextMock();
 
         $context
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('createQueue')
             ->willReturn($routerTopic)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('createQueue')
             ->willReturn($processorTopic)
         ;

--- a/pkg/enqueue/Tests/Client/Driver/RdKafkaDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/RdKafkaDriverTest.php
@@ -47,17 +47,17 @@ class RdKafkaDriverTest extends TestCase
         $context = $this->createContextMock();
 
         $context
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('createQueue')
             ->willReturn($routerTopic)
         ;
         $context
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('createQueue')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('createQueue')
             ->willReturn($processorTopic)
         ;

--- a/pkg/enqueue/Tests/Client/Driver/SqsDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/SqsDriverTest.php
@@ -42,25 +42,25 @@ class SqsDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('createQueue')
             ->with('aprefix_dot_default')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('declareQueue')
             ->with($this->identicalTo($routerQueue))
         ;
         // setup processor queue
         $context
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('createQueue')
             ->with('aprefix_dot_default')
             ->willReturn($processorQueue)
         ;
         $context
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('declareQueue')
             ->with($this->identicalTo($processorQueue))
         ;

--- a/pkg/enqueue/Tests/Client/Driver/SqsDriverTest.php
+++ b/pkg/enqueue/Tests/Client/Driver/SqsDriverTest.php
@@ -42,25 +42,25 @@ class SqsDriverTest extends TestCase
         $context = $this->createContextMock();
         // setup router
         $context
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('createQueue')
             ->with('aprefix_dot_default')
             ->willReturn($routerQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('declareQueue')
             ->with($this->identicalTo($routerQueue))
         ;
         // setup processor queue
         $context
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('createQueue')
             ->with('aprefix_dot_default')
             ->willReturn($processorQueue)
         ;
         $context
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('declareQueue')
             ->with($this->identicalTo($processorQueue))
         ;

--- a/pkg/enqueue/Tests/Client/ProducerSendCommandTest.php
+++ b/pkg/enqueue/Tests/Client/ProducerSendCommandTest.php
@@ -370,7 +370,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onPreSendCommand')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -408,7 +408,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onPreSendCommand')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -446,7 +446,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onDriverPreSend')
             ->willReturnCallback(function (DriverPreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -478,7 +478,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onPostSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());

--- a/pkg/enqueue/Tests/Client/ProducerSendCommandTest.php
+++ b/pkg/enqueue/Tests/Client/ProducerSendCommandTest.php
@@ -479,7 +479,7 @@ class ProducerSendCommandTest extends TestCase
 
         $extension
             ->expects(self::once())
-            ->method('onDriverPreSend')
+            ->method('onPostSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
                 $this->assertSame($producer, $context->getProducer());

--- a/pkg/enqueue/Tests/Client/ProducerSendCommandTest.php
+++ b/pkg/enqueue/Tests/Client/ProducerSendCommandTest.php
@@ -370,7 +370,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onPreSendCommand')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -408,7 +408,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onPreSendCommand')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -446,7 +446,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onDriverPreSend')
             ->willReturnCallback(function (DriverPreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -478,7 +478,7 @@ class ProducerSendCommandTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onDriverPreSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());

--- a/pkg/enqueue/Tests/Client/ProducerSendEventTest.php
+++ b/pkg/enqueue/Tests/Client/ProducerSendEventTest.php
@@ -326,7 +326,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onPreSendEvent')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -364,7 +364,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onPreSendEvent')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -402,7 +402,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onDriverPreSend')
             ->willReturnCallback(function (DriverPreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -434,7 +434,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onDriverPreSend')
             ->willReturnCallback(function (DriverPreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -466,7 +466,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onPostSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -498,7 +498,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('onPostSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());

--- a/pkg/enqueue/Tests/Client/ProducerSendEventTest.php
+++ b/pkg/enqueue/Tests/Client/ProducerSendEventTest.php
@@ -499,7 +499,7 @@ class ProducerSendEventTest extends TestCase
 
         $extension
             ->expects(self::once())
-            ->method('onDriverPreSend')
+            ->method('onPostSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
                 $this->assertSame($producer, $context->getProducer());

--- a/pkg/enqueue/Tests/Client/ProducerSendEventTest.php
+++ b/pkg/enqueue/Tests/Client/ProducerSendEventTest.php
@@ -326,7 +326,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onPreSendEvent')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -364,7 +364,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onPreSendEvent')
             ->willReturnCallback(function (PreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -402,7 +402,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onDriverPreSend')
             ->willReturnCallback(function (DriverPreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -434,7 +434,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onDriverPreSend')
             ->willReturnCallback(function (DriverPreSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -466,7 +466,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onPostSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());
@@ -498,7 +498,7 @@ class ProducerSendEventTest extends TestCase
         $producer = new Producer($driver, $this->createRpcFactoryMock(), $extension);
 
         $extension
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('onDriverPreSend')
             ->willReturnCallback(function (PostSend $context) use ($message, $producer, $driver) {
                 $this->assertSame($message, $context->getMessage());

--- a/pkg/enqueue/Tests/Client/ResourcesTest.php
+++ b/pkg/enqueue/Tests/Client/ResourcesTest.php
@@ -28,7 +28,7 @@ class ResourcesTest extends TestCase
     {
         $availableDrivers = Resources::getAvailableDrivers();
 
-        $this->assertInternalType('array', $availableDrivers);
+        self::assertIsArray($availableDrivers);
         $this->assertGreaterThan(0, count($availableDrivers));
 
         $driverInfo = $availableDrivers[0];
@@ -50,7 +50,7 @@ class ResourcesTest extends TestCase
     {
         $availableDrivers = Resources::getAvailableDrivers();
 
-        $this->assertInternalType('array', $availableDrivers);
+        self::assertIsArray($availableDrivers);
         $this->assertGreaterThan(0, count($availableDrivers));
 
         $driverInfo = $availableDrivers[1];
@@ -72,7 +72,7 @@ class ResourcesTest extends TestCase
     {
         $knownDrivers = Resources::getAvailableDrivers();
 
-        $this->assertInternalType('array', $knownDrivers);
+        self::assertIsArray($knownDrivers);
         $this->assertGreaterThan(0, count($knownDrivers));
 
         $driverInfo = $knownDrivers[0];

--- a/pkg/enqueue/Tests/Client/RouterProcessorTest.php
+++ b/pkg/enqueue/Tests/Client/RouterProcessorTest.php
@@ -13,6 +13,7 @@ use Enqueue\Consumption\Result;
 use Enqueue\Null\NullContext;
 use Enqueue\Null\NullMessage;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Destination;
 use Interop\Queue\Message as TransportMessage;
 use Interop\Queue\Processor;
@@ -21,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 class RouterProcessorTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementProcessorInterface()
     {
@@ -195,15 +197,15 @@ class RouterProcessorTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \PHPUnit\Framework\MockObject\MockObject|DriverInterface
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driver = $this->createMock(DriverInterface::class);
         $driver
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         return $driver;

--- a/pkg/enqueue/Tests/Client/SpoolProducerTest.php
+++ b/pkg/enqueue/Tests/Client/SpoolProducerTest.php
@@ -68,17 +68,17 @@ class SpoolProducerTest extends TestCase
 
         $realProducer = $this->createProducerMock();
         $realProducer
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('sendEvent')
             ->with('foo_topic', 'first')
         ;
         $realProducer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('sendEvent')
             ->with('bar_topic', ['second'])
         ;
         $realProducer
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('sendEvent')
             ->with('baz_topic', $this->identicalTo($message))
         ;
@@ -103,17 +103,17 @@ class SpoolProducerTest extends TestCase
 
         $realProducer = $this->createProducerMock();
         $realProducer
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('sendCommand')
             ->with('foo_command', 'first')
         ;
         $realProducer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('sendCommand')
             ->with('bar_command', ['second'])
         ;
         $realProducer
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('sendCommand')
             ->with('baz_command', $this->identicalTo($message))
         ;

--- a/pkg/enqueue/Tests/Client/SpoolProducerTest.php
+++ b/pkg/enqueue/Tests/Client/SpoolProducerTest.php
@@ -68,17 +68,17 @@ class SpoolProducerTest extends TestCase
 
         $realProducer = $this->createProducerMock();
         $realProducer
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('sendEvent')
             ->with('foo_topic', 'first')
         ;
         $realProducer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('sendEvent')
             ->with('bar_topic', ['second'])
         ;
         $realProducer
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('sendEvent')
             ->with('baz_topic', $this->identicalTo($message))
         ;
@@ -103,17 +103,17 @@ class SpoolProducerTest extends TestCase
 
         $realProducer = $this->createProducerMock();
         $realProducer
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('sendCommand')
             ->with('foo_command', 'first')
         ;
         $realProducer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('sendCommand')
             ->with('bar_command', ['second'])
         ;
         $realProducer
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('sendCommand')
             ->with('baz_command', $this->identicalTo($message))
         ;

--- a/pkg/enqueue/Tests/Client/TraceableProducerTest.php
+++ b/pkg/enqueue/Tests/Client/TraceableProducerTest.php
@@ -2,6 +2,7 @@
 
 namespace Enqueue\Tests\Client;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Enqueue\Client\Message;
 use Enqueue\Client\ProducerInterface;
 use Enqueue\Client\TraceableProducer;
@@ -45,7 +46,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendEvent('aFooTopic', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => 'aFooTopic',
                 'command' => null,
@@ -70,7 +71,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendEvent('aFooTopic', ['foo' => 'fooVal', 'bar' => 'barVal']);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => 'aFooTopic',
                 'command' => null,
@@ -106,7 +107,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendEvent('aFooTopic', $message);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => 'aFooTopic',
                 'command' => null,
@@ -168,7 +169,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendCommand('aFooCommand', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => null,
                 'command' => 'aFooCommand',
@@ -193,7 +194,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendCommand('aFooCommand', ['foo' => 'fooVal', 'bar' => 'barVal']);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => null,
                 'command' => 'aFooCommand',
@@ -229,7 +230,7 @@ class TraceableProducerTest extends TestCase
 
         $producer->sendCommand('aFooCommand', $message);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             [
                 'topic' => null,
                 'command' => 'aFooCommand',
@@ -275,7 +276,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendEvent('aFooTopic', 'aFooBody');
         $producer->sendEvent('aFooTopic', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
                 ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
                 ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
         ], $producer->getTraces());
@@ -288,7 +289,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendEvent('aFooTopic', 'aFooBody');
         $producer->sendEvent('aBarTopic', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
             ['topic' => 'aBarTopic', 'body' => 'aBarBody'],
         ], $producer->getTraces());
@@ -301,11 +302,11 @@ class TraceableProducerTest extends TestCase
         $producer->sendEvent('aFooTopic', 'aFooBody');
         $producer->sendEvent('aBarTopic', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['topic' => 'aFooTopic', 'body' => 'aFooBody'],
         ], $producer->getTopicTraces('aFooTopic'));
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['topic' => 'aBarTopic', 'body' => 'aBarBody'],
         ], $producer->getTopicTraces('aBarTopic'));
     }
@@ -317,7 +318,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendCommand('aFooCommand', 'aFooBody');
         $producer->sendCommand('aFooCommand', 'aFooBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
         ], $producer->getTraces());
@@ -330,7 +331,7 @@ class TraceableProducerTest extends TestCase
         $producer->sendCommand('aFooCommand', 'aFooBody');
         $producer->sendCommand('aBarCommand', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
             ['command' => 'aBarCommand', 'body' => 'aBarBody'],
         ], $producer->getTraces());
@@ -343,11 +344,11 @@ class TraceableProducerTest extends TestCase
         $producer->sendCommand('aFooCommand', 'aFooBody');
         $producer->sendCommand('aBarCommand', 'aBarBody');
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aFooCommand', 'body' => 'aFooBody'],
         ], $producer->getCommandTraces('aFooCommand'));
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             ['command' => 'aBarCommand', 'body' => 'aBarBody'],
         ], $producer->getCommandTraces('aBarCommand'));
     }

--- a/pkg/enqueue/Tests/Consumption/FallbackSubscriptionConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/FallbackSubscriptionConsumerTest.php
@@ -3,6 +3,7 @@
 namespace Enqueue\Tests\Consumption;
 
 use Enqueue\Consumption\FallbackSubscriptionConsumer;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Message as InteropMessage;
 use Interop\Queue\Queue as InteropQueue;
@@ -11,6 +12,8 @@ use PHPUnit\Framework\TestCase;
 
 class FallbackSubscriptionConsumerTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     public function testShouldImplementSubscriptionConsumerInterface()
     {
         $rc = new \ReflectionClass(FallbackSubscriptionConsumer::class);

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -206,7 +206,6 @@ class QueueConsumerTest extends TestCase
         $contextSubscriptionConsumer
             ->expects($this->once())
             ->method('consume')
-            ->willReturn(null)
         ;
 
         $fallbackSubscriptionConsumer = $this->createSubscriptionConsumerMock();
@@ -254,7 +253,6 @@ class QueueConsumerTest extends TestCase
         $fallbackSubscriptionConsumer
             ->expects($this->once())
             ->method('consume')
-            ->willReturn(null)
         ;
 
         $contextMock = $this->createContextWithoutSubscriptionConsumerMock();
@@ -291,7 +289,6 @@ class QueueConsumerTest extends TestCase
             ->expects($this->once())
             ->method('consume')
             ->with(12345)
-            ->willReturn(null)
         ;
 
         $contextMock = $this->createContextWithoutSubscriptionConsumerMock();
@@ -322,7 +319,6 @@ class QueueConsumerTest extends TestCase
         $subscriptionConsumerMock
             ->expects($this->exactly(5))
             ->method('consume')
-            ->willReturn(null)
         ;
 
         $contextMock = $this->createContextWithoutSubscriptionConsumerMock();

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -1537,6 +1537,9 @@ class QueueConsumerTest extends TestCase
      */
     private function createConsumerStub($queue = null): Consumer
     {
+        if ($queue === null) {
+            $queue = 'queue';
+        }
         if (is_string($queue)) {
             $queue = new NullQueue($queue);
         }

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -1537,7 +1537,7 @@ class QueueConsumerTest extends TestCase
      */
     private function createConsumerStub($queue = null): Consumer
     {
-        if ($queue === null) {
+        if (null === $queue) {
             $queue = 'queue';
         }
         if (is_string($queue)) {

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -21,6 +21,7 @@ use Enqueue\Consumption\ExtensionInterface;
 use Enqueue\Consumption\QueueConsumer;
 use Enqueue\Consumption\Result;
 use Enqueue\Null\NullQueue;
+use Enqueue\Test\ReadAttributeTrait;
 use Enqueue\Tests\Consumption\Mock\BreakCycleExtension;
 use Enqueue\Tests\Consumption\Mock\DummySubscriptionConsumer;
 use Interop\Queue\Consumer;
@@ -36,6 +37,8 @@ use Psr\Log\NullLogger;
 
 class QueueConsumerTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     public function testCouldBeConstructedWithAllArguments()
     {
         new QueueConsumer($this->createContextStub(), null, [], null, 0);
@@ -177,7 +180,7 @@ class QueueConsumerTest extends TestCase
 
         $boundProcessors = $this->readAttribute($consumer, 'boundProcessors');
 
-        $this->assertInternalType('array', $boundProcessors);
+        self::assertIsArray($boundProcessors);
         $this->assertCount(1, $boundProcessors);
         $this->assertArrayHasKey($queueName, $boundProcessors);
 

--- a/pkg/enqueue/Tests/DoctrineConnectionFactoryFactoryTest.php
+++ b/pkg/enqueue/Tests/DoctrineConnectionFactoryFactoryTest.php
@@ -9,9 +9,12 @@ use Enqueue\ConnectionFactoryFactoryInterface;
 use Enqueue\Dbal\ManagerRegistryConnectionFactory;
 use Enqueue\Doctrine\DoctrineConnectionFactoryFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class DoctrineConnectionFactoryFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ManagerRegistry|\Prophecy\Prophecy\ObjectProphecy
      */

--- a/pkg/enqueue/Tests/DoctrineConnectionFactoryFactoryTest.php
+++ b/pkg/enqueue/Tests/DoctrineConnectionFactoryFactoryTest.php
@@ -25,7 +25,7 @@ class DoctrineConnectionFactoryFactoryTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->registry = $this->prophesize(ManagerRegistry::class);
         $this->fallbackFactory = $this->prophesize(ConnectionFactoryFactoryInterface::class);

--- a/pkg/enqueue/Tests/ResourcesTest.php
+++ b/pkg/enqueue/Tests/ResourcesTest.php
@@ -28,7 +28,7 @@ class ResourcesTest extends TestCase
     {
         $availableConnections = Resources::getAvailableConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        self::assertIsArray($availableConnections);
         $this->assertArrayHasKey(RedisConnectionFactory::class, $availableConnections);
 
         $connectionInfo = $availableConnections[RedisConnectionFactory::class];
@@ -46,7 +46,7 @@ class ResourcesTest extends TestCase
     {
         $availableConnections = Resources::getKnownConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        self::assertIsArray($availableConnections);
         $this->assertArrayHasKey(RedisConnectionFactory::class, $availableConnections);
 
         $connectionInfo = $availableConnections[RedisConnectionFactory::class];
@@ -93,12 +93,12 @@ class ResourcesTest extends TestCase
         Resources::addConnection('theConnectionClass', ['foo'], [], 'foo');
 
         $knownConnections = Resources::getKnownConnections();
-        $this->assertInternalType('array', $knownConnections);
+        self::assertIsArray($knownConnections);
         $this->assertArrayHasKey('theConnectionClass', $knownConnections);
 
         $availableConnections = Resources::getAvailableConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        self::assertIsArray($availableConnections);
         $this->assertArrayNotHasKey('theConnectionClass', $availableConnections);
     }
 
@@ -115,7 +115,7 @@ class ResourcesTest extends TestCase
 
         $availableConnections = Resources::getAvailableConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        self::assertIsArray($availableConnections);
         $this->assertArrayHasKey($connectionClass, $availableConnections);
 
         $connectionInfo = $availableConnections[$connectionClass];
@@ -133,7 +133,7 @@ class ResourcesTest extends TestCase
     {
         $availableConnections = Resources::getKnownConnections();
 
-        $this->assertInternalType('array', $availableConnections);
+        self::assertIsArray($availableConnections);
         $this->assertArrayHasKey(WampConnectionFactory::class, $availableConnections);
 
         $connectionInfo = $availableConnections[WampConnectionFactory::class];

--- a/pkg/enqueue/Tests/Router/RouteRecipientListProcessorTest.php
+++ b/pkg/enqueue/Tests/Router/RouteRecipientListProcessorTest.php
@@ -45,12 +45,12 @@ class RouteRecipientListProcessorTest extends TestCase
 
         $producerMock = $this->createProducerMock();
         $producerMock
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('send')
             ->with($this->identicalTo($fooRecipient->getDestination()), $this->identicalTo($fooRecipient->getMessage()))
         ;
         $producerMock
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('send')
             ->with($this->identicalTo($barRecipient->getDestination()), $this->identicalTo($barRecipient->getMessage()))
         ;

--- a/pkg/enqueue/Tests/Router/RouteRecipientListProcessorTest.php
+++ b/pkg/enqueue/Tests/Router/RouteRecipientListProcessorTest.php
@@ -45,12 +45,12 @@ class RouteRecipientListProcessorTest extends TestCase
 
         $producerMock = $this->createProducerMock();
         $producerMock
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('send')
             ->with($this->identicalTo($fooRecipient->getDestination()), $this->identicalTo($fooRecipient->getMessage()))
         ;
         $producerMock
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('send')
             ->with($this->identicalTo($barRecipient->getDestination()), $this->identicalTo($barRecipient->getMessage()))
         ;

--- a/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
@@ -269,13 +269,13 @@ class ConsumeCommandTest extends TestCase
 
         $driver = $this->createDriverStub($routeCollection);
         $driver
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('createQueue')
             ->with('default', true)
             ->willReturn($defaultQueue)
         ;
         $driver
-            ->expects($this->at(4))
+            ->expects(self::once())
             ->method('createQueue')
             ->with('custom', true)
             ->willReturn($customQueue)
@@ -283,17 +283,17 @@ class ConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('bind')
             ->with($this->identicalTo($defaultQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('bind')
             ->with($this->identicalTo($customQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -408,13 +408,13 @@ class ConsumeCommandTest extends TestCase
 
         $driver = $this->createDriverStub($routeCollection);
         $driver
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('createQueue')
             ->with('default', true)
             ->willReturn($defaultQueue)
         ;
         $driver
-            ->expects($this->at(4))
+            ->expects(self::once())
             ->method('createQueue', true)
             ->with('custom')
             ->willReturn($customQueue)
@@ -422,17 +422,17 @@ class ConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('bind')
             ->with($this->identicalTo($defaultQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('bind')
             ->with($this->identicalTo($customQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -473,7 +473,7 @@ class ConsumeCommandTest extends TestCase
             ->with($this->identicalTo($defaultQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -513,19 +513,19 @@ class ConsumeCommandTest extends TestCase
 
         $driver = $this->createDriverStub($routeCollection);
         $driver
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('createQueue', true)
             ->with('default')
             ->willReturn($queue)
         ;
         $driver
-            ->expects($this->at(4))
+            ->expects(self::once())
             ->method('createQueue', true)
             ->with('fooQueue')
             ->willReturn($queue)
         ;
         $driver
-            ->expects($this->at(5))
+            ->expects(self::once())
             ->method('createQueue', true)
             ->with('ololoQueue')
             ->willReturn($queue)

--- a/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
@@ -269,13 +269,13 @@ class ConsumeCommandTest extends TestCase
 
         $driver = $this->createDriverStub($routeCollection);
         $driver
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('createQueue')
             ->with('default', true)
             ->willReturn($defaultQueue)
         ;
         $driver
-            ->expects(self::once())
+            ->expects($this->at(4))
             ->method('createQueue')
             ->with('custom', true)
             ->willReturn($customQueue)
@@ -283,17 +283,17 @@ class ConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('bind')
             ->with($this->identicalTo($defaultQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('bind')
             ->with($this->identicalTo($customQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -408,13 +408,13 @@ class ConsumeCommandTest extends TestCase
 
         $driver = $this->createDriverStub($routeCollection);
         $driver
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('createQueue')
             ->with('default', true)
             ->willReturn($defaultQueue)
         ;
         $driver
-            ->expects(self::once())
+            ->expects($this->at(4))
             ->method('createQueue', true)
             ->with('custom')
             ->willReturn($customQueue)
@@ -422,17 +422,17 @@ class ConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('bind')
             ->with($this->identicalTo($defaultQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('bind')
             ->with($this->identicalTo($customQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -473,7 +473,7 @@ class ConsumeCommandTest extends TestCase
             ->with($this->identicalTo($defaultQueue), $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -513,19 +513,19 @@ class ConsumeCommandTest extends TestCase
 
         $driver = $this->createDriverStub($routeCollection);
         $driver
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('createQueue', true)
             ->with('default')
             ->willReturn($queue)
         ;
         $driver
-            ->expects(self::once())
+            ->expects($this->at(4))
             ->method('createQueue', true)
             ->with('fooQueue')
             ->willReturn($queue)
         ;
         $driver
-            ->expects(self::once())
+            ->expects($this->at(5))
             ->method('createQueue', true)
             ->with('ololoQueue')
             ->willReturn($queue)

--- a/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
@@ -677,7 +677,7 @@ class ConsumeCommandTest extends TestCase
      */
     private function createConsumerStub($queue = null): Consumer
     {
-        if ($queue === null) {
+        if (null === $queue) {
             $queue = 'queue';
         }
         if (is_string($queue)) {

--- a/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
@@ -677,6 +677,9 @@ class ConsumeCommandTest extends TestCase
      */
     private function createConsumerStub($queue = null): Consumer
     {
+        if ($queue === null) {
+            $queue = 'queue';
+        }
         if (is_string($queue)) {
             $queue = new NullQueue($queue);
         }

--- a/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/ConsumeCommandTest.php
@@ -605,13 +605,13 @@ class ConsumeCommandTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|DriverInterface
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driverMock = $this->createMock(DriverInterface::class);
         $driverMock
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         $driverMock

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildClientExtensionsPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildClientExtensionsPassTest.php
@@ -72,7 +72,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -99,7 +99,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -125,7 +125,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -151,7 +151,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -247,7 +247,7 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertCount(4, $extensions->getArgument(0));
     }
 
@@ -275,12 +275,12 @@ class BuildClientExtensionsPassTest extends TestCase
         $pass = new BuildClientExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $fooExtensions->getArgument(0));
+        self::assertIsArray($fooExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $fooExtensions->getArgument(0));
 
-        $this->assertInternalType('array', $barExtensions->getArgument(0));
+        self::assertIsArray($barExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aBarExtension'),
         ], $barExtensions->getArgument(0));

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildCommandSubscriberRoutesPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildCommandSubscriberRoutesPassTest.php
@@ -96,7 +96,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -120,7 +120,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -144,7 +144,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -166,7 +166,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -222,7 +222,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -266,7 +266,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
 
         $this->assertCount(1, $routeCollection->getArgument(0));
 
@@ -305,7 +305,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -372,7 +372,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(3, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -422,7 +422,7 @@ class BuildCommandSubscriberRoutesPassTest extends TestCase
         $pass = new BuildCommandSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildConsumptionExtensionsPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildConsumptionExtensionsPassTest.php
@@ -72,7 +72,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -99,7 +99,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -125,7 +125,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -151,7 +151,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -247,7 +247,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertCount(4, $extensions->getArgument(0));
     }
 
@@ -275,12 +275,12 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $fooExtensions->getArgument(0));
+        self::assertIsArray($fooExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $fooExtensions->getArgument(0));
 
-        $this->assertInternalType('array', $barExtensions->getArgument(0));
+        self::assertIsArray($barExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aBarExtension'),
         ], $barExtensions->getArgument(0));

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildProcessorRegistryPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildProcessorRegistryPassTest.php
@@ -136,7 +136,7 @@ class BuildProcessorRegistryPassTest extends TestCase
         $locatorId = (string) $locatorId;
 
         $this->assertTrue($container->hasDefinition($locatorId));
-        $this->assertRegExp('/\.?service_locator\..*?\.enqueue\./', $locatorId);
+        $this->assertMatchesRegularExpression('/\.?service_locator\..*?\.enqueue\./', $locatorId);
 
         $match = [];
         if (false == preg_match('/(\.?service_locator\..*?)\.enqueue\./', $locatorId, $match)) {

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildProcessorRoutesPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildProcessorRoutesPassTest.php
@@ -112,7 +112,7 @@ class BuildProcessorRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -136,7 +136,7 @@ class BuildProcessorRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -160,7 +160,7 @@ class BuildProcessorRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -180,7 +180,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -212,7 +212,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -244,7 +244,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -279,7 +279,7 @@ class BuildProcessorRoutesPassTest extends TestCase
         $pass = new BuildProcessorRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(3, $routeCollection->getArgument(0));
 
         $this->assertEquals(

--- a/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildTopicSubscriberRoutesPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/DependencyInjection/BuildTopicSubscriberRoutesPassTest.php
@@ -96,7 +96,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -120,7 +120,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -144,7 +144,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
 
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
     }
 
@@ -166,7 +166,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(1, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -222,7 +222,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -265,7 +265,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -332,7 +332,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(3, $routeCollection->getArgument(0));
 
         $this->assertEquals(
@@ -379,7 +379,7 @@ class BuildTopicSubscriberRoutesPassTest extends TestCase
         $pass = new BuildTopicSubscriberRoutesPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $routeCollection->getArgument(0));
+        self::assertIsArray($routeCollection->getArgument(0));
         $this->assertCount(2, $routeCollection->getArgument(0));
 
         $this->assertEquals(

--- a/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/FlushSpoolProducerListenerTest.php
@@ -23,7 +23,7 @@ class FlushSpoolProducerListenerTest extends TestCase
     {
         $events = FlushSpoolProducerListener::getSubscribedEvents();
 
-        $this->assertInternalType('array', $events);
+        self::assertIsArray($events);
         $this->assertArrayHasKey(KernelEvents::TERMINATE, $events);
 
         $this->assertEquals('flushMessages', $events[KernelEvents::TERMINATE]);
@@ -33,7 +33,7 @@ class FlushSpoolProducerListenerTest extends TestCase
     {
         $events = FlushSpoolProducerListener::getSubscribedEvents();
 
-        $this->assertInternalType('array', $events);
+        self::assertIsArray($events);
         $this->assertArrayHasKey(ConsoleEvents::TERMINATE, $events);
 
         $this->assertEquals('flushMessages', $events[ConsoleEvents::TERMINATE]);

--- a/pkg/enqueue/Tests/Symfony/Client/RoutesCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/RoutesCommandTest.php
@@ -116,7 +116,7 @@ OUTPUT;
             '--client' => 'foo',
         ]);
 
-        $this->assertContains('Found 1 routes', $tester->getDisplay());
+        $this->assertStringContainsString('Found 1 routes', $tester->getDisplay());
     }
 
     public function testThrowIfClientNotFound()

--- a/pkg/enqueue/Tests/Symfony/Client/RoutesCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/RoutesCommandTest.php
@@ -331,7 +331,7 @@ OUTPUT;
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \PHPUnit\Framework\MockObject\MockObject|DriverInterface
      */
     private function createDriverStub(Config $config, RouteCollection $routeCollection): DriverInterface
     {

--- a/pkg/enqueue/Tests/Symfony/Client/SetupBrokerCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/SetupBrokerCommandTest.php
@@ -78,7 +78,7 @@ class SetupBrokerCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
 
-        $this->assertContains('Broker set up', $tester->getDisplay());
+        $this->assertStringContainsString('Broker set up', $tester->getDisplay());
     }
 
     public function testShouldCallRequestedClientDriverSetupBrokerMethod()
@@ -105,7 +105,7 @@ class SetupBrokerCommandTest extends TestCase
             '--client' => 'foo',
         ]);
 
-        $this->assertContains('Broker set up', $tester->getDisplay());
+        $this->assertStringContainsString('Broker set up', $tester->getDisplay());
     }
 
     public function testShouldThrowIfClientNotFound()

--- a/pkg/enqueue/Tests/Symfony/Client/SimpleConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/SimpleConsumeCommandTest.php
@@ -122,13 +122,13 @@ class SimpleConsumeCommandTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|DriverInterface
      */
-    private function createDriverStub(RouteCollection $routeCollection = null): DriverInterface
+    private function createDriverStub(?RouteCollection $routeCollection = null): DriverInterface
     {
         $driverMock = $this->createMock(DriverInterface::class);
         $driverMock
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->willReturn($routeCollection)
+            ->willReturn($routeCollection ?? new RouteCollection([]))
         ;
 
         $driverMock

--- a/pkg/enqueue/Tests/Symfony/Client/SimpleSetupBrokerCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Client/SimpleSetupBrokerCommandTest.php
@@ -74,7 +74,7 @@ class SimpleSetupBrokerCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
 
-        $this->assertContains('Broker set up', $tester->getDisplay());
+        $this->assertStringContainsString('Broker set up', $tester->getDisplay());
     }
 
     /**

--- a/pkg/enqueue/Tests/Symfony/Consumption/ConfigurableConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/ConfigurableConsumeCommandTest.php
@@ -163,17 +163,17 @@ class ConfigurableConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('bind')
             ->with('queue-name', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('bind')
             ->with('another-queue-name', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -205,17 +205,17 @@ class ConfigurableConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('bind')
             ->with('fooSubscribedQueues', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('bind')
             ->with('barSubscribedQueues', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;

--- a/pkg/enqueue/Tests/Symfony/Consumption/ConfigurableConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/ConfigurableConsumeCommandTest.php
@@ -163,17 +163,17 @@ class ConfigurableConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('bind')
             ->with('queue-name', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('bind')
             ->with('another-queue-name', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;
@@ -205,17 +205,17 @@ class ConfigurableConsumeCommandTest extends TestCase
 
         $consumer = $this->createQueueConsumerMock();
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('bind')
             ->with('fooSubscribedQueues', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('bind')
             ->with('barSubscribedQueues', $this->identicalTo($processor))
         ;
         $consumer
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('consume')
             ->with($this->isInstanceOf(ChainExtension::class))
         ;

--- a/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
@@ -221,6 +221,9 @@ class ConsumeCommandTest extends TestCase
      */
     private function createConsumerStub($queue = null): Consumer
     {
+        if ($queue === null) {
+            $queue = 'queue';
+        }
         if (is_string($queue)) {
             $queue = new NullQueue($queue);
         }

--- a/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
+++ b/pkg/enqueue/Tests/Symfony/Consumption/ConsumeCommandTest.php
@@ -221,7 +221,7 @@ class ConsumeCommandTest extends TestCase
      */
     private function createConsumerStub($queue = null): Consumer
     {
-        if ($queue === null) {
+        if (null === $queue) {
             $queue = 'queue';
         }
         if (is_string($queue)) {

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildConsumptionExtensionsPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildConsumptionExtensionsPassTest.php
@@ -72,7 +72,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -99,7 +99,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -125,7 +125,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $extensions->getArgument(0));
@@ -151,7 +151,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
             new Reference('aBarExtension'),
@@ -247,7 +247,7 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $extensions->getArgument(0));
+        self::assertIsArray($extensions->getArgument(0));
         $this->assertCount(4, $extensions->getArgument(0));
     }
 
@@ -275,12 +275,12 @@ class BuildConsumptionExtensionsPassTest extends TestCase
         $pass = new BuildConsumptionExtensionsPass();
         $pass->process($container);
 
-        $this->assertInternalType('array', $fooExtensions->getArgument(0));
+        self::assertIsArray($fooExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aFooExtension'),
         ], $fooExtensions->getArgument(0));
 
-        $this->assertInternalType('array', $barExtensions->getArgument(0));
+        self::assertIsArray($barExtensions->getArgument(0));
         $this->assertEquals([
             new Reference('aBarExtension'),
         ], $barExtensions->getArgument(0));

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildProcessorRegistryPassTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/BuildProcessorRegistryPassTest.php
@@ -199,7 +199,7 @@ class BuildProcessorRegistryPassTest extends TestCase
         $locatorId = (string) $locatorId;
 
         $this->assertTrue($container->hasDefinition($locatorId));
-        $this->assertRegExp('/\.?service_locator\..*?\.enqueue\./', $locatorId);
+        $this->assertMatchesRegularExpression('/\.?service_locator\..*?\.enqueue\./', $locatorId);
 
         $match = [];
         if (false == preg_match('/(\.?service_locator\..*?)\.enqueue\./', $locatorId, $match)) {

--- a/pkg/enqueue/Tests/Util/UUIDTest.php
+++ b/pkg/enqueue/Tests/Util/UUIDTest.php
@@ -11,7 +11,7 @@ class UUIDTest extends TestCase
     {
         $uuid = UUID::generate();
 
-        $this->assertInternalType('string', $uuid);
+        $this->assertIsString($uuid);
         $this->assertEquals(36, strlen($uuid));
     }
 

--- a/pkg/enqueue/composer.json
+++ b/pkg/enqueue/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/null": "^0.10",
@@ -16,7 +16,7 @@
         "psr/container": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "symfony/console": "^4.3|^5",
         "symfony/dependency-injection": "^4.3|^5",
         "symfony/config": "^4.3|^5",

--- a/pkg/fs/Tests/FsConnectionFactoryConfigTest.php
+++ b/pkg/fs/Tests/FsConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Fs\Tests;
 
 use Enqueue\Fs\FsConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class FsConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/fs/Tests/FsConnectionFactoryTest.php
+++ b/pkg/fs/Tests/FsConnectionFactoryTest.php
@@ -5,11 +5,13 @@ namespace Enqueue\Fs\Tests;
 use Enqueue\Fs\FsConnectionFactory;
 use Enqueue\Fs\FsContext;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 
 class FsConnectionFactoryTest extends \PHPUnit\Framework\TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/fs/Tests/FsContextTest.php
+++ b/pkg/fs/Tests/FsContextTest.php
@@ -9,6 +9,7 @@ use Enqueue\Fs\FsMessage;
 use Enqueue\Fs\FsProducer;
 use Enqueue\Null\NullQueue;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Context;
 use Interop\Queue\Exception\InvalidDestinationException;
 use Makasim\File\TempFile;
@@ -16,6 +17,7 @@ use Makasim\File\TempFile;
 class FsContextTest extends \PHPUnit\Framework\TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementContextInterface()
     {

--- a/pkg/fs/Tests/FsContextTest.php
+++ b/pkg/fs/Tests/FsContextTest.php
@@ -192,7 +192,7 @@ class FsContextTest extends \PHPUnit\Framework\TestCase
 
         $queue = $context->createQueue($tmpFile->getFilename());
 
-        $this->assertFileNotExists((string) $tmpFile);
+        $this->assertFileDoesNotExist((string) $tmpFile);
 
         $context->declareDestination($queue);
 

--- a/pkg/fs/Tests/Functional/FsCommonUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsCommonUseCasesTest.php
@@ -17,14 +17,14 @@ class FsCommonUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $fsContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 
         new TempFile(sys_get_temp_dir().'/fs_test_queue');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->fsContext->close();
     }

--- a/pkg/fs/Tests/Functional/FsCommonUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsCommonUseCasesTest.php
@@ -17,7 +17,7 @@ class FsCommonUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsConsumerTest.php
+++ b/pkg/fs/Tests/Functional/FsConsumerTest.php
@@ -15,14 +15,14 @@ class FsConsumerTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 
         $this->fsContext->purgeQueue($this->fsContext->createQueue('fs_test_queue'));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->fsContext->close();
     }

--- a/pkg/fs/Tests/Functional/FsConsumerTest.php
+++ b/pkg/fs/Tests/Functional/FsConsumerTest.php
@@ -15,7 +15,7 @@ class FsConsumerTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsConsumptionUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsConsumptionUseCasesTest.php
@@ -25,14 +25,14 @@ class FsConsumptionUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $fsContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 
         new TempFile(sys_get_temp_dir().'/fs_test_queue');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->fsContext->close();
     }

--- a/pkg/fs/Tests/Functional/FsConsumptionUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsConsumptionUseCasesTest.php
@@ -25,7 +25,7 @@ class FsConsumptionUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsProducerTest.php
+++ b/pkg/fs/Tests/Functional/FsProducerTest.php
@@ -14,7 +14,7 @@ class FsProducerTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 
@@ -22,7 +22,7 @@ class FsProducerTest extends TestCase
         file_put_contents(sys_get_temp_dir().'/fs_test_queue', '');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->fsContext->close();
     }

--- a/pkg/fs/Tests/Functional/FsProducerTest.php
+++ b/pkg/fs/Tests/Functional/FsProducerTest.php
@@ -14,7 +14,7 @@ class FsProducerTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/Functional/FsRpcUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsRpcUseCasesTest.php
@@ -20,7 +20,7 @@ class FsRpcUseCasesTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 
@@ -28,7 +28,7 @@ class FsRpcUseCasesTest extends TestCase
         new TempFile(sys_get_temp_dir().'/fs_reply_queue');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->fsContext->close();
     }

--- a/pkg/fs/Tests/Functional/FsRpcUseCasesTest.php
+++ b/pkg/fs/Tests/Functional/FsRpcUseCasesTest.php
@@ -20,7 +20,7 @@ class FsRpcUseCasesTest extends TestCase
      */
     private $fsContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fsContext = (new FsConnectionFactory(['path' => sys_get_temp_dir()]))->createContext();
 

--- a/pkg/fs/Tests/LegacyFilesystemLockTest.php
+++ b/pkg/fs/Tests/LegacyFilesystemLockTest.php
@@ -6,12 +6,14 @@ use Enqueue\Fs\FsContext;
 use Enqueue\Fs\LegacyFilesystemLock;
 use Enqueue\Fs\Lock;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Makasim\File\TempFile;
 use PHPUnit\Framework\TestCase;
 
 class LegacyFilesystemLockTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementLockInterface()
     {

--- a/pkg/fs/composer.json
+++ b/pkg/fs/composer.json
@@ -6,14 +6,14 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "symfony/filesystem": "^4.3|^5",
         "makasim/temp-file": "^0.2@stable"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/null": "0.10.x-dev",
         "enqueue/test": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6",

--- a/pkg/gearman/Tests/GearmanConnectionFactoryConfigTest.php
+++ b/pkg/gearman/Tests/GearmanConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Gearman\Tests;
 
 use Enqueue\Gearman\GearmanConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class GearmanConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
     use SkipIfGearmanExtensionIsNotInstalledTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()

--- a/pkg/gearman/Tests/SkipIfGearmanExtensionIsNotInstalledTrait.php
+++ b/pkg/gearman/Tests/SkipIfGearmanExtensionIsNotInstalledTrait.php
@@ -4,7 +4,7 @@ namespace Enqueue\Gearman\Tests;
 
 trait SkipIfGearmanExtensionIsNotInstalledTrait
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (false == class_exists(\GearmanClient::class)) {
             $this->markTestSkipped('The gearman extension is not installed');

--- a/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveFromQueueTest.php
+++ b/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveFromQueueTest.php
@@ -13,7 +13,7 @@ class GearmanSendToTopicAndReceiveFromQueueTest extends SendToTopicAndReceiveFro
 {
     private $time;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveFromQueueTest.php
+++ b/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveFromQueueTest.php
@@ -13,7 +13,7 @@ class GearmanSendToTopicAndReceiveFromQueueTest extends SendToTopicAndReceiveFro
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveNoWaitFromQueueTest.php
@@ -13,7 +13,7 @@ class GearmanSendToTopicAndReceiveNoWaitFromQueueTest extends SendToTopicAndRece
 {
     private $time;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/gearman/Tests/Spec/GearmanSendToTopicAndReceiveNoWaitFromQueueTest.php
@@ -13,7 +13,7 @@ class GearmanSendToTopicAndReceiveNoWaitFromQueueTest extends SendToTopicAndRece
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/gearman/composer.json
+++ b/pkg/gearman/composer.json
@@ -6,12 +6,12 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "ext-gearman": "^2.0",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"

--- a/pkg/gps/Tests/GpsConnectionFactoryConfigTest.php
+++ b/pkg/gps/Tests/GpsConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Gps\Tests;
 
 use Enqueue\Gps\GpsConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class GpsConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/gps/composer.json
+++ b/pkg/gps/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "google/cloud-pubsub": "^1.0",
         "enqueue/dsn": "^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"
     },

--- a/pkg/job-queue/Tests/CalculateRootJobStatusServiceTest.php
+++ b/pkg/job-queue/Tests/CalculateRootJobStatusServiceTest.php
@@ -102,7 +102,10 @@ class CalculateRootJobStatusServiceTest extends \PHPUnit\Framework\TestCase
         $case->calculate($childJob);
 
         $this->assertEquals($stopStatus, $rootJob->getStatus());
-        $this->assertEquals(new \DateTime(), $rootJob->getStoppedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $rootJob->getStoppedAt()->getTimestamp()
+        );
     }
 
     public function testShouldSetStoppedAtOnlyIfWasNotSet()
@@ -129,7 +132,10 @@ class CalculateRootJobStatusServiceTest extends \PHPUnit\Framework\TestCase
         $case = new CalculateRootJobStatusService($em);
         $case->calculate($childJob);
 
-        $this->assertEquals(new \DateTime('2012-12-12 12:12:12'), $rootJob->getStoppedAt());
+        $this->assertEquals(
+            (new \DateTime('2012-12-12 12:12:12'))->getTimestamp(),
+            $rootJob->getStoppedAt()->getTimestamp()
+        );
     }
 
     public function testShouldThrowIfInvalidStatus()

--- a/pkg/job-queue/Tests/Doctrine/JobStorageTest.php
+++ b/pkg/job-queue/Tests/Doctrine/JobStorageTest.php
@@ -440,12 +440,12 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             })
         ;
         $connection
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('insert')
             ->with('unique_table', ['name' => 'owner-id'])
         ;
         $connection
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('insert')
             ->with('unique_table', ['name' => 'job-name'])
         ;
@@ -510,12 +510,12 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $connection = $this->createConnectionMock();
         $connection
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('delete')
             ->with('unique_table', ['name' => 'owner-id'])
         ;
         $connection
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('delete')
             ->with('unique_table', ['name' => 'job-name'])
         ;

--- a/pkg/job-queue/Tests/Doctrine/JobStorageTest.php
+++ b/pkg/job-queue/Tests/Doctrine/JobStorageTest.php
@@ -440,12 +440,12 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             })
         ;
         $connection
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('insert')
             ->with('unique_table', ['name' => 'owner-id'])
         ;
         $connection
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('insert')
             ->with('unique_table', ['name' => 'job-name'])
         ;
@@ -510,12 +510,12 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $connection = $this->createConnectionMock();
         $connection
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('delete')
             ->with('unique_table', ['name' => 'owner-id'])
         ;
         $connection
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('delete')
             ->with('unique_table', ['name' => 'job-name'])
         ;

--- a/pkg/job-queue/Tests/Functional/WebTestCase.php
+++ b/pkg/job-queue/Tests/Functional/WebTestCase.php
@@ -18,7 +18,7 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected static $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/job-queue/Tests/JobProcessorTest.php
+++ b/pkg/job-queue/Tests/JobProcessorTest.php
@@ -60,8 +60,14 @@ class JobProcessorTest extends TestCase
 
         $this->assertSame($job, $result);
         $this->assertEquals(Job::STATUS_NEW, $job->getStatus());
-        $this->assertEquals(new \DateTime(), $job->getCreatedAt(), '', 1);
-        $this->assertEquals(new \DateTime(), $job->getStartedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getCreatedAt()->getTimestamp()
+        );
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getStartedAt()->getTimestamp()
+        );
         $this->assertNull($job->getStoppedAt());
         $this->assertEquals('job-name', $job->getName());
         $this->assertEquals('owner-id', $job->getOwnerId());
@@ -183,7 +189,10 @@ class JobProcessorTest extends TestCase
 
         $this->assertSame($job, $result);
         $this->assertEquals(Job::STATUS_NEW, $job->getStatus());
-        $this->assertEquals(new \DateTime(), $job->getCreatedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getCreatedAt()->getTimestamp()
+        );
         $this->assertNull($job->getStartedAt());
         $this->assertNull($job->getStoppedAt());
         $this->assertEquals('job-name', $job->getName());
@@ -256,7 +265,10 @@ class JobProcessorTest extends TestCase
         $processor->startChildJob($job);
 
         $this->assertEquals(Job::STATUS_RUNNING, $job->getStatus());
-        $this->assertEquals(new \DateTime(), $job->getStartedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getStartedAt()->getTimestamp()
+        );
     }
 
     public function testSuccessChildJobShouldThrowIfRootJob()
@@ -325,7 +337,10 @@ class JobProcessorTest extends TestCase
         $processor->successChildJob($job);
 
         $this->assertEquals(Job::STATUS_SUCCESS, $job->getStatus());
-        $this->assertEquals(new \DateTime(), $job->getStoppedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getStoppedAt()->getTimestamp()
+        );
     }
 
     public function testFailChildJobShouldThrowIfRootJob()
@@ -394,7 +409,10 @@ class JobProcessorTest extends TestCase
         $processor->failChildJob($job);
 
         $this->assertEquals(Job::STATUS_FAILED, $job->getStatus());
-        $this->assertEquals(new \DateTime(), $job->getStoppedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getStoppedAt()->getTimestamp()
+        );
     }
 
     public function testCancelChildJobShouldThrowIfRootJob()
@@ -463,8 +481,14 @@ class JobProcessorTest extends TestCase
         $processor->cancelChildJob($job);
 
         $this->assertEquals(Job::STATUS_CANCELLED, $job->getStatus());
-        $this->assertEquals(new \DateTime(), $job->getStoppedAt(), '', 1);
-        $this->assertEquals(new \DateTime(), $job->getStartedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getStoppedAt()->getTimestamp()
+        );
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $job->getStartedAt()->getTimestamp()
+        );
     }
 
     public function testInterruptRootJobShouldThrowIfNotRootJob()
@@ -536,7 +560,10 @@ class JobProcessorTest extends TestCase
         $processor->interruptRootJob($rootJob, true);
 
         $this->assertTrue($rootJob->isInterrupted());
-        $this->assertEquals(new \DateTime(), $rootJob->getStoppedAt(), '', 1);
+        $this->assertEquals(
+            (new \DateTime())->getTimestamp(),
+            $rootJob->getStoppedAt()->getTimestamp()
+        );
     }
 
     /**

--- a/pkg/job-queue/composer.json
+++ b/pkg/job-queue/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "enqueue/enqueue": "^0.10",
         "enqueue/null": "^0.10",
         "queue-interop/queue-interop": "^0.8",
@@ -14,7 +14,7 @@
         "doctrine/dbal": "<2.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "doctrine/doctrine-bundle": "~1.2|^2",
         "symfony/browser-kit": "^4.3|^5",

--- a/pkg/mongodb/Tests/Functional/MongodbConsumerTest.php
+++ b/pkg/mongodb/Tests/Functional/MongodbConsumerTest.php
@@ -19,7 +19,7 @@ class MongodbConsumerTest extends TestCase
      */
     private $context;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->context = $this->buildMongodbContext();
     }

--- a/pkg/mongodb/Tests/Functional/MongodbConsumerTest.php
+++ b/pkg/mongodb/Tests/Functional/MongodbConsumerTest.php
@@ -19,7 +19,7 @@ class MongodbConsumerTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildMongodbContext();
     }

--- a/pkg/mongodb/Tests/MongodbConnectionFactoryTest.php
+++ b/pkg/mongodb/Tests/MongodbConnectionFactoryTest.php
@@ -5,6 +5,7 @@ namespace Enqueue\Mongodb\Tests;
 use Enqueue\Mongodb\MongodbConnectionFactory;
 use Enqueue\Mongodb\MongodbContext;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -14,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 class MongodbConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/mongodb/Tests/MongodbContextTest.php
+++ b/pkg/mongodb/Tests/MongodbContextTest.php
@@ -8,6 +8,7 @@ use Enqueue\Mongodb\MongodbDestination;
 use Enqueue\Mongodb\MongodbMessage;
 use Enqueue\Mongodb\MongodbProducer;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Context;
 use Interop\Queue\Destination;
 use Interop\Queue\Exception\InvalidDestinationException;
@@ -21,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 class MongodbContextTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementContextInterface()
     {

--- a/pkg/mongodb/Tests/MongodbSubscriptionConsumerTest.php
+++ b/pkg/mongodb/Tests/MongodbSubscriptionConsumerTest.php
@@ -7,6 +7,7 @@ namespace Enqueue\Mongodb\Tests;
 use Enqueue\Mongodb\MongodbConsumer;
 use Enqueue\Mongodb\MongodbContext;
 use Enqueue\Mongodb\MongodbSubscriptionConsumer;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Queue;
 use Interop\Queue\SubscriptionConsumer;
@@ -14,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 class MongodbSubscriptionConsumerTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     public function testShouldImplementSubscriptionConsumerInterface()
     {
         $rc = new \ReflectionClass(MongodbSubscriptionConsumer::class);

--- a/pkg/mongodb/Tests/Spec/MongodbSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/mongodb/Tests/Spec/MongodbSendAndReceivePriorityMessagesFromQueueTest.php
@@ -18,7 +18,7 @@ class MongodbSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceiveP
 
     private $publishedAt;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/mongodb/Tests/Spec/MongodbSendAndReceivePriorityMessagesFromQueueTest.php
+++ b/pkg/mongodb/Tests/Spec/MongodbSendAndReceivePriorityMessagesFromQueueTest.php
@@ -18,7 +18,7 @@ class MongodbSendAndReceivePriorityMessagesFromQueueTest extends SendAndReceiveP
 
     private $publishedAt;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/mongodb/composer.json
+++ b/pkg/mongodb/composer.json
@@ -10,13 +10,13 @@
   "homepage": "https://enqueue.forma-pro.com/",
   "license": "MIT",
   "require": {
-    "php": "^7.1.3",
+    "php": "^7.3",
     "queue-interop/queue-interop": "^0.8",
     "mongodb/mongodb": "^1.2",
     "ext-mongodb": "^1.5"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.5",
+    "phpunit/phpunit": "^9.5",
     "queue-interop/queue-spec": "^0.6",
     "enqueue/test": "0.10.x-dev",
     "enqueue/null": "0.10.x-dev"

--- a/pkg/monitoring/composer.json
+++ b/pkg/monitoring/composer.json
@@ -6,12 +6,12 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "enqueue/enqueue": "^0.10",
         "enqueue/dsn": "^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "influxdb/influxdb-php": "^1.14",
         "datadog/php-datadogstatsd": "^1.3",

--- a/pkg/null/composer.json
+++ b/pkg/null/composer.json
@@ -6,11 +6,11 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"
     },

--- a/pkg/pheanstalk/Tests/PheanstalkConnectionFactoryConfigTest.php
+++ b/pkg/pheanstalk/Tests/PheanstalkConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Pheanstalk\Tests;
 
 use Enqueue\Pheanstalk\PheanstalkConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class PheanstalkConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveFromQueueTest.php
+++ b/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveFromQueueTest.php
@@ -13,7 +13,7 @@ class PheanstalkSendToTopicAndReceiveFromQueueTest extends SendToTopicAndReceive
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveFromQueueTest.php
+++ b/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveFromQueueTest.php
@@ -13,7 +13,7 @@ class PheanstalkSendToTopicAndReceiveFromQueueTest extends SendToTopicAndReceive
 {
     private $time;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest.php
@@ -13,7 +13,7 @@ class PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest extends SendToTopicAndR
 {
     private $time;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest.php
+++ b/pkg/pheanstalk/Tests/Spec/PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest.php
@@ -13,7 +13,7 @@ class PheanstalkSendToTopicAndReceiveNoWaitFromQueueTest extends SendToTopicAndR
 {
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->time = time();
     }

--- a/pkg/pheanstalk/composer.json
+++ b/pkg/pheanstalk/composer.json
@@ -6,12 +6,12 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "pda/pheanstalk": "^3",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"

--- a/pkg/rdkafka/Tests/JsonSerializerTest.php
+++ b/pkg/rdkafka/Tests/JsonSerializerTest.php
@@ -43,7 +43,7 @@ class JsonSerializerTest extends TestCase
         $resource = fopen(__FILE__, 'r');
 
         //guard
-        $this->assertInternalType('resource', $resource);
+        $this->assertIsResource($resource);
 
         $message = new RdKafkaMessage('theBody', ['aProp' => $resource]);
 

--- a/pkg/rdkafka/Tests/RdKafkaConnectionFactoryConfigTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\RdKafka\Tests;
 
 use Enqueue\RdKafka\RdKafkaConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class RdKafkaConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {
@@ -39,7 +41,7 @@ class RdKafkaConnectionFactoryConfigTest extends TestCase
     {
         $factory = new RdKafkaConnectionFactory($config);
 
-        $config = $this->getObjectAttribute($factory, 'config');
+        $config = $this->readAttribute($factory, 'config');
 
         $this->assertNotEmpty($config['global']['group.id']);
 

--- a/pkg/rdkafka/Tests/RdKafkaConnectionFactoryTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaConnectionFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Enqueue\RdKafka\Tests;
 
 use Enqueue\RdKafka\RdKafkaConnectionFactory;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -10,6 +11,8 @@ use PHPUnit\Framework\TestCase;
  */
 class RdKafkaConnectionFactoryTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {
         $this->expectException(\LogicException::class);

--- a/pkg/rdkafka/Tests/RdKafkaConnectionFactoryTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaConnectionFactoryTest.php
@@ -41,7 +41,7 @@ class RdKafkaConnectionFactoryTest extends TestCase
     {
         $factory = new RdKafkaConnectionFactory(null);
 
-        $config = $this->getObjectAttribute($factory, 'config');
+        $config = $this->readAttribute($factory, 'config');
 
         $this->assertNotEmpty($config['global']['group.id']);
 
@@ -58,7 +58,7 @@ class RdKafkaConnectionFactoryTest extends TestCase
     {
         $factory = new RdKafkaConnectionFactory('kafka:');
 
-        $config = $this->getObjectAttribute($factory, 'config');
+        $config = $this->readAttribute($factory, 'config');
 
         $this->assertNotEmpty($config['global']['group.id']);
 

--- a/pkg/rdkafka/composer.json
+++ b/pkg/rdkafka/composer.json
@@ -6,12 +6,12 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "ext-rdkafka": "^3.0.3|^4.0|^5.0",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6",

--- a/pkg/redis/Tests/Functional/PRedisCommonUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PRedisCommonUseCasesTest.php
@@ -11,15 +11,15 @@ use PHPUnit\Framework\TestCase;
  */
 class PRedisCommonUseCasesTest extends TestCase
 {
-    use RedisExtension;
     use CommonUseCasesTrait;
+    use RedisExtension;
 
     /**
      * @var RedisContext
      */
     private $context;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->context = $this->buildPRedisContext();
 
@@ -27,7 +27,7 @@ class PRedisCommonUseCasesTest extends TestCase
         $this->context->deleteTopic($this->context->createTopic('enqueue.test_topic'));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->context->close();
     }

--- a/pkg/redis/Tests/Functional/PRedisCommonUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PRedisCommonUseCasesTest.php
@@ -19,7 +19,7 @@ class PRedisCommonUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPRedisContext();
 

--- a/pkg/redis/Tests/Functional/PRedisConsumptionUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PRedisConsumptionUseCasesTest.php
@@ -11,15 +11,15 @@ use PHPUnit\Framework\TestCase;
  */
 class PRedisConsumptionUseCasesTest extends TestCase
 {
-    use RedisExtension;
     use ConsumptionUseCasesTrait;
+    use RedisExtension;
 
     /**
      * @var RedisContext
      */
     private $context;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->context = $this->buildPRedisContext();
 
@@ -27,7 +27,7 @@ class PRedisConsumptionUseCasesTest extends TestCase
         $this->context->deleteQueue($this->context->createQueue('enqueue.test_queue_reply'));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->context->close();
     }

--- a/pkg/redis/Tests/Functional/PRedisConsumptionUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PRedisConsumptionUseCasesTest.php
@@ -19,7 +19,7 @@ class PRedisConsumptionUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPRedisContext();
 

--- a/pkg/redis/Tests/Functional/PhpRedisCommonUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PhpRedisCommonUseCasesTest.php
@@ -11,15 +11,15 @@ use PHPUnit\Framework\TestCase;
  */
 class PhpRedisCommonUseCasesTest extends TestCase
 {
-    use RedisExtension;
     use CommonUseCasesTrait;
+    use RedisExtension;
 
     /**
      * @var RedisContext
      */
     private $context;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->context = $this->buildPhpRedisContext();
 
@@ -27,7 +27,7 @@ class PhpRedisCommonUseCasesTest extends TestCase
         $this->context->deleteTopic($this->context->createTopic('enqueue.test_topic'));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->context->close();
     }

--- a/pkg/redis/Tests/Functional/PhpRedisCommonUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PhpRedisCommonUseCasesTest.php
@@ -19,7 +19,7 @@ class PhpRedisCommonUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPhpRedisContext();
 

--- a/pkg/redis/Tests/Functional/PhpRedisConsumptionUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PhpRedisConsumptionUseCasesTest.php
@@ -11,15 +11,15 @@ use PHPUnit\Framework\TestCase;
  */
 class PhpRedisConsumptionUseCasesTest extends TestCase
 {
-    use RedisExtension;
     use ConsumptionUseCasesTrait;
+    use RedisExtension;
 
     /**
      * @var RedisContext
      */
     private $context;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->context = $this->buildPhpRedisContext();
 
@@ -27,7 +27,7 @@ class PhpRedisConsumptionUseCasesTest extends TestCase
         $this->context->deleteQueue($this->context->createQueue('enqueue.test_queue_reply'));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->context->close();
     }

--- a/pkg/redis/Tests/Functional/PhpRedisConsumptionUseCasesTest.php
+++ b/pkg/redis/Tests/Functional/PhpRedisConsumptionUseCasesTest.php
@@ -19,7 +19,7 @@ class PhpRedisConsumptionUseCasesTest extends TestCase
      */
     private $context;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->buildPhpRedisContext();
 

--- a/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
+++ b/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
@@ -5,6 +5,7 @@ namespace Enqueue\Redis\Tests;
 use Enqueue\Redis\Redis;
 use Enqueue\Redis\RedisConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 class RedisConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/redis/Tests/RedisConnectionFactoryTest.php
+++ b/pkg/redis/Tests/RedisConnectionFactoryTest.php
@@ -5,12 +5,14 @@ namespace Enqueue\Redis\Tests;
 use Enqueue\Redis\RedisConnectionFactory;
 use Enqueue\Redis\RedisContext;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
 class RedisConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {
@@ -26,6 +28,6 @@ class RedisConnectionFactoryTest extends TestCase
         $this->assertInstanceOf(RedisContext::class, $context);
 
         $this->assertAttributeEquals(null, 'redis', $context);
-        $this->assertInternalType('callable', $this->readAttribute($context, 'redisFactory'));
+        self::assertIsCallable($this->readAttribute($context, 'redisFactory'));
     }
 }

--- a/pkg/redis/Tests/RedisConsumerTest.php
+++ b/pkg/redis/Tests/RedisConsumerTest.php
@@ -187,19 +187,19 @@ class RedisConsumerTest extends \PHPUnit\Framework\TestCase
 
         $redisMock = $this->createRedisMock();
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('brpop')
             ->with(['aQueue'], $expectedTimeout)
             ->willReturn(null)
         ;
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(5))
             ->method('brpop')
             ->with(['aQueue'], $expectedTimeout)
             ->willReturn(null)
         ;
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(8))
             ->method('brpop')
             ->with(['aQueue'], $expectedTimeout)
             ->willReturn(new RedisResult('aQueue', $serializer->toString(new RedisMessage('aBody'))))

--- a/pkg/redis/Tests/RedisConsumerTest.php
+++ b/pkg/redis/Tests/RedisConsumerTest.php
@@ -187,19 +187,19 @@ class RedisConsumerTest extends \PHPUnit\Framework\TestCase
 
         $redisMock = $this->createRedisMock();
         $redisMock
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('brpop')
             ->with(['aQueue'], $expectedTimeout)
             ->willReturn(null)
         ;
         $redisMock
-            ->expects($this->at(5))
+            ->expects(self::once())
             ->method('brpop')
             ->with(['aQueue'], $expectedTimeout)
             ->willReturn(null)
         ;
         $redisMock
-            ->expects($this->at(8))
+            ->expects(self::once())
             ->method('brpop')
             ->with(['aQueue'], $expectedTimeout)
             ->willReturn(new RedisResult('aQueue', $serializer->toString(new RedisMessage('aBody'))))

--- a/pkg/redis/Tests/RedisContextTest.php
+++ b/pkg/redis/Tests/RedisContextTest.php
@@ -161,17 +161,17 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
     {
         $redisMock = $this->createRedisMock();
         $redisMock
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('del')
             ->with('aQueueName')
         ;
         $redisMock
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('del')
             ->with('aQueueName:delayed')
         ;
         $redisMock
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('del')
             ->with('aQueueName:reserved')
         ;
@@ -201,17 +201,17 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
     {
         $redisMock = $this->createRedisMock();
         $redisMock
-            ->expects($this->at(0))
+            ->expects(self::once())
             ->method('del')
             ->with('aTopicName')
         ;
         $redisMock
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('del')
             ->with('aTopicName:delayed')
         ;
         $redisMock
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('del')
             ->with('aTopicName:reserved')
         ;

--- a/pkg/redis/Tests/RedisContextTest.php
+++ b/pkg/redis/Tests/RedisContextTest.php
@@ -161,17 +161,17 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
     {
         $redisMock = $this->createRedisMock();
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('del')
             ->with('aQueueName')
         ;
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('del')
             ->with('aQueueName:delayed')
         ;
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('del')
             ->with('aQueueName:reserved')
         ;
@@ -201,17 +201,17 @@ class RedisContextTest extends \PHPUnit\Framework\TestCase
     {
         $redisMock = $this->createRedisMock();
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(0))
             ->method('del')
             ->with('aTopicName')
         ;
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('del')
             ->with('aTopicName:delayed')
         ;
         $redisMock
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('del')
             ->with('aTopicName:reserved')
         ;

--- a/pkg/redis/Tests/RedisProducerTest.php
+++ b/pkg/redis/Tests/RedisProducerTest.php
@@ -104,7 +104,7 @@ class RedisProducerTest extends TestCase
             ->with(
                 'aDestination:delayed',
                 $this->isJson(),
-                $this->equalTo(time() + 5, 1)
+                $this->equalTo(time() + 5)
             )
         ;
 

--- a/pkg/redis/Tests/RedisProducerTest.php
+++ b/pkg/redis/Tests/RedisProducerTest.php
@@ -67,7 +67,7 @@ class RedisProducerTest extends TestCase
                 $this->assertNotEmpty($message['headers']['message_id']);
                 $this->assertSame(0, $message['headers']['attempts']);
 
-                return true;
+                return 1;
             })
         ;
 

--- a/pkg/redis/Tests/RedisSubscriptionConsumerTest.php
+++ b/pkg/redis/Tests/RedisSubscriptionConsumerTest.php
@@ -5,6 +5,7 @@ namespace Enqueue\Redis\Tests;
 use Enqueue\Redis\RedisConsumer;
 use Enqueue\Redis\RedisContext;
 use Enqueue\Redis\RedisSubscriptionConsumer;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Queue;
 use Interop\Queue\SubscriptionConsumer;
@@ -12,6 +13,8 @@ use PHPUnit\Framework\TestCase;
 
 class RedisSubscriptionConsumerTest extends TestCase
 {
+    use ReadAttributeTrait;
+
     public function testShouldImplementSubscriptionConsumerInterface()
     {
         $rc = new \ReflectionClass(RedisSubscriptionConsumer::class);

--- a/pkg/redis/Tests/Spec/JsonSerializerTest.php
+++ b/pkg/redis/Tests/Spec/JsonSerializerTest.php
@@ -43,7 +43,7 @@ class JsonSerializerTest extends TestCase
         $resource = fopen(__FILE__, 'r');
 
         //guard
-        $this->assertInternalType('resource', $resource);
+        $this->assertIsResource($resource);
 
         $message = new RedisMessage('theBody', ['aProp' => $resource]);
 

--- a/pkg/redis/composer.json
+++ b/pkg/redis/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "ramsey/uuid": "^3|^4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "predis/predis": "^1.1",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",

--- a/pkg/simple-client/composer.json
+++ b/pkg/simple-client/composer.json
@@ -6,14 +6,14 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "enqueue/enqueue": "^0.10",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "symfony/config": "^4.3|^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/amqp-ext": "0.10.x-dev",
         "enqueue/fs": "0.10.x-dev",

--- a/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Sns\Tests;
 
 use Enqueue\Sns\SnsConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class SnsConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/sns/Tests/SnsConnectionFactoryTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryTest.php
@@ -7,12 +7,14 @@ use Enqueue\Sns\SnsClient;
 use Enqueue\Sns\SnsConnectionFactory;
 use Enqueue\Sns\SnsContext;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
 class SnsConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/sns/composer.json
+++ b/pkg/sns/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "aws/aws-sdk-php": "~3.26"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"
     },

--- a/pkg/snsqs/Tests/SnsQsProducerTest.php
+++ b/pkg/snsqs/Tests/SnsQsProducerTest.php
@@ -18,10 +18,12 @@ use Interop\Queue\Message;
 use Interop\Queue\Producer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class SnsQsProducerTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ProphecyTrait;
 
     public function testShouldImplementProducerInterface()
     {

--- a/pkg/snsqs/composer.json
+++ b/pkg/snsqs/composer.json
@@ -6,14 +6,14 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "enqueue/sns": "^0.10",
         "enqueue/sqs": "^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"
     },

--- a/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsCommonUseCasesTest.php
@@ -27,7 +27,7 @@ class SqsCommonUseCasesTest extends TestCase
      */
     private $queueName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/sqs/Tests/Functional/SqsConsumptionUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsConsumptionUseCasesTest.php
@@ -18,8 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 class SqsConsumptionUseCasesTest extends TestCase
 {
-    use SqsExtension;
     use RetryTrait;
+    use SqsExtension;
 
     /**
      * @var SqsContext

--- a/pkg/sqs/Tests/Functional/SqsConsumptionUseCasesTest.php
+++ b/pkg/sqs/Tests/Functional/SqsConsumptionUseCasesTest.php
@@ -26,7 +26,7 @@ class SqsConsumptionUseCasesTest extends TestCase
      */
     private $context;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Sqs\Tests;
 
 use Enqueue\Sqs\SqsConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class SqsConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/sqs/Tests/SqsConnectionFactoryTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryTest.php
@@ -7,12 +7,14 @@ use Enqueue\Sqs\SqsClient;
 use Enqueue\Sqs\SqsConnectionFactory;
 use Enqueue\Sqs\SqsContext;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;
 
 class SqsConnectionFactoryTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {

--- a/pkg/sqs/composer.json
+++ b/pkg/sqs/composer.json
@@ -6,13 +6,13 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "aws/aws-sdk-php": "~3.26"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"
     },

--- a/pkg/stomp/Tests/BufferedStompClientTest.php
+++ b/pkg/stomp/Tests/BufferedStompClientTest.php
@@ -128,12 +128,12 @@ class BufferedStompClientTest extends \PHPUnit\Framework\TestCase
 
         $connection = $this->createStompConnectionMock();
         $connection
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('readFrame')
             ->willReturn($frame)
         ;
         $connection
-            ->expects($this->at(2))
+            ->expects(self::once())
             ->method('readFrame')
             ->willReturn(false)
         ;
@@ -159,12 +159,12 @@ class BufferedStompClientTest extends \PHPUnit\Framework\TestCase
 
         $connection = $this->createStompConnectionMock();
         $connection
-            ->expects($this->at(1))
+            ->expects(self::once())
             ->method('readFrame')
             ->willReturn($frame1)
         ;
         $connection
-            ->expects($this->at(3))
+            ->expects(self::once())
             ->method('readFrame')
             ->willReturn($frame2)
         ;

--- a/pkg/stomp/Tests/BufferedStompClientTest.php
+++ b/pkg/stomp/Tests/BufferedStompClientTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Stomp\Tests;
 
 use Enqueue\Stomp\BufferedStompClient;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Enqueue\Test\WriteAttributeTrait;
 use Stomp\Client;
 use Stomp\Network\Connection;
@@ -12,6 +13,7 @@ use Stomp\Transport\Frame;
 class BufferedStompClientTest extends \PHPUnit\Framework\TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
     use WriteAttributeTrait;
 
     public function testShouldExtendLibStompClient()

--- a/pkg/stomp/Tests/BufferedStompClientTest.php
+++ b/pkg/stomp/Tests/BufferedStompClientTest.php
@@ -128,12 +128,12 @@ class BufferedStompClientTest extends \PHPUnit\Framework\TestCase
 
         $connection = $this->createStompConnectionMock();
         $connection
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('readFrame')
             ->willReturn($frame)
         ;
         $connection
-            ->expects(self::once())
+            ->expects($this->at(2))
             ->method('readFrame')
             ->willReturn(false)
         ;
@@ -159,12 +159,12 @@ class BufferedStompClientTest extends \PHPUnit\Framework\TestCase
 
         $connection = $this->createStompConnectionMock();
         $connection
-            ->expects(self::once())
+            ->expects($this->at(1))
             ->method('readFrame')
             ->willReturn($frame1)
         ;
         $connection
-            ->expects(self::once())
+            ->expects($this->at(3))
             ->method('readFrame')
             ->willReturn($frame2)
         ;

--- a/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
@@ -12,22 +12,22 @@ use Enqueue\Test\RabbitmqStompExtension;
  */
 class StompCommonUseCasesTest extends \PHPUnit\Framework\TestCase
 {
-    use RabbitmqStompExtension;
     use RabbitManagementExtensionTrait;
+    use RabbitmqStompExtension;
 
     /**
      * @var StompContext
      */
     private $stompContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 
         $this->removeQueue('stomp.test');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->stompContext->close();
     }

--- a/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompCommonUseCasesTest.php
@@ -20,7 +20,7 @@ class StompCommonUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $stompContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 

--- a/pkg/stomp/Tests/Functional/StompConnectionFactoryTest.php
+++ b/pkg/stomp/Tests/Functional/StompConnectionFactoryTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Stomp\Tests\Functional;
 
 use Enqueue\Stomp\StompConnectionFactory;
 use Enqueue\Test\RabbitmqStompExtension;
+use Enqueue\Test\ReadAttributeTrait;
 use Stomp\Network\Observer\Exception\HeartbeatException;
 use Stomp\Network\Observer\HeartbeatEmitter;
 use Stomp\Network\Observer\ServerAliveObserver;
@@ -14,6 +15,7 @@ use Stomp\Network\Observer\ServerAliveObserver;
 class StompConnectionFactoryTest extends \PHPUnit\Framework\TestCase
 {
     use RabbitmqStompExtension;
+    use ReadAttributeTrait;
 
     public function testShouldNotCreateConnectionWithSendHeartbeat()
     {

--- a/pkg/stomp/Tests/Functional/StompConsumptionUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompConsumptionUseCasesTest.php
@@ -20,22 +20,22 @@ use Interop\Queue\Processor;
  */
 class StompConsumptionUseCasesTest extends \PHPUnit\Framework\TestCase
 {
-    use RabbitmqStompExtension;
     use RabbitManagementExtensionTrait;
+    use RabbitmqStompExtension;
 
     /**
      * @var StompContext
      */
     private $stompContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 
         $this->removeQueue('stomp.test');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->stompContext->close();
     }

--- a/pkg/stomp/Tests/Functional/StompConsumptionUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompConsumptionUseCasesTest.php
@@ -28,7 +28,7 @@ class StompConsumptionUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $stompContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 

--- a/pkg/stomp/Tests/Functional/StompRpcUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompRpcUseCasesTest.php
@@ -14,15 +14,15 @@ use Enqueue\Test\RabbitmqStompExtension;
  */
 class StompRpcUseCasesTest extends \PHPUnit\Framework\TestCase
 {
-    use RabbitmqStompExtension;
     use RabbitManagementExtensionTrait;
+    use RabbitmqStompExtension;
 
     /**
      * @var StompContext
      */
     private $stompContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 
@@ -30,7 +30,7 @@ class StompRpcUseCasesTest extends \PHPUnit\Framework\TestCase
         $this->removeQueue('stomp.rpc.reply_test');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->stompContext->close();
     }

--- a/pkg/stomp/Tests/Functional/StompRpcUseCasesTest.php
+++ b/pkg/stomp/Tests/Functional/StompRpcUseCasesTest.php
@@ -22,7 +22,7 @@ class StompRpcUseCasesTest extends \PHPUnit\Framework\TestCase
      */
     private $stompContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stompContext = $this->buildStompContext();
 

--- a/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
+++ b/pkg/stomp/Tests/StompConnectionFactoryConfigTest.php
@@ -4,6 +4,7 @@ namespace Enqueue\Stomp\Tests;
 
 use Enqueue\Stomp\StompConnectionFactory;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class StompConnectionFactoryConfigTest extends TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testThrowNeitherArrayStringNorNullGivenAsConfig()
     {

--- a/pkg/stomp/Tests/StompConnectionFactoryTest.php
+++ b/pkg/stomp/Tests/StompConnectionFactoryTest.php
@@ -5,11 +5,13 @@ namespace Enqueue\Stomp\Tests;
 use Enqueue\Stomp\StompConnectionFactory;
 use Enqueue\Stomp\StompContext;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\ConnectionFactory;
 
 class StompConnectionFactoryTest extends \PHPUnit\Framework\TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementConnectionFactoryInterface()
     {
@@ -26,7 +28,7 @@ class StompConnectionFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertAttributeEquals(null, 'stomp', $context);
         $this->assertAttributeEquals(true, 'useExchangePrefix', $context);
-        $this->assertInternalType('callable', $this->readAttribute($context, 'stompFactory'));
+        self::assertIsCallable($this->readAttribute($context, 'stompFactory'));
     }
 
     public function testShouldCreateRabbitMQContext()

--- a/pkg/stomp/Tests/StompConsumerTest.php
+++ b/pkg/stomp/Tests/StompConsumerTest.php
@@ -523,8 +523,8 @@ class StompConsumerTest extends \PHPUnit\Framework\TestCase
         $fooConsumer = new StompConsumer($this->createStompClientMock(), $destination);
         $barConsumer = new StompConsumer($this->createStompClientMock(), $destination);
 
-        $this->assertAttributeNotEmpty('subscriptionId', $fooConsumer);
-        $this->assertAttributeNotEmpty('subscriptionId', $barConsumer);
+        $this->assertNotEmpty($this->readAttribute($fooConsumer, 'subscriptionId'));
+        $this->assertNotEmpty($this->readAttribute($barConsumer, 'subscriptionId'));
 
         $fooSubscriptionId = $this->readAttribute($fooConsumer, 'subscriptionId');
         $barSubscriptionId = $this->readAttribute($barConsumer, 'subscriptionId');

--- a/pkg/stomp/Tests/StompConsumerTest.php
+++ b/pkg/stomp/Tests/StompConsumerTest.php
@@ -8,6 +8,7 @@ use Enqueue\Stomp\StompConsumer;
 use Enqueue\Stomp\StompDestination;
 use Enqueue\Stomp\StompMessage;
 use Enqueue\Test\ClassExtensionTrait;
+use Enqueue\Test\ReadAttributeTrait;
 use Interop\Queue\Consumer;
 use Interop\Queue\Exception\InvalidMessageException;
 use Interop\Queue\Message;
@@ -17,6 +18,7 @@ use Stomp\Transport\Frame;
 class StompConsumerTest extends \PHPUnit\Framework\TestCase
 {
     use ClassExtensionTrait;
+    use ReadAttributeTrait;
 
     public function testShouldImplementMessageConsumerInterface()
     {

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "enqueue/dsn": "^0.10",
         "stomp-php/stomp-php": "^4",
         "queue-interop/queue-interop": "^0.8",
@@ -15,7 +15,7 @@
         "richardfullmer/rabbitmq-management-api": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"

--- a/pkg/test/ReadAttributeTrait.php
+++ b/pkg/test/ReadAttributeTrait.php
@@ -21,7 +21,7 @@ trait ReadAttributeTrait
         string $attribute,
         ?string $class = null
     ): ReflectionProperty {
-        if ($class === null) {
+        if (null === $class) {
             $class = get_class($object);
         }
 
@@ -29,7 +29,7 @@ trait ReadAttributeTrait
             return new ReflectionProperty($class, $attribute);
         } catch (\ReflectionException $exception) {
             $parentClass = get_parent_class($object);
-            if ($parentClass === false) {
+            if (false === $parentClass) {
                 throw $exception;
             }
 

--- a/pkg/test/ReadAttributeTrait.php
+++ b/pkg/test/ReadAttributeTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Enqueue\Test;
+
+trait ReadAttributeTrait
+{
+    public function readAttribute(object $object, string $attribute)
+    {
+        $refProperty = new \ReflectionProperty(get_class($object), $attribute);
+        $refProperty->setAccessible(true);
+        $value = $refProperty->getValue($object);
+        $refProperty->setAccessible(false);
+
+        return $value;
+    }
+
+    private function assertAttributeSame($expected, string $attribute, object $object): void
+    {
+        static::assertSame($expected, $this->readAttribute($object, $attribute));
+    }
+
+    private function assertAttributeEquals($expected, string $attribute, object $object): void
+    {
+        static::assertEquals($expected, $this->readAttribute($object, $attribute));
+    }
+
+    private function assertAttributeInstanceOf(string $expected, string $attribute, object $object): void
+    {
+        static::assertInstanceOf($expected, $this->readAttribute($object, $attribute));
+    }
+
+    private function assertAttributeCount(int $count, string $attribute, object $object): void
+    {
+        static::assertCount($count, $this->readAttribute($object, $attribute));
+    }
+}

--- a/pkg/test/RetryTrait.php
+++ b/pkg/test/RetryTrait.php
@@ -4,6 +4,7 @@ namespace Enqueue\Test;
 
 use PHPUnit\Framework\IncompleteTestError;
 use PHPUnit\Framework\SkippedTestError;
+use PHPUnit\Util\Test;
 
 trait RetryTrait
 {
@@ -46,7 +47,7 @@ trait RetryTrait
      */
     private function getNumberOfRetries()
     {
-        $annotations = $this->getAnnotations();
+        $annotations = Test::parseTestMethodAnnotations(static::class, $this->getName(false));
 
         if (isset($annotations['method']['retry'][0])) {
             return $annotations['method']['retry'][0];

--- a/pkg/wamp/Tests/Functional/WampConsumerTest.php
+++ b/pkg/wamp/Tests/Functional/WampConsumerTest.php
@@ -16,8 +16,8 @@ use Thruway\Logging\Logger;
  */
 class WampConsumerTest extends TestCase
 {
-    use WampExtension;
     use RetryTrait;
+    use WampExtension;
 
     public static function setUpBeforeClass(): void
     {

--- a/pkg/wamp/Tests/Functional/WampConsumerTest.php
+++ b/pkg/wamp/Tests/Functional/WampConsumerTest.php
@@ -19,7 +19,7 @@ class WampConsumerTest extends TestCase
     use WampExtension;
     use RetryTrait;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Logger::set(new NullLogger());
     }

--- a/pkg/wamp/Tests/Functional/WampSubscriptionConsumerTest.php
+++ b/pkg/wamp/Tests/Functional/WampSubscriptionConsumerTest.php
@@ -16,7 +16,7 @@ class WampSubscriptionConsumerTest extends TestCase
 {
     use WampExtension;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Logger::set(new NullLogger());
     }

--- a/pkg/wamp/Tests/Spec/JsonSerializerTest.php
+++ b/pkg/wamp/Tests/Spec/JsonSerializerTest.php
@@ -43,7 +43,7 @@ class JsonSerializerTest extends TestCase
         $resource = fopen(__FILE__, 'r');
 
         //guard
-        $this->assertInternalType('resource', $resource);
+        $this->assertIsResource($resource);
 
         $message = new WampMessage('theBody', ['aProp' => $resource]);
 

--- a/pkg/wamp/composer.json
+++ b/pkg/wamp/composer.json
@@ -6,14 +6,14 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "thruway/client": "^0.5.0",
         "thruway/pawl-transport": "^0.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "^9.5",
         "enqueue/test": "0.10.x-dev",
         "enqueue/null": "0.10.x-dev",
         "queue-interop/queue-spec": "^0.6"


### PR DESCRIPTION
- Update PHPUnit to 9.5;
- Drop PHP 7.1 and 7.2.

This is part of the effort to add support for PHP 8.