### PR TITLE
Fix dbal delivery delay to always keep integer value

### DIFF
--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -35,9 +35,6 @@ class DbalProducer implements Producer
      */
     private $context;
 
-    /**
-     * @param DbalContext $context
-     */
     public function __construct(DbalContext $context)
     {
         $this->context = $context;
@@ -85,10 +82,7 @@ class DbalProducer implements Producer
         $delay = $message->getDeliveryDelay();
         if ($delay) {
             if (!is_int($delay)) {
-                throw new \LogicException(sprintf(
-                    'Delay must be integer but got: "%s"',
-                    is_object($delay) ? get_class($delay) : gettype($delay)
-                ));
+                throw new \LogicException(sprintf('Delay must be integer but got: "%s"', is_object($delay) ? get_class($delay) : gettype($delay)));
             }
 
             if ($delay <= 0) {
@@ -101,10 +95,7 @@ class DbalProducer implements Producer
         $timeToLive = $message->getTimeToLive();
         if ($timeToLive) {
             if (!is_int($timeToLive)) {
-                throw new \LogicException(sprintf(
-                    'TimeToLive must be integer but got: "%s"',
-                    is_object($timeToLive) ? get_class($timeToLive) : gettype($timeToLive)
-                ));
+                throw new \LogicException(sprintf('TimeToLive must be integer but got: "%s"', is_object($timeToLive) ? get_class($timeToLive) : gettype($timeToLive)));
             }
 
             if ($timeToLive <= 0) {

--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -111,7 +111,7 @@ class DbalProducer implements Producer
                 throw new \LogicException(sprintf('TimeToLive must be positive integer but got: "%s"', $timeToLive));
             }
 
-            $dbalMessage['time_to_live'] = time() + (int) $timeToLive / 1000;
+            $dbalMessage['time_to_live'] = time() + (int) ($timeToLive / 1000);
         }
 
         try {


### PR DESCRIPTION
Fixes incorrect calculations that may result in float instead of int:


`SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: \"1619173911.5\" at /data/app/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php:102, Doctrine\\DBAL\\Driver\\PDO\\Exception(code: 22P02): SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: \"1619173911.5\" at /data/app/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDO/Exception.php:18, PDOException(code: 22P02): SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: \"1619173911.5\" at /data/app/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:115)`