### PR TITLE
Replace rabbitmq-management-api with a packagist source and fixed small github actions typo

### DIFF
--- a/pkg/stomp/.github/workflows/ci.yml
+++ b/pkg/stomp/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           composer-options: "--prefer-source"
 
-      - run: vendor/bin/phpunit --exlude-group=functional
+      - run: vendor/bin/phpunit --exclude-group=functional

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -5,12 +5,6 @@
     "keywords": ["messaging", "queue", "stomp"],
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/andrewmy/php-rabbitmq-management-api.git"
-        }
-    ],
     "require": {
         "php": "^7.3|^8.0",
         "enqueue/dsn": "^0.10",
@@ -18,7 +12,7 @@
         "queue-interop/queue-interop": "^0.8",
         "php-http/guzzle7-adapter": "^0.1.1",
         "php-http/client-common": "^2.2.1",
-        "richardfullmer/rabbitmq-management-api": "^2.1.1",
+        "andrewmy/rabbitmq-management-api": "^2.1.2",
         "guzzlehttp/guzzle": "^7.0.1",
         "php-http/discovery": "^1.13"
     },


### PR DESCRIPTION
Basically this just does what @andrewmy has already done in this PR for the stomp package, details here: https://github.com/php-enqueue/enqueue-dev/pull/1238/commits/d1a2239b58286ca83ab0ca90f407fa9123ce9266

This is done for all the same reasons to "_make builds quicker, race-condition free, and avoid the weirdness of using a source repo in a widely used package._"

Also fixed small typo that would prevent github actions from working if that is ever needed in future.