### PR TITLE
Set to Header only Headers

### DIFF
--- a/pkg/amqp-lib/AmqpContext.php
+++ b/pkg/amqp-lib/AmqpContext.php
@@ -299,14 +299,14 @@ class AmqpContext implements InteropAmqpContext, DelayStrategyAware
      */
     public function convertMessage(LibAMQPMessage $amqpMessage): InteropAmqpMessage
     {
-        $headers = new AMQPTable($amqpMessage->get_properties());
-        $headers = $headers->getNativeData();
+        $amqpTable = new AMQPTable($amqpMessage->get_properties());
+        $properties = $amqpTable->getNativeData();
 
-        $properties = [];
-        if (isset($headers['application_headers'])) {
-            $properties = $headers['application_headers'];
+        $headers = [];
+        if (isset($properties['application_headers'])) {
+            $headers = $properties['application_headers'];
         }
-        unset($headers['application_headers']);
+        unset($properties['application_headers']);
 
         $message = new AmqpMessage($amqpMessage->getBody(), $properties, $headers);
         $message->setDeliveryTag((int) $amqpMessage->delivery_info['delivery_tag']);


### PR DESCRIPTION
I`m setting headers and properties

<img width="709" alt="Снимок экрана 2021-10-25 в 17 13 04" src="https://user-images.githubusercontent.com/4567634/138723153-161d1d3c-7518-48b1-b482-e8a28694c3ed.png">

If i use function ```$message->getHeaders()``` i get properties instead and if use ```$message->getProperties()``` i get headers!!!

This PR fixing it

**Before fix**
```json
{"headers":{"delivery_mode":1,"user_id":"guest"}}
```

**After fix**
```json
{"headers":{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01","z-traceparent":"dsjdhsjdhsjds"}}
```

