### PR TITLE
Perform at least once delivery when rejecting with requeue

### DIFF
--- a/pkg/dbal/DbalConsumer.php
+++ b/pkg/dbal/DbalConsumer.php
@@ -100,14 +100,14 @@ class DbalConsumer implements Consumer
     {
         InvalidMessageException::assertMessageInstanceOf($message, DbalMessage::class);
 
-        $this->acknowledge($message);
-
         if ($requeue) {
             $message = clone $message;
             $message->setRedelivered(false);
 
             $this->getContext()->createProducer()->send($this->queue, $message);
         }
+
+        $this->acknowledge($message);
     }
 
     protected function getContext(): DbalContext


### PR DESCRIPTION
During rejection with requeue there is possibility for losing message. 
The scenario may happen, if after acknowledge we will lose connection. 
In that case, message will not be redelivered and original message will be lost. 

Given solution performs redelivery first and then perform the acknowledge. 
In the scenario with losing the connection in between, the message will be delivered twice instead of being lost. 
This work in "at least once delivery" manner, just like RabbitMQ. 