### PR TITLE
non-static QueueSubscriberInterface::getSubscribedQueues()

### DIFF
--- a/pkg/enqueue/Consumption/QueueSubscriberInterface.php
+++ b/pkg/enqueue/Consumption/QueueSubscriberInterface.php
@@ -10,5 +10,5 @@ interface QueueSubscriberInterface
      *
      * @return string[]
      */
-    public static function getSubscribedQueues();
+    public function getSubscribedQueues();
 }


### PR DESCRIPTION
I propose to make this accessor non-static to allow developers build more sophisticated mechanism of subscription. For example I have code:
```php
abstract class AbstractConsumer implements Processor, QueueSubscriberInterface
{
  // ....
  // ....
    public function process(Message $message, Context $context)
    {
        $event = $this->serializer->deserialize($message->getBody(), $this->eventModel(), $this->format());
        try {
            $this->doProcessEvent($event);
        } catch (OperationNotSupportedException $e) {
            return self::REJECT;
        } catch (OperationFailedException $e) {
            return self::REQUEUE;
        }

        return self::ACK;
    }

    abstract protected function eventModel(): string;

    abstract protected function doProcessEvent(EventInterface $event): void;

    // FYI getSubscribedQueues() is implemented by child classes
}
```
where `getSubscribedQueues()` is implemented by child classes.
In my project I want to introduce `EventProcessorInterface`, which can process events data mapped to `eventModel()` considering `getSubscribedEvents(): string[]`. But I cannot INJECT `EventProcessorInterface` to `AbstractConsumer` and delegate `QueueSubscriberInterface::getSubscribedQueues()` to `EventProcessorInterface::getSubscribedEvents()` because it is static method!