### PR TITLE
Fix CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "influxdb/influxdb-php": "^1.14",
     "datadog/php-datadogstatsd": "^1.3",
     "guzzlehttp/guzzle": "^7.0.1",
+    "guzzlehttp/psr7": "^1.0",
     "php-http/discovery": "^1.13",
     "voryx/thruway-common": "^1.0.1",
     "react/dns": "^1.4",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,9 @@ RUN set -x && \
         php${PHP_VERSION}-curl \
         make \
         g++ \
-        unzip
+        unzip \
+    && \
+    update-alternatives --install /usr/bin/php php /usr/bin/php${PHP_VERSION} 100
 
 ## gearman
 RUN set -x && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,13 +22,20 @@ RUN set -x && \
         php${PHP_VERSION}-xml \
         php${PHP_VERSION}-mysql \
         php${PHP_VERSION}-curl \
-        libgearman-dev \
-        php-pear \
         make \
-        unzip \
+        g++ \
+        unzip
+
+## gearman
+RUN set -x && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        libgearman-dev \
     && \
-    pecl channel-update pecl.php.net && \
-    pecl install gearman && \
+    mkdir -p $HOME/gearman && \
+    cd $HOME/gearman && \
+    git clone https://github.com/php/pecl-networking-gearman.git . && \
+    git checkout gearman-2.1.0 && \
+    phpize && ./configure && make && make install && \
     if [ ! -f /etc/php/${PHP_VERSION}/cli/conf.d/20-gearman.ini ]; then \
         echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/cli/conf.d/20-gearman.ini && \
         echo "extension=gearman.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/20-gearman.ini \
@@ -37,16 +44,19 @@ RUN set -x && \
 
 ## librdkafka
 RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests \
-        g++ \
-    && \
     mkdir -p $HOME/librdkafka && \
     cd $HOME/librdkafka && \
     git clone https://github.com/edenhill/librdkafka.git . && \
     git checkout v1.0.0 && \
-    ./configure && make && make install && \
-    pecl install rdkafka && \
+    ./configure && make && make install
+
+## php-rdkafka
+RUN set -x && \
+    mkdir -p $HOME/php-rdkafka && \
+    cd $HOME/php-rdkafka && \
+    git clone https://github.com/arnaud-lb/php-rdkafka.git . && \
+    git checkout 5.0.1 && \
+    phpize && ./configure && make all && make install && \
     echo "extension=rdkafka.so" > /etc/php/${PHP_VERSION}/cli/conf.d/10-rdkafka.ini && \
     echo "extension=rdkafka.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/10-rdkafka.ini
 

--- a/docker/thruway/Dockerfile
+++ b/docker/thruway/Dockerfile
@@ -1,4 +1,4 @@
-FROM makasim/nginx-php-fpm:latest-all-exts
+FROM makasim/nginx-php-fpm:7.4-all-exts
 
 RUN mkdir -p /thruway
 WORKDIR /thruway


### PR DESCRIPTION
The CI is red and this PR fix it.

There's 3 problems:
* Thruway docker image (`docker/thruway/Dockerfile`) use `voryx/thruway` which also uses `thruway/client` which is not currently compatible with PHP 8.0. So before the library is compatible, I've fixed the PHP version to 7.4 for this container.
* `docker/Dockerfile` image is executed with PHP 7.4 & 8.0 and use `PEAR` to install some extensions. As `PR` is not fully compatible with PHP 8.0, required dependencies are compiled.
* `enqueue` libraries depends on `thruway/pawl-transport` which depend on `ratchet/pawl` (`^0.3.1`). The 0.3.x version doesn't support `guzzlehttp/psr7` 2.x branch. So we needs to restrict `guzzlehttp/psr7` to `1.x` branch