### PR TITLE
Add PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
 
       - run: bin/dev -b
         env:
-          PHP_VERSION: ${{ matrix.php }}
+          PHP_VERSION: "${{ matrix.php }}"
         if: matrix.prepare_container
 
       - run: bin/phpunit --exclude-group=functional

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,23 @@ jobs:
             functional_tests: false
             rdkafka_tests: true
             prepare_container: true
+          - php: 8.0
+            symfony_version: 5.2.*
+            unit_tests: true
+            functional_tests: false
+            rdkafka_tests: false
+            prepare_container: false
+          - php: 8.0
+            symfony_version: 5.2.*
+            unit_tests: false
+            functional_tests: true
+            rdkafka_tests: false
+            prepare_container: true
+          - php: 8.0
+            symfony_version: 5.2.*
+            unit_tests: false
+            rdkafka_tests: true
+            prepare_container: true
 
     name: PHP ${{ matrix.php }} tests on Sf ${{ matrix.symfony_version }}, unit=${{ matrix.unit_tests }}, func=${{ matrix.functional_tests }}, rdkafka=${{ matrix.rdkafka_tests }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,19 +124,19 @@ jobs:
             functional_tests: false
             rdkafka_tests: true
             prepare_container: true
-          - php: 8.0
+          - php: "8.0"
             symfony_version: 5.2.*
             unit_tests: true
             functional_tests: false
             rdkafka_tests: false
             prepare_container: false
-          - php: 8.0
+          - php: "8.0"
             symfony_version: 5.2.*
             unit_tests: false
             functional_tests: true
             rdkafka_tests: false
             prepare_container: true
-          - php: 8.0
+          - php: "8.0"
             symfony_version: 5.2.*
             unit_tests: false
             rdkafka_tests: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
       - run: sed -i 's/525568/16777471/' vendor/kwn/php-rdkafka-stubs/stubs/constants.php
 
       - run: bin/dev -b
+        env:
+          PHP_VERSION: ${{ matrix.php }}
         if: matrix.prepare_container
 
       - run: bin/phpunit --exclude-group=functional

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,9 @@ jobs:
           extensions: mongodb, redis, :xdebug
           ini-values: memory_limit=2048M
 
-      - run: php ./bin/fix-symfony-version.php "4.3.*"
+      - run: php ./bin/fix-symfony-version.php "5.2.*"
 
       - uses: "ramsey/composer-install@v1"
-
       - run: sed -i 's/525568/16777471/' vendor/kwn/php-rdkafka-stubs/stubs/constants.php
 
       - run: docker run --workdir="/mqdev" -v "`pwd`:/mqdev" --rm enqueue/dev:latest php -d memory_limit=1024M bin/phpstan analyse -l 1 -c phpstan.neon --error-format=github -- ${{ env.GIT_DIFF_FILTERED }}
@@ -50,10 +49,9 @@ jobs:
           extensions: mongodb, redis, :xdebug
           ini-values: memory_limit=2048M
 
-      - run: php ./bin/fix-symfony-version.php "4.3.*"
+      - run: php ./bin/fix-symfony-version.php "5.2.*"
 
       - uses: "ramsey/composer-install@v1"
-
       - run: sed -i 's/525568/16777471/' vendor/kwn/php-rdkafka-stubs/stubs/constants.php
 
       - run: ./bin/php-cs-fixer fix --config=.php_cs.php --no-interaction --dry-run --diff -v --path-mode=intersection -- ${{ env.GIT_DIFF_FILTERED }}
@@ -98,6 +96,12 @@ jobs:
             prepare_container: false
           - php: 7.4
             symfony_version: 5.0.*
+            unit_tests: true
+            functional_tests: false
+            rdkafka_tests: false
+            prepare_container: false
+          - php: 7.4
+            symfony_version: 5.2.*
             unit_tests: true
             functional_tests: false
             rdkafka_tests: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - run: php ./bin/fix-symfony-version.php "5.2.*"
 
       - uses: "ramsey/composer-install@v1"
+
       - run: sed -i 's/525568/16777471/' vendor/kwn/php-rdkafka-stubs/stubs/constants.php
 
       - run: docker run --workdir="/mqdev" -v "`pwd`:/mqdev" --rm enqueue/dev:latest php -d memory_limit=1024M bin/phpstan analyse -l 1 -c phpstan.neon --error-format=github -- ${{ env.GIT_DIFF_FILTERED }}
@@ -52,6 +53,7 @@ jobs:
       - run: php ./bin/fix-symfony-version.php "5.2.*"
 
       - uses: "ramsey/composer-install@v1"
+
       - run: sed -i 's/525568/16777471/' vendor/kwn/php-rdkafka-stubs/stubs/constants.php
 
       - run: ./bin/php-cs-fixer fix --config=.php_cs.php --no-interaction --dry-run --diff -v --path-mode=intersection -- ${{ env.GIT_DIFF_FILTERED }}

--- a/bin/dev
+++ b/bin/dev
@@ -6,7 +6,7 @@ set -e
 while getopts "bustefdp" OPTION; do
   case $OPTION in
     b)
