### PR TITLE
add subscription_interval as config for dbal subscription consumer

### DIFF
--- a/pkg/dbal/DbalContext.php
+++ b/pkg/dbal/DbalContext.php
@@ -39,14 +39,13 @@ class DbalContext implements Context
      * Callable must return instance of Doctrine\DBAL\Connection once called.
      *
      * @param Connection|callable $connection
-     * @param array               $config
      */
     public function __construct($connection, array $config = [])
     {
         $this->config = array_replace([
             'table_name' => 'enqueue',
             'polling_interval' => null,
-            'subscription_interval' => null,
+            'subscription_polling_interval' => null,
         ], $config);
 
         if ($connection instanceof Connection) {
@@ -54,11 +53,7 @@ class DbalContext implements Context
         } elseif (is_callable($connection)) {
             $this->connectionFactory = $connection;
         } else {
-            throw new \InvalidArgumentException(sprintf(
-                'The connection argument must be either %s or callable that returns %s.',
-                Connection::class,
-                Connection::class
-            ));
+            throw new \InvalidArgumentException(sprintf('The connection argument must be either %s or callable that returns %s.', Connection::class, Connection::class));
         }
     }
 
@@ -136,8 +131,8 @@ class DbalContext implements Context
             $consumer->setRedeliveryDelay($this->config['redelivery_delay']);
         }
 
-        if (isset($this->config['subscription_interval'])) {
-            $consumer->setSubscriptionInterval($this->config['subscription_interval']);
+        if (isset($this->config['subscription_polling_interval'])) {
+            $consumer->setPollingInterval($this->config['subscription_polling_interval']);
         }
 
         return $consumer;
@@ -207,10 +202,7 @@ class DbalContext implements Context
         if (false == $this->connection) {
             $connection = call_user_func($this->connectionFactory);
             if (false == $connection instanceof Connection) {
-                throw new \LogicException(sprintf(
-                    'The factory must return instance of Doctrine\DBAL\Connection. It returns %s',
-                    is_object($connection) ? get_class($connection) : gettype($connection)
-                ));
+                throw new \LogicException(sprintf('The factory must return instance of Doctrine\DBAL\Connection. It returns %s', is_object($connection) ? get_class($connection) : gettype($connection)));
             }
 
             $this->connection = $connection;

--- a/pkg/dbal/DbalContext.php
+++ b/pkg/dbal/DbalContext.php
@@ -46,6 +46,7 @@ class DbalContext implements Context
         $this->config = array_replace([
             'table_name' => 'enqueue',
             'polling_interval' => null,
+            'subscription_interval' => null,
         ], $config);
 
         if ($connection instanceof Connection) {
@@ -133,6 +134,10 @@ class DbalContext implements Context
 
         if (isset($this->config['redelivery_delay'])) {
             $consumer->setRedeliveryDelay($this->config['redelivery_delay']);
+        }
+
+        if (isset($this->config['subscription_interval'])) {
+            $consumer->setSubscriptionInterval($this->config['subscription_interval']);
         }
 
         return $consumer;

--- a/pkg/dbal/DbalSubscriptionConsumer.php
+++ b/pkg/dbal/DbalSubscriptionConsumer.php
@@ -37,6 +37,13 @@ class DbalSubscriptionConsumer implements SubscriptionConsumer
     private $redeliveryDelay;
 
     /**
+     * Time to wait between subscription requests in milliseconds.
+     *
+     * @var int
+     */
+    private $subscriptionInterval = 200;
+
+    /**
      * @param DbalContext $context
      */
     public function __construct(DbalContext $context)
@@ -59,6 +66,13 @@ class DbalSubscriptionConsumer implements SubscriptionConsumer
     public function setRedeliveryDelay(int $redeliveryDelay): self
     {
         $this->redeliveryDelay = $redeliveryDelay;
+
+        return $this;
+    }
+
+    public function setSubscriptionInterval(int $subscriptionInterval): self
+    {
+        $this->subscriptionInterval = $subscriptionInterval;
 
         return $this;
     }
@@ -92,7 +106,7 @@ class DbalSubscriptionConsumer implements SubscriptionConsumer
                  * @var DbalConsumer
                  * @var callable     $callback
                  */
-                list($consumer, $callback) = $this->subscribers[$message->getQueue()];
+                [$consumer, $callback] = $this->subscribers[$message->getQueue()];
 
                 if (false === call_user_func($callback, $message, $consumer)) {
                     return;
@@ -102,7 +116,7 @@ class DbalSubscriptionConsumer implements SubscriptionConsumer
             } else {
                 $currentQueueNames = [];
 
-                usleep(200000); // 200ms
+                usleep($this->subscriptionInterval * 1000); // 200ms
             }
 
             if ($timeout && microtime(true) >= $now + $timeout) {

--- a/pkg/dbal/DbalSubscriptionConsumer.php
+++ b/pkg/dbal/DbalSubscriptionConsumer.php
@@ -41,11 +41,8 @@ class DbalSubscriptionConsumer implements SubscriptionConsumer
      *
      * @var int
      */
-    private $subscriptionInterval = 200;
+    private $pollingInterval = 200;
 
-    /**
-     * @param DbalContext $context
-     */
     public function __construct(DbalContext $context)
     {
         $this->context = $context;
@@ -70,9 +67,14 @@ class DbalSubscriptionConsumer implements SubscriptionConsumer
         return $this;
     }
 
-    public function setSubscriptionInterval(int $subscriptionInterval): self
+    public function getPollingInterval(): int
     {
-        $this->subscriptionInterval = $subscriptionInterval;
+        return $this->pollingInterval;
+    }
+
+    public function setPollingInterval(int $msec): self
+    {
+        $this->pollingInterval = $msec;
 
         return $this;
     }
@@ -116,7 +118,7 @@ class DbalSubscriptionConsumer implements SubscriptionConsumer
             } else {
                 $currentQueueNames = [];
 
-                usleep($this->subscriptionInterval * 1000); // 200ms
+                usleep($this->getPollingInterval() * 1000);
             }
 
             if ($timeout && microtime(true) >= $now + $timeout) {

--- a/pkg/dbal/Tests/DbalContextTest.php
+++ b/pkg/dbal/Tests/DbalContextTest.php
@@ -39,6 +39,7 @@ class DbalContextTest extends TestCase
         $this->assertAttributeEquals([
             'table_name' => 'enqueue',
             'polling_interval' => null,
+            'subscription_polling_interval' => null,
         ], 'config', $factory);
     }
 
@@ -47,11 +48,13 @@ class DbalContextTest extends TestCase
         $factory = new DbalContext($this->createConnectionMock(), [
             'table_name' => 'theTableName',
             'polling_interval' => 12345,
+            'subscription_polling_interval' => 12345,
         ]);
 
         $this->assertAttributeEquals([
             'table_name' => 'theTableName',
             'polling_interval' => 12345,
+            'subscription_polling_interval' => 12345,
         ], 'config', $factory);
     }
 


### PR DESCRIPTION
I am facing an issue with the situation, that I have a few JobWorker running and my DB doesn't like that many requests. Without the change, I am getting 50 Requests in 10 Seconds with 1 JobWorker. Because of this, I am getting many "MySQL Server has gone away" messages.