### PR TITLE
Allow ext-rdkafka 6 usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "ext-amqp": "^1.9.3",
     "ext-gearman": "^2.0",
     "ext-mongodb": "^1.5",
-    "ext-rdkafka": "^4.0|^5.0",
+    "ext-rdkafka": "^4.0|^5.0|^6.0",
 
     "queue-interop/amqp-interop": "^0.8.2",
     "queue-interop/queue-interop": "^0.8.1",


### PR DESCRIPTION
`ext-rdkafka` v6.0 is available.

Allow its usage in this library.

According to the [release note](https://github.com/arnaud-lb/php-rdkafka/releases/tag/6.0.0), there's no BC breaks.