-      docker-compose pull && docker-compose build
+      docker-compose pull -q && docker-compose build
       ;;
     u)
       docker-compose up

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "pda/pheanstalk": "^3",
     "aws/aws-sdk-php": "^3.26",
     "stomp-php/stomp-php": "^4",
-    "php-http/guzzle6-adapter": "^1.1",
+    "php-http/guzzle7-adapter": "^0.1.1",
     "php-http/client-common": "^2.2.1",
     "richardfullmer/rabbitmq-management-api": "dev-http-client-2 as 2.1.0",
     "predis/predis": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
     "cs-lint": "bin/php-cs-fixer fix --config=.php_cs.php --no-interaction --dry-run --diff",
     "phpstan": "bin/phpstan analyse --memory-limit=512M -c phpstan.neon"
   },
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/andrewmy/rabbitmq-management-api.git"
+    }
+  ],
   "require": {
     "php": "^7.3|^8.0",
 
@@ -33,7 +39,7 @@
     "stomp-php/stomp-php": "^4",
     "php-http/guzzle6-adapter": "^1.1",
     "php-http/client-common": "^2.2.1",
-    "richardfullmer/rabbitmq-management-api": "^2.0",
+    "richardfullmer/rabbitmq-management-api": "dev-http-client-2 as 2.1.0",
     "predis/predis": "^1.1",
     "thruway/client": "^0.5.0",
     "thruway/pawl-transport": "^0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "phpstan": "bin/phpstan analyse --memory-limit=512M -c phpstan.neon"
   },
   "require": {
-    "php": "^7.3",
+    "php": "^7.3|^8.0",
 
     "ext-amqp": "^1.9.3",
     "ext-gearman": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "symfony/yaml": "^4.3|^5",
     "empi89/php-amqp-stubs": "*@dev",
     "doctrine/doctrine-bundle": "~1.2|^2",
-    "doctrine/mongodb-odm-bundle": "^3.5|4.3.x-dev as 4.3.0",
+    "doctrine/mongodb-odm-bundle": "4.3.x-dev as 4.3.0",
     "alcaeus/mongo-php-adapter": "^1.0",
     "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
     "friendsofphp/php-cs-fixer": "^2",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "queue-interop/queue-interop": "^0.7|^0.8",
     "bunny/bunny": "^0.2.4|^0.3|^0.4",
     "php-amqplib/php-amqplib": "^2.7",
-    "doctrine/dbal": "^2.6,<2.10",
+    "doctrine/dbal": "^2.12",
     "ramsey/uuid": "^2|^3.5|^4.0",
     "psr/log": "^1",
     "psr/container": "^1",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/andrewmy/rabbitmq-management-api.git"
+      "url": "https://github.com/andrewmy/php-rabbitmq-management-api.git"
     }
   ],
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
     {
       "type": "git",
       "url": "https://github.com/andrewmy/php-rabbitmq-management-api.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/rimvislt/DoctrineMongoDBBundle.git"
     }
   ],
   "require": {
@@ -64,7 +68,7 @@
     "symfony/yaml": "^4.3|^5",
     "empi89/php-amqp-stubs": "*@dev",
     "doctrine/doctrine-bundle": "~1.2|^2",
-    "doctrine/mongodb-odm-bundle": "^3.5|^4",
+    "doctrine/mongodb-odm-bundle": "4.3.x-dev as 4.3.0",
     "alcaeus/mongo-php-adapter": "^1.0",
     "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
     "friendsofphp/php-cs-fixer": "^2",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "symfony/yaml": "^4.3|^5",
     "empi89/php-amqp-stubs": "*@dev",
     "doctrine/doctrine-bundle": "~1.2|^2",
-    "doctrine/mongodb-odm-bundle": "4.3.x-dev as 4.3.0",
+    "doctrine/mongodb-odm-bundle": "^3.5|4.3.x-dev as 4.3.0",
     "alcaeus/mongo-php-adapter": "^1.0",
     "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
     "friendsofphp/php-cs-fixer": "^2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "aws/aws-sdk-php": "^3.26",
     "stomp-php/stomp-php": "^4",
     "php-http/guzzle6-adapter": "^1.1",
-    "php-http/client-common": "^1.7@dev",
+    "php-http/client-common": "^2.2.1",
     "richardfullmer/rabbitmq-management-api": "^2.0",
     "predis/predis": "^1.1",
     "thruway/client": "^0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,6 @@
     },
     {
       "type": "git",
-      "url": "https://github.com/rimvislt/DoctrineMongoDBBundle.git"
-    },
-    {
-      "type": "git",
       "url": "https://github.com/andrewmy/stomp-php.git"
     }
   ],
@@ -72,7 +68,7 @@
     "symfony/yaml": "^4.3|^5",
     "empi89/php-amqp-stubs": "*@dev",
     "doctrine/doctrine-bundle": "~1.2|^2",
-    "doctrine/mongodb-odm-bundle": "4.3.x-dev as 4.3.0",
+    "doctrine/mongodb-odm-bundle": "^3.5|^4.3",
     "alcaeus/mongo-php-adapter": "^1.0",
     "kwn/php-rdkafka-stubs": "^1.0.2 | ^2.0",
     "friendsofphp/php-cs-fixer": "^2",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,6 @@
     {
       "type": "git",
       "url": "https://github.com/andrewmy/php-rabbitmq-management-api.git"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/andrewmy/stomp-php.git"
     }
   ],
   "require": {
@@ -40,7 +36,7 @@
     "mongodb/mongodb": "^1.2",
     "pda/pheanstalk": "^3",
     "aws/aws-sdk-php": "^3.26",
-    "stomp-php/stomp-php": "dev-php-8-travis as 4.6.1",
+    "stomp-php/stomp-php": "^4|^5",
     "php-http/guzzle7-adapter": "^0.1.1",
     "php-http/client-common": "^2.2.1",
     "richardfullmer/rabbitmq-management-api": "dev-http-client-2 as 2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,10 @@
     {
       "type": "git",
       "url": "https://github.com/rimvislt/DoctrineMongoDBBundle.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/andrewmy/stomp-php.git"
     }
   ],
   "require": {
@@ -40,7 +44,7 @@
     "mongodb/mongodb": "^1.2",
     "pda/pheanstalk": "^3",
     "aws/aws-sdk-php": "^3.26",
-    "stomp-php/stomp-php": "^4",
+    "stomp-php/stomp-php": "dev-php-8-travis as 4.6.1",
     "php-http/guzzle7-adapter": "^0.1.1",
     "php-http/client-common": "^2.2.1",
     "richardfullmer/rabbitmq-management-api": "dev-http-client-2 as 2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "stomp-php/stomp-php": "^4|^5",
     "php-http/guzzle7-adapter": "^0.1.1",
     "php-http/client-common": "^2.2.1",
-    "richardfullmer/rabbitmq-management-api": "dev-http-client-2 as 2.1.0",
+    "richardfullmer/rabbitmq-management-api": "^2.1.1",
     "predis/predis": "^1.1",
     "thruway/client": "^0.5.0",
     "thruway/pawl-transport": "^0.5.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build:
       context: docker
       args:
-        PHP_VERSION: ${PHP_VERSION:-7.3}
+        PHP_VERSION: "${PHP_VERSION:-7.3}"
     depends_on:
       - rabbitmq
       - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,12 @@ version: '2'
 
 services:
   dev:
-    image: enqueue/dev:latest
+    # when image publishing gets sorted:
+    # image: enqueue/dev:${PHP_VERSION}
+    build:
+      context: docker
+      args:
+        - PHP_VERSION=${PHP_VERSION:7.3}
     depends_on:
       - rabbitmq
       - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build:
       context: docker
       args:
-        - PHP_VERSION=${PHP_VERSION:7.3}
+        PHP_VERSION: ${PHP_VERSION:-7.3}
     depends_on:
       - rabbitmq
       - mysql

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x && \
 ## librdkafka
 RUN set -x && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests g++ php${PHP_VERSION}-pear php${PHP_VERSION}-dev make && \
+    apt-get install -y --no-install-recommends --no-install-suggests g++ php-pear php${PHP_VERSION}-dev make && \
     mkdir -p $HOME/librdkafka && \
     cd $HOME/librdkafka && \
     git clone https://github.com/edenhill/librdkafka.git . && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,12 +6,12 @@ ARG PHP_VERSION
 ## libs
 RUN set -x && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests wget curl openssl ca-certificates nano netcat php-dev php${PHP_VERSION}-redis php${PHP_VERSION}-pgsql git python php-amqp
+    apt-get install -y --no-install-recommends --no-install-suggests wget curl openssl ca-certificates nano netcat php${PHP_VERSION}-dev php${PHP_VERSION}-redis php${PHP_VERSION}-pgsql git python php${PHP_VERSION}-amqp
 
 ## librdkafka
 RUN set -x && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests g++ php-pear php${PHP_VERSION}-dev make && \
+    apt-get install -y --no-install-recommends --no-install-suggests g++ php${PHP_VERSION}-pear php${PHP_VERSION}-dev make && \
     mkdir -p $HOME/librdkafka && \
     cd $HOME/librdkafka && \
     git clone https://github.com/edenhill/librdkafka.git . && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,24 +1,27 @@
-FROM formapro/nginx-php-fpm:7.3-latest-all-exts
+ARG PHP_VERSION=7.3
+FROM formapro/nginx-php-fpm:${PHP_VERSION}-latest-all-exts
+
+ARG PHP_VERSION
 
 ## libs
 RUN set -x && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests wget curl openssl ca-certificates nano netcat php7.3-dev php7.3-redis php7.3-pgsql git python php-amqp
+    apt-get install -y --no-install-recommends --no-install-suggests wget curl openssl ca-certificates nano netcat php-dev php${PHP_VERSION}-redis php${PHP_VERSION}-pgsql git python php-amqp
 
 ## librdkafka
 RUN set -x && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests g++ php-pear php7.3-dev make && \
+    apt-get install -y --no-install-recommends --no-install-suggests g++ php-pear php${PHP_VERSION}-dev make && \
     mkdir -p $HOME/librdkafka && \
     cd $HOME/librdkafka && \
     git clone https://github.com/edenhill/librdkafka.git . && \
     git checkout v1.0.0 && \
     ./configure && make && make install && \
     pecl install rdkafka && \
-    echo "extension=rdkafka.so" > /etc/php/7.3/cli/conf.d/10-rdkafka.ini && \
-    echo "extension=rdkafka.so" > /etc/php/7.3/fpm/conf.d/10-rdkafka.ini
+    echo "extension=rdkafka.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-rdkafka.ini && \
+    echo "extension=rdkafka.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-rdkafka.ini
 
-COPY ./php/cli.ini /etc/php/7.3/cli/conf.d/1-dev_cli.ini
+COPY ./php/cli.ini /etc/php/${PHP_VERSION}/cli/conf.d/1-dev_cli.ini
 COPY ./bin/dev_entrypoiny.sh /usr/local/bin/entrypoint.sh
 RUN chmod u+x /usr/local/bin/entrypoint.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=7.3
-FROM formapro/nginx-php-fpm:${PHP_VERSION}-latest-all-exts
+FROM makasim/nginx-php-fpm:${PHP_VERSION}-latest-all-exts
 
 ARG PHP_VERSION
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,6 @@ ARG PHP_VERSION
 
 ## libs
 RUN set -x && \
-    pecl channel-update pecl.php.net && \
     apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \
         wget \
@@ -22,6 +21,7 @@ RUN set -x && \
         php${PHP_VERSION}-amqp \
         libgearman-dev \
     && \
+    pecl channel-update pecl.php.net && \
     pecl install gearman && \
     echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini && \
     echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-gearman.ini

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x && \
         python \
         php${PHP_VERSION}-amqp \
         libgearman-dev \
+        php-pear \
     && \
     pecl channel-update pecl.php.net && \
     pecl install gearman && \
@@ -29,7 +30,10 @@ RUN set -x && \
 ## librdkafka
 RUN set -x && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests g++ php-pear php${PHP_VERSION}-dev make && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        g++ \
+        make \
+    && \
     mkdir -p $HOME/librdkafka && \
     cd $HOME/librdkafka && \
     git clone https://github.com/edenhill/librdkafka.git . && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN set -x && \
         php${PHP_VERSION}-amqp \
         libgearman-dev \
         php-pear \
+        make \
     && \
     pecl channel-update pecl.php.net && \
     pecl install gearman && \
@@ -32,7 +33,6 @@ RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \
         g++ \
-        make \
     && \
     mkdir -p $HOME/librdkafka && \
     cd $HOME/librdkafka && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,26 @@ ARG PHP_VERSION
 
 ## libs
 RUN set -x && \
+    pecl channel-update pecl.php.net && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests wget curl openssl ca-certificates nano netcat php${PHP_VERSION}-dev php${PHP_VERSION}-redis php${PHP_VERSION}-pgsql git python php${PHP_VERSION}-amqp
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        wget \
+        curl \
+        openssl \
+        ca-certificates \
+        nano \
+        netcat \
+        php${PHP_VERSION}-dev \
+        php${PHP_VERSION}-redis \
+        php${PHP_VERSION}-pgsql \
+        git \
+        python \
+        php${PHP_VERSION}-amqp \
+        libgearman-dev \
+    && \
+    pecl install gearman && \
+    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini && \
+    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-gearman.ini
 
 ## librdkafka
 RUN set -x && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN set -x && \
         git \
         python \
         php${PHP_VERSION}-amqp \
+        php${PHP_VERSION}-xml \
         libgearman-dev \
         php-pear \
         make \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,10 @@ RUN set -x && \
         php-pear \
         make \
     && \
-    pecl channel-update pecl.php.net
+    pecl channel-update pecl.php.net && \
+    pecl install gearman && \
+    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini && \
+    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-gearman.ini
 
 ## librdkafka
 RUN set -x && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,12 +21,18 @@ RUN set -x && \
         php${PHP_VERSION}-amqp \
         php${PHP_VERSION}-xml \
         php${PHP_VERSION}-mysql \
+        php${PHP_VERSION}-curl \
         libgearman-dev \
         php-pear \
         make \
     && \
     pecl channel-update pecl.php.net && \
-    pecl install gearman
+    pecl install gearman && \
+    if [ ! -f /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini ]; then \
+        echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini && \
+        echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-gearman.ini \
+        ; \
+    fi;
 
 ## librdkafka
 RUN set -x && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x && \
         python \
         php${PHP_VERSION}-amqp \
         php${PHP_VERSION}-xml \
+        php${PHP_VERSION}-mysql \
         libgearman-dev \
         php-pear \
         make \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,10 +25,7 @@ RUN set -x && \
         php-pear \
         make \
     && \
-    pecl channel-update pecl.php.net && \
-    pecl install gearman && \
-    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini && \
-    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-gearman.ini
+    pecl channel-update pecl.php.net
 
 ## librdkafka
 RUN set -x && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=7.3
-FROM makasim/nginx-php-fpm:${PHP_VERSION}-latest-all-exts
+FROM makasim/nginx-php-fpm:${PHP_VERSION}-all-exts
 
 ARG PHP_VERSION
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,9 +26,7 @@ RUN set -x && \
         make \
     && \
     pecl channel-update pecl.php.net && \
-    pecl install gearman && \
-    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini && \
-    echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-gearman.ini
+    pecl install gearman
 
 ## librdkafka
 RUN set -x && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,9 @@ RUN set -x && \
     && \
     pecl channel-update pecl.php.net && \
     pecl install gearman && \
-    if [ ! -f /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini ]; then \
-        echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-gearman.ini && \
-        echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-gearman.ini \
+    if [ ! -f /etc/php/${PHP_VERSION}/cli/conf.d/20-gearman.ini ]; then \
+        echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/20-gearman.ini && \
+        echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/20-gearman.ini \
         ; \
     fi;
 

--- a/docker/thruway/Dockerfile
+++ b/docker/thruway/Dockerfile
@@ -1,4 +1,4 @@
-FROM formapro/nginx-php-fpm:latest-all-exts
+FROM makasim/nginx-php-fpm:latest-all-exts
 
 RUN mkdir -p /thruway
 WORKDIR /thruway

--- a/pkg/amqp-bunny/.github/workflows/ci.yml
+++ b/pkg/amqp-bunny/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/amqp-bunny/composer.json
+++ b/pkg/amqp-bunny/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "bunny/bunny": "^0.4",

--- a/pkg/amqp-ext/.github/workflows/ci.yml
+++ b/pkg/amqp-ext/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/amqp-ext/composer.json
+++ b/pkg/amqp-ext/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-amqp": "^1.9.3",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/amqp-lib/.github/workflows/ci.yml
+++ b/pkg/amqp-lib/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/amqp-lib/composer.json
+++ b/pkg/amqp-lib/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "php-amqplib/php-amqplib": "^2.10",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/amqp-tools/.github/workflows/ci.yml
+++ b/pkg/amqp-tools/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/amqp-tools/composer.json
+++ b/pkg/amqp-tools/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10"

--- a/pkg/async-command/.github/workflows/ci.yml
+++ b/pkg/async-command/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/async-command/composer.json
+++ b/pkg/async-command/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": ">=7.1",
+        "php": "^7.3|^8.0",
         "enqueue/enqueue": "^0.10",
         "queue-interop/queue-interop": "^0.8",
         "symfony/console": "^4.3|^5",

--- a/pkg/async-event-dispatcher/.github/workflows/ci.yml
+++ b/pkg/async-event-dispatcher/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/async-event-dispatcher/composer.json
+++ b/pkg/async-event-dispatcher/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "enqueue/enqueue": "^0.10",
         "queue-interop/queue-interop": "^0.8",
         "symfony/event-dispatcher": "^4.3|^5"

--- a/pkg/dbal/.github/workflows/ci.yml
+++ b/pkg/dbal/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/dbal/composer.json
+++ b/pkg/dbal/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "doctrine/dbal": "^2.6",
         "ramsey/uuid": "^3|^4"

--- a/pkg/dbal/composer.json
+++ b/pkg/dbal/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
-        "doctrine/dbal": "^2.6",
+        "doctrine/dbal": "^2.12",
         "ramsey/uuid": "^3|^4"
     },
     "require-dev": {

--- a/pkg/dsn/.github/workflows/ci.yml
+++ b/pkg/dsn/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/dsn/composer.json
+++ b/pkg/dsn/composer.json
@@ -6,10 +6,10 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "support": {
         "email": "opensource@forma-pro.com",

--- a/pkg/enqueue-bundle/.github/workflows/ci.yml
+++ b/pkg/enqueue-bundle/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -113,7 +113,11 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
 
         $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for path "enqueue.default.client.driver_options". Expected array, but got string');
+        // Exception messages vary slightly between versions
+        $this->expectExceptionMessageMatches(
+            '/Invalid type for path "enqueue\.default\.client\.driver_options"\. Expected "?array"?, but got "?string"?/'
+        );
+
         $processor->processConfiguration($configuration, [[
             'default' => [
                 'transport' => 'null:',

--- a/pkg/enqueue-bundle/composer.json
+++ b/pkg/enqueue-bundle/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "symfony/framework-bundle": "^4.3|^5",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/enqueue-bundle/composer.json
+++ b/pkg/enqueue-bundle/composer.json
@@ -37,7 +37,7 @@
         "enqueue/async-command": "0.10.x-dev",
         "php-amqplib/php-amqplib": "^2.7",
         "doctrine/doctrine-bundle": "~1.2|^2",
-        "doctrine/mongodb-odm-bundle": "^3.5|^4",
+        "doctrine/mongodb-odm-bundle": "^3.5|^4.3",
         "alcaeus/mongo-php-adapter": "^1.0",
         "symfony/browser-kit": "^4.3|^5",
         "symfony/expression-language": "^4.3|^5",

--- a/pkg/enqueue/.github/workflows/ci.yml
+++ b/pkg/enqueue/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
+++ b/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
@@ -69,7 +69,11 @@ class ContainerProcessorRegistryTest extends TestCase
         $registry = new ContainerProcessorRegistry($containerMock);
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Return value of Enqueue\Symfony\ContainerProcessorRegistry::get() must implement interface Interop\Queue\Processor, instance of stdClass returned');
+        // Exception messages vary slightly between versions
+        $this->expectExceptionMessageMatches(
+            '/Return value of Enqueue\\Symfony\\ContainerProcessorRegistry::get\(\) .+ Interop\\Queue\\Processor, .?stdClass returned/'
+        );
+
         $registry->get('processor-name');
     }
 

--- a/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
+++ b/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
@@ -71,7 +71,7 @@ class ContainerProcessorRegistryTest extends TestCase
         $this->expectException(\TypeError::class);
         // Exception messages vary slightly between versions
         $this->expectExceptionMessageMatches(
-            '/Enqueue\\Symfony\\ContainerProcessorRegistry::get\(\) .+ Interop\\Queue\\Processor, .*stdClass returned/'
+            '/Enqueue\\Symfony\\ContainerProcessorRegistry\:\:get\(\).+ Interop\\Queue\\Processor, .*stdClass returned/'
         );
 
         $registry->get('processor-name');

--- a/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
+++ b/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
@@ -71,7 +71,7 @@ class ContainerProcessorRegistryTest extends TestCase
         $this->expectException(\TypeError::class);
         // Exception messages vary slightly between versions
         $this->expectExceptionMessageMatches(
-            '/Enqueue\\Symfony\\ContainerProcessorRegistry\:\:get\(\).+ Interop\\Queue\\Processor, .*stdClass returned/'
+            '/Enqueue\\\\Symfony\\\\ContainerProcessorRegistry::get\(\).+ Interop\\\\Queue\\\\Processor,.*stdClass returned/'
         );
 
         $registry->get('processor-name');

--- a/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
+++ b/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
@@ -71,7 +71,7 @@ class ContainerProcessorRegistryTest extends TestCase
         $this->expectException(\TypeError::class);
         // Exception messages vary slightly between versions
         $this->expectExceptionMessageMatches(
-            '/Return value of Enqueue\\Symfony\\ContainerProcessorRegistry::get\(\) .+ Interop\\Queue\\Processor, .?stdClass returned/'
+            '/Return value of Enqueue\\Symfony\\ContainerProcessorRegistry::get\(\) .+ Interop\\Queue\\Processor, .*stdClass returned/'
         );
 
         $registry->get('processor-name');

--- a/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
+++ b/pkg/enqueue/Tests/Symfony/ContainerProcessorRegistryTest.php
@@ -71,7 +71,7 @@ class ContainerProcessorRegistryTest extends TestCase
         $this->expectException(\TypeError::class);
         // Exception messages vary slightly between versions
         $this->expectExceptionMessageMatches(
-            '/Return value of Enqueue\\Symfony\\ContainerProcessorRegistry::get\(\) .+ Interop\\Queue\\Processor, .*stdClass returned/'
+            '/Enqueue\\Symfony\\ContainerProcessorRegistry::get\(\) .+ Interop\\Queue\\Processor, .*stdClass returned/'
         );
 
         $registry->get('processor-name');

--- a/pkg/enqueue/composer.json
+++ b/pkg/enqueue/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/null": "^0.10",

--- a/pkg/fs/.github/workflows/ci.yml
+++ b/pkg/fs/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/fs/composer.json
+++ b/pkg/fs/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "symfony/filesystem": "^4.3|^5",

--- a/pkg/gearman/.github/workflows/ci.yml
+++ b/pkg/gearman/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/gearman/composer.json
+++ b/pkg/gearman/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-gearman": "^2.0",
         "queue-interop/queue-interop": "^0.8"
     },

--- a/pkg/gps/.github/workflows/ci.yml
+++ b/pkg/gps/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/gps/composer.json
+++ b/pkg/gps/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "google/cloud-pubsub": "^1.0",
         "enqueue/dsn": "^0.10"

--- a/pkg/job-queue/.github/workflows/ci.yml
+++ b/pkg/job-queue/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/job-queue/Test/DbalPersistedConnection.php
+++ b/pkg/job-queue/Test/DbalPersistedConnection.php
@@ -33,7 +33,6 @@ class DbalPersistedConnection extends Connection
 
         if ($this->hasPersistedConnection()) {
             $this->_conn = $this->getPersistedConnection();
-            $this->setConnected(true);
         } else {
             parent::connect();
             $this->persistConnection($this->_conn);
@@ -64,22 +63,6 @@ class DbalPersistedConnection extends Connection
     public function rollBack()
     {
         $this->wrapTransactionNestingLevel('rollBack');
-    }
-
-    /**
-     * @param bool $connected
-     */
-    protected function setConnected($connected)
-    {
-        $rc = new \ReflectionClass(Connection::class);
-        $rp = $rc->hasProperty('isConnected') ?
-            $rc->getProperty('isConnected') :
-            $rc->getProperty('_isConnected')
-        ;
-
-        $rp->setAccessible(true);
-        $rp->setValue($this, $connected);
-        $rp->setAccessible(false);
     }
 
     /**

--- a/pkg/job-queue/composer.json
+++ b/pkg/job-queue/composer.json
@@ -11,7 +11,7 @@
         "enqueue/null": "^0.10",
         "queue-interop/queue-interop": "^0.8",
         "doctrine/orm": "~2.4",
-        "doctrine/dbal": "<2.10"
+        "doctrine/dbal": "^2.12"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/pkg/job-queue/composer.json
+++ b/pkg/job-queue/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "enqueue/enqueue": "^0.10",
         "enqueue/null": "^0.10",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/mongodb/.github/workflows/ci.yml
+++ b/pkg/mongodb/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/mongodb/composer.json
+++ b/pkg/mongodb/composer.json
@@ -10,7 +10,7 @@
   "homepage": "https://enqueue.forma-pro.com/",
   "license": "MIT",
   "require": {
-    "php": "^7.3",
+    "php": "^7.3|^8.0",
     "queue-interop/queue-interop": "^0.8",
     "mongodb/mongodb": "^1.2",
     "ext-mongodb": "^1.5"

--- a/pkg/monitoring/.github/workflows/ci.yml
+++ b/pkg/monitoring/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/monitoring/composer.json
+++ b/pkg/monitoring/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "enqueue/enqueue": "^0.10",
         "enqueue/dsn": "^0.10"
     },

--- a/pkg/null/.github/workflows/ci.yml
+++ b/pkg/null/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/null/composer.json
+++ b/pkg/null/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {

--- a/pkg/pheanstalk/.github/workflows/ci.yml
+++ b/pkg/pheanstalk/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/pheanstalk/composer.json
+++ b/pkg/pheanstalk/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "pda/pheanstalk": "^3",
         "queue-interop/queue-interop": "^0.8"
     },

--- a/pkg/rdkafka/.github/workflows/ci.yml
+++ b/pkg/rdkafka/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/rdkafka/composer.json
+++ b/pkg/rdkafka/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-rdkafka": "^3.0.3|^4.0|^5.0",
         "queue-interop/queue-interop": "^0.8"
     },

--- a/pkg/redis/.github/workflows/ci.yml
+++ b/pkg/redis/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/redis/composer.json
+++ b/pkg/redis/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "ramsey/uuid": "^3|^4"

--- a/pkg/simple-client/.github/workflows/ci.yml
+++ b/pkg/simple-client/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/simple-client/composer.json
+++ b/pkg/simple-client/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "enqueue/enqueue": "^0.10",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/sns/.github/workflows/ci.yml
+++ b/pkg/sns/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/sns/composer.json
+++ b/pkg/sns/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "aws/aws-sdk-php": "~3.26"

--- a/pkg/snsqs/.github/workflows/ci.yml
+++ b/pkg/snsqs/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/snsqs/composer.json
+++ b/pkg/snsqs/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "enqueue/sns": "^0.10",

--- a/pkg/sqs/.github/workflows/ci.yml
+++ b/pkg/sqs/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/sqs/composer.json
+++ b/pkg/sqs/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "aws/aws-sdk-php": "~3.26"

--- a/pkg/stomp/.github/workflows/ci.yml
+++ b/pkg/stomp/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "enqueue/dsn": "^0.10",
         "stomp-php/stomp-php": "^4",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -10,7 +10,7 @@
         "enqueue/dsn": "^0.10",
         "stomp-php/stomp-php": "^4",
         "queue-interop/queue-interop": "^0.8",
-        "php-http/guzzle6-adapter": "^1.1",
+        "php-http/guzzle7-adapter": "^0.1.1",
         "php-http/client-common": "^2.2.1",
         "richardfullmer/rabbitmq-management-api": "^2.0"
     },

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -11,7 +11,7 @@
         "stomp-php/stomp-php": "^4",
         "queue-interop/queue-interop": "^0.8",
         "php-http/guzzle6-adapter": "^1.1",
-        "php-http/client-common": "^1.7@dev",
+        "php-http/client-common": "^2.2.1",
         "richardfullmer/rabbitmq-management-api": "^2.0"
     },
     "require-dev": {

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -12,7 +12,7 @@
         "queue-interop/queue-interop": "^0.8",
         "php-http/guzzle7-adapter": "^0.1.1",
         "php-http/client-common": "^2.2.1",
-        "richardfullmer/rabbitmq-management-api": "^2.0"
+        "richardfullmer/rabbitmq-management-api": "^2.1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "enqueue/dsn": "^0.10",
-        "stomp-php/stomp-php": "^4",
+        "stomp-php/stomp-php": "^4.0|^5.0",
         "queue-interop/queue-interop": "^0.8",
         "php-http/guzzle7-adapter": "^0.1.1",
         "php-http/client-common": "^2.2.1",

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -5,6 +5,12 @@
     "keywords": ["messaging", "queue", "stomp"],
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/andrewmy/php-rabbitmq-management-api.git"
+        }
+    ],
     "require": {
         "php": "^7.3|^8.0",
         "enqueue/dsn": "^0.10",

--- a/pkg/wamp/.github/workflows/ci.yml
+++ b/pkg/wamp/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/pkg/wamp/composer.json
+++ b/pkg/wamp/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "thruway/client": "^0.5.0",


### PR DESCRIPTION
Currently blocked by:
- [ ] https://github.com/richardfullmer/php-rabbitmq-management-api/pull/11 — green, waiting for merge, using a fork for testing.
- [x] https://github.com/doctrine/DoctrineMongoDBBundle/pull/662 ~or https://github.com/doctrine/DoctrineMongoDBBundle/pull/665~ — ~almost~ green 😬 ~using a fork for testing~ v4.3 🎉
- [x] https://github.com/formapro/docker-nginx-php-fpm/pull/6 or https://github.com/makasim/docker-nginx-php-fpm/pull/2 — green
- [x] https://github.com/stomp-php/stomp-php/pull/157 — green ~, waiting for merge, using a fork for testing~ v5 🎉;
  - originally not tested even on 7.4 😬 the latest is 4.6.1 (`php: ^7.0`); CI installs 4.2.2 as it has an open PHP version constraint (`>=5.5.0`) 😂 
- [x] a `7.3` tag for the docker image :D https://github.com/makasim/docker-nginx-php-fpm/pull/2#issuecomment-766823344

Notes:
- ~ODM bundle v4.3.x won't work with Symfony 4.3, not sure if affects anyone once we can specify `^3.5|^4.3` for the bundle again~ all g
- Not sure how to handle enqueue/dev docker image pushing, building from ~formapro~ makasim base atm

Fixes #1108
Fixes #1123