### PR TITLE
[Redis] Support `unix` in `scheme_extensions`

### DIFF
--- a/pkg/redis/PhpRedis.php
+++ b/pkg/redis/PhpRedis.php
@@ -106,11 +106,12 @@ class PhpRedis implements Redis
         $this->redis = new \Redis();
 
         $connectionMethod = $this->config['persistent'] ? 'pconnect' : 'connect';
+        $unix = 'unix' === $this->config['scheme'] || in_array('unix', (array) $this->config['scheme_extensions'], true);
 
         $result = call_user_func(
             [$this->redis, $connectionMethod],
-            'unix' === $this->config['scheme'] ? $this->config['path'] : $this->config['host'],
-            $this->config['port'],
+            $unix ? $this->config['path'] : $this->config['host'],
+            $unix ? null : $this->config['port'],
             $this->config['timeout'],
             $this->config['persistent'] ? ($this->config['phpredis_persistent_id'] ?? null) : null,
             $this->config['phpredis_retry_interval'] ?? null,


### PR DESCRIPTION
Support `unix` in `scheme_extensions`.
When use `SimpleClient` with dsn `redis+phpredis+unix:/home/.socket/redis.sock` `PhpRedis` connection by `host` because `scheme` is `redis`. Fix it.