### PR TITLE
Fix dbal delivery delay to always keep integer value

### DIFF
--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -89,7 +89,7 @@ class DbalProducer implements Producer
                 throw new \LogicException(sprintf('Delay must be positive integer but got: "%s"', $delay));
             }
 
-            $dbalMessage['delayed_until'] = time() + (int) $delay / 1000;
+            $dbalMessage['delayed_until'] = time() + (int) ($delay / 1000);
         }
 
         $timeToLive = $message->getTimeToLive();


### PR DESCRIPTION
In this issue I have fixed TTL: https://github.com/php-enqueue/enqueue-dev/pull/1161
This MR fixes the delay.