### PR TITLE
Use onPostConsume Hook for Calculating Messages Consumed

### DIFF
--- a/pkg/enqueue/Consumption/Extension/LimitConsumedMessagesExtension.php
+++ b/pkg/enqueue/Consumption/Extension/LimitConsumedMessagesExtension.php
@@ -2,13 +2,13 @@
 
 namespace Enqueue\Consumption\Extension;
 
-use Enqueue\Consumption\Context\PostMessageReceived;
+use Enqueue\Consumption\Context\PostConsume;
 use Enqueue\Consumption\Context\PreConsume;
-use Enqueue\Consumption\PostMessageReceivedExtensionInterface;
+use Enqueue\Consumption\PostConsumeExtensionInterface;
 use Enqueue\Consumption\PreConsumeExtensionInterface;
 use Psr\Log\LoggerInterface;
 
-class LimitConsumedMessagesExtension implements PreConsumeExtensionInterface, PostMessageReceivedExtensionInterface
+class LimitConsumedMessagesExtension implements PreConsumeExtensionInterface, PostConsumeExtensionInterface
 {
     /**
      * @var int
@@ -18,7 +18,7 @@ class LimitConsumedMessagesExtension implements PreConsumeExtensionInterface, Po
     /**
      * @var int
      */
-    protected $messageConsumed;
+    protected $messageConsumed = 0;
 
     /**
      * @param int $messageLimit
@@ -26,7 +26,6 @@ class LimitConsumedMessagesExtension implements PreConsumeExtensionInterface, Po
     public function __construct(int $messageLimit)
     {
         $this->messageLimit = $messageLimit;
-        $this->messageConsumed = 0;
     }
 
     public function onPreConsume(PreConsume $context): void
@@ -37,7 +36,7 @@ class LimitConsumedMessagesExtension implements PreConsumeExtensionInterface, Po
         }
     }
 
-    public function onPostMessageReceived(PostMessageReceived $context): void
+    public function onPostConsume(PostConsume $context): void
     {
         ++$this->messageConsumed;
 


### PR DESCRIPTION
Fixes issue where no messages are consumed if value is set to 1. The first messages will be received and processing will stop.