### PR TITLE
Fixes timeout in messages

### DIFF
--- a/pkg/redis/RedisConsumerHelperTrait.php
+++ b/pkg/redis/RedisConsumerHelperTrait.php
@@ -34,7 +34,7 @@ trait RedisConsumerHelperTrait
         while ($expires > time()) {
             $this->migrateExpiredMessages($this->queueNames);
 
-            if (false == $result = $this->getContext()->getRedis()->brpop($this->queueNames, $thisTimeout)) {
+            if (false == $result = $this->getContext()->getRedis()->brpop($this->queueNames, $expires - time())) {
                 return null;
             }
 


### PR DESCRIPTION
My understanding is that the old code would have an exponential decay. Basically, it would subtract the amount of seconds that had elapsed since the code started executing with each attempt.

This would mean that a retry after two seconds would subtract 2 seconds from the timeout, a retry after 5 seconds, would remove another 5 seconds.