### PR TITLE
Allow to configure a Serializer for Kafka

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "google/cloud-pubsub": "^1.4.3",
     "doctrine/orm": "^2.7.4",
     "doctrine/persistence": "^1.3.3|^2.0",
-    "mongodb/mongodb": "^1.2",
     "aws/aws-sdk-php": "^3.155",
     "stomp-php/stomp-php": "^4.5|^5",
     "php-http/guzzle7-adapter": "^0.1.1",

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,6 @@
   "require": {
     "php": "^7.3|^8.0",
 
-    "ext-amqp": "^1.9.3",
-    "ext-gearman": "^2.0",
-    "ext-mongodb": "^1.5",
-    "ext-rdkafka": "^4.0|^5.0",
-
     "queue-interop/amqp-interop": "^0.8.2",
     "queue-interop/queue-interop": "^0.8.1",
     "bunny/bunny": "^0.4|^0.5",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "doctrine/orm": "^2.7.4",
     "doctrine/persistence": "^1.3.3|^2.0",
     "mongodb/mongodb": "^1.2",
-    "pda/pheanstalk": "^3.1",
     "aws/aws-sdk-php": "^3.155",
     "stomp-php/stomp-php": "^4.5|^5",
     "php-http/guzzle7-adapter": "^0.1.1",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     "stomp-php/stomp-php": "^4.5|^5",
     "php-http/guzzle7-adapter": "^0.1.1",
     "php-http/client-common": "^2.2.1",
-    "richardfullmer/rabbitmq-management-api": "^2.1.0",
     "predis/predis": "^1.1",
     "thruway/client": "^0.5",
     "thruway/pawl-transport": "^0.5.1",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "stomp-php/stomp-php": "^4.5|^5",
     "php-http/guzzle7-adapter": "^0.1.1",
     "php-http/client-common": "^2.2.1",
-    "richardfullmer/rabbitmq-management-api": "^2.1.1",
+    "richardfullmer/rabbitmq-management-api": "^2.1.0",
     "predis/predis": "^1.1",
     "thruway/client": "^0.5",
     "thruway/pawl-transport": "^0.5.1",

--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -55,7 +55,12 @@ class RdKafkaContext implements Context
         $this->kafkaConsumers = [];
         $this->rdKafkaConsumers = [];
 
-        $this->setSerializer(new JsonSerializer());
+        // Check for custom Serializers passed via the $config
+        if (! empty($config)) {
+            $this->setSerializer(new $config['serializer']());
+        } else {
+            $this->setSerializer(new JsonSerializer());
+        }
     }
 
     /**


### PR DESCRIPTION
## Notes

Hello everyone, first off, great job on making this such an active PHP project!
I'd like to use the Kafka queue, however my messages are encoded in Avro, which means I need to serialise them using a Schema registry. The only clean way without being intrusive, according to me, was to add a configuration entry called "serializer" and to capture this when setting up the RdKafkaContext.

If there are better ways of doing this, I'd love to hear them, if I need to alter some code or extra checks, i.e. check if the passes class exists before trying to instantiate it, let me know!

**UPDATE**
It was not my intention to edit the composer.json file, but it seems that the master version where I forked from has the requirement of needing "all" of the php extensions for all of the different queues this package supports.

I think I need some pointers on how to contribute best to this package, as the rdkafka is a read-only one.