### PR TITLE
Changed: Clear Doctrine cache before calculate Root Job Status

### DIFF
--- a/pkg/job-queue/CalculateRootJobStatusProcessor.php
+++ b/pkg/job-queue/CalculateRootJobStatusProcessor.php
@@ -48,7 +48,6 @@ class CalculateRootJobStatusProcessor implements Processor, CommandSubscriberInt
 
     public function process(Message $message, Context $context)
     {
-        $this->jobStorage->clearJobCache();
         $data = JSON::decode($message->getBody());
 
         if (!isset($data['jobId'])) {

--- a/pkg/job-queue/CalculateRootJobStatusProcessor.php
+++ b/pkg/job-queue/CalculateRootJobStatusProcessor.php
@@ -48,6 +48,7 @@ class CalculateRootJobStatusProcessor implements Processor, CommandSubscriberInt
 
     public function process(Message $message, Context $context)
     {
+        $this->jobStorage->clearJobCache();
         $data = JSON::decode($message->getBody());
 
         if (!isset($data['jobId'])) {

--- a/pkg/job-queue/CalculateRootJobStatusService.php
+++ b/pkg/job-queue/CalculateRootJobStatusService.php
@@ -69,6 +69,7 @@ class CalculateRootJobStatusService
         $success = 0;
 
         foreach ($jobs as $job) {
+            $this->jobStorage->refreshedJobEntity($job);
             switch ($job->getStatus()) {
                 case Job::STATUS_NEW:
                     $new++;

--- a/pkg/job-queue/CalculateRootJobStatusService.php
+++ b/pkg/job-queue/CalculateRootJobStatusService.php
@@ -69,7 +69,7 @@ class CalculateRootJobStatusService
         $success = 0;
 
         foreach ($jobs as $job) {
-            $this->jobStorage->refreshedJobEntity($job);
+            $this->jobStorage->refreshJobEntity($job);
             switch ($job->getStatus()) {
                 case Job::STATUS_NEW:
                     $new++;

--- a/pkg/job-queue/Doctrine/JobStorage.php
+++ b/pkg/job-queue/Doctrine/JobStorage.php
@@ -179,6 +179,11 @@ class JobStorage
         }
     }
 
+    public function clearJobCache()
+    {
+        $this->getEntityManager()->clear($this->entityClass);
+    }
+
     /**
      * @return EntityRepository
      */

--- a/pkg/job-queue/Doctrine/JobStorage.php
+++ b/pkg/job-queue/Doctrine/JobStorage.php
@@ -182,7 +182,7 @@ class JobStorage
     /**
      * @param Job $job
      */
-    public function refreshedJobEntity($job)
+    public function refreshJobEntity($job)
     {
         $this->getEntityManager()->refresh($job);
     }

--- a/pkg/job-queue/Doctrine/JobStorage.php
+++ b/pkg/job-queue/Doctrine/JobStorage.php
@@ -58,13 +58,18 @@ class JobStorage
     {
         $qb = $this->getEntityRepository()->createQueryBuilder('job');
 
-        return $qb
+        $job = $qb
             ->addSelect('rootJob')
             ->leftJoin('job.rootJob', 'rootJob')
             ->where('job = :id')
             ->setParameter('id', $id)
             ->getQuery()->getOneOrNullResult()
         ;
+        if ($job) {
+            $this->refreshJobEntity($job);
+        }
+
+        return $job;
     }
 
     /**

--- a/pkg/job-queue/Doctrine/JobStorage.php
+++ b/pkg/job-queue/Doctrine/JobStorage.php
@@ -179,9 +179,12 @@ class JobStorage
         }
     }
 
-    public function clearJobCache()
+    /**
+     * @param Job $job
+     */
+    public function refreshedJobEntity($job)
     {
-        $this->getEntityManager()->clear($this->entityClass);
+        $this->getEntityManager()->refresh($job);
     }
 
     /**


### PR DESCRIPTION
Before determine Root Job Status Doctrine cache for Job entity must be cleared, otherwise if this root job was processed in previous request by the same enqueue, then it will falsely return old status, which will cause infinite running root jobs