### PR TITLE
ResetServicesExtension to run _after_ message received

### DIFF
--- a/pkg/enqueue-bundle/Consumption/Extension/ResetServicesExtension.php
+++ b/pkg/enqueue-bundle/Consumption/Extension/ResetServicesExtension.php
@@ -2,11 +2,11 @@
 
 namespace Enqueue\Bundle\Consumption\Extension;
 
-use Enqueue\Consumption\Context\MessageReceived;
-use Enqueue\Consumption\MessageReceivedExtensionInterface;
+use Enqueue\Consumption\Context\PostMessageReceived;
+use Enqueue\Consumption\PostMessageReceivedExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 
-class ResetServicesExtension implements MessageReceivedExtensionInterface
+class ResetServicesExtension implements PostMessageReceivedExtensionInterface
 {
     /**
      * @var ServicesResetter
@@ -18,7 +18,7 @@ class ResetServicesExtension implements MessageReceivedExtensionInterface
         $this->resetter = $resetter;
     }
 
-    public function onMessageReceived(MessageReceived $context): void
+    public function onPostMessageReceived(PostMessageReceived $context): void
     {
         $context->getLogger()->debug('[ResetServicesExtension] Resetting services.');
 

--- a/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/ResetServicesExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/ResetServicesExtensionTest.php
@@ -37,7 +37,7 @@ class ResetServicesExtensionTest extends TestCase
         ;
 
         $extension = new ResetServicesExtension($resetter);
-        $extension->onMessageReceived($context);
+        $extension->onPostMessageReceived($context);
     }
 
     protected function createContext(): MessageReceived

--- a/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/ResetServicesExtensionTest.php
+++ b/pkg/enqueue-bundle/Tests/Unit/Consumption/Extension/ResetServicesExtensionTest.php
@@ -4,7 +4,7 @@ namespace Enqueue\Bundle\Tests\Unit\Consumption\Extension;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Enqueue\Bundle\Consumption\Extension\ResetServicesExtension;
-use Enqueue\Consumption\Context\MessageReceived;
+use Enqueue\Consumption\Context\PostMessageReceived;
 use Interop\Queue\Consumer;
 use Interop\Queue\Context as InteropContext;
 use Interop\Queue\Message;
@@ -40,9 +40,9 @@ class ResetServicesExtensionTest extends TestCase
         $extension->onPostMessageReceived($context);
     }
 
-    protected function createContext(): MessageReceived
+    protected function createContext(): PostMessageReceived
     {
-        return new MessageReceived(
+        return new PostMessageReceived(
             $this->createMock(InteropContext::class),
             $this->createMock(Consumer::class),
             $this->createMock(Message::class),


### PR DESCRIPTION
Resolves https://github.com/php-enqueue/enqueue-dev/issues/1156

Reset the services after message is received, so that logs are flushed without having to wait for a new message