### PR TITLE
#1190 add index on delivery_id to prevent slow queries

### DIFF
--- a/pkg/dbal/DbalContext.php
+++ b/pkg/dbal/DbalContext.php
@@ -238,6 +238,7 @@ class DbalContext implements Context
 
         $table->addIndex(['redeliver_after', 'delivery_id']);
         $table->addIndex(['time_to_live', 'delivery_id']);
+        $table->addIndex(['delivery_id']);
 
         $sm->createTable($table);
     }


### PR DESCRIPTION
Background is a shopware 6.4 installation. We have 3.4 million entries in the mysql table enqueue.

A query like: DELETE FROM enqueue WHERE delivery_id = '1ea18942-283b-4cfd-a24a-1bf9917a9d0f'

takes 20-60 seconds. CPU load is by 100%. So this provides a race condition as the enqueue-table is growing fast and deleting entries is very slow.

Creating directly in mysql an index on delivery_id solves the problem. Queries are again done in milliseconds.