### PR TITLE
refactor(namespaces): renamed \Null to \NullTransport for future comp…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
       "Enqueue\\Gps\\": "pkg/gps/",
       "Enqueue\\JobQueue\\": "pkg/job-queue/",
       "Enqueue\\Mongodb\\": "pkg/mongodb/",
-      "Enqueue\\Null\\": "pkg/null/",
+      "Enqueue\\NullTransporter\\": "pkg/null/",
       "Enqueue\\Pheanstalk\\": "pkg/pheanstalk/",
       "Enqueue\\RdKafka\\": "pkg/rdkafka/",
       "Enqueue\\Redis\\": "pkg/redis/",

--- a/pkg/null/NullConnectionFactory.php
+++ b/pkg/null/NullConnectionFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\ConnectionFactory;
 use Interop\Queue\Context;

--- a/pkg/null/NullConsumer.php
+++ b/pkg/null/NullConsumer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\Consumer;
 use Interop\Queue\Destination;

--- a/pkg/null/NullContext.php
+++ b/pkg/null/NullContext.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\Consumer;
 use Interop\Queue\Context;

--- a/pkg/null/NullMessage.php
+++ b/pkg/null/NullMessage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\Message;
 

--- a/pkg/null/NullProducer.php
+++ b/pkg/null/NullProducer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\Destination;
 use Interop\Queue\Message;

--- a/pkg/null/NullQueue.php
+++ b/pkg/null/NullQueue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\Queue;
 

--- a/pkg/null/NullSubscriptionConsumer.php
+++ b/pkg/null/NullSubscriptionConsumer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\Consumer;
 use Interop\Queue\SubscriptionConsumer;

--- a/pkg/null/NullTopic.php
+++ b/pkg/null/NullTopic.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransporter;
 
 use Interop\Queue\Topic;
 

--- a/pkg/null/Tests/NullConnectionFactoryTest.php
+++ b/pkg/null/Tests/NullConnectionFactoryTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransporter\Tests;
 
-use Enqueue\Null\NullConnectionFactory;
-use Enqueue\Null\NullContext;
+use Enqueue\NullTransporter\NullConnectionFactory;
+use Enqueue\NullTransporter\NullContext;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;

--- a/pkg/null/Tests/NullConsumerTest.php
+++ b/pkg/null/Tests/NullConsumerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransporter\Tests;
 
-use Enqueue\Null\NullConsumer;
-use Enqueue\Null\NullMessage;
-use Enqueue\Null\NullQueue;
+use Enqueue\NullTransporter\NullConsumer;
+use Enqueue\NullTransporter\NullMessage;
+use Enqueue\NullTransporter\NullQueue;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Consumer;
 use PHPUnit\Framework\TestCase;

--- a/pkg/null/Tests/NullContextTest.php
+++ b/pkg/null/Tests/NullContextTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransporter\Tests;
 
-use Enqueue\Null\NullConsumer;
-use Enqueue\Null\NullContext;
-use Enqueue\Null\NullMessage;
-use Enqueue\Null\NullProducer;
-use Enqueue\Null\NullQueue;
-use Enqueue\Null\NullTopic;
+use Enqueue\NullTransporter\NullConsumer;
+use Enqueue\NullTransporter\NullContext;
+use Enqueue\NullTransporter\NullMessage;
+use Enqueue\NullTransporter\NullProducer;
+use Enqueue\NullTransporter\NullQueue;
+use Enqueue\NullTransporter\NullTopic;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Context;
 use PHPUnit\Framework\TestCase;

--- a/pkg/null/Tests/NullMessageTest.php
+++ b/pkg/null/Tests/NullMessageTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransporter\Tests;
 
-use Enqueue\Null\NullMessage;
+use Enqueue\NullTransporter\NullMessage;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Message;
 use PHPUnit\Framework\TestCase;

--- a/pkg/null/Tests/NullProducerTest.php
+++ b/pkg/null/Tests/NullProducerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransporter\Tests;
 
-use Enqueue\Null\NullMessage;
-use Enqueue\Null\NullProducer;
-use Enqueue\Null\NullTopic;
+use Enqueue\NullTransporter\NullMessage;
+use Enqueue\NullTransporter\NullProducer;
+use Enqueue\NullTransporter\NullTopic;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Producer;
 use PHPUnit\Framework\TestCase;

--- a/pkg/null/Tests/NullQueueTest.php
+++ b/pkg/null/Tests/NullQueueTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransporter\Tests;
 
-use Enqueue\Null\NullQueue;
+use Enqueue\NullTransporter\NullQueue;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Queue;
 use PHPUnit\Framework\TestCase;

--- a/pkg/null/Tests/NullTopicTest.php
+++ b/pkg/null/Tests/NullTopicTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransporter\Tests;
 
-use Enqueue\Null\NullTopic;
+use Enqueue\NullTransporter\NullTopic;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Topic;
 use PHPUnit\Framework\TestCase;

--- a/pkg/null/Tests/Spec/NullMessageTest.php
+++ b/pkg/null/Tests/Spec/NullMessageTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests\Spec;
+namespace Enqueue\NullTransporter\Tests\Spec;
 
-use Enqueue\Null\NullMessage;
+use Enqueue\NullTransporter\NullMessage;
 use Interop\Queue\Spec\MessageSpec;
 
 class NullMessageTest extends MessageSpec

--- a/pkg/null/composer.json
+++ b/pkg/null/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md"
     },
     "autoload": {
-        "psr-4": { "Enqueue\\Null\\": "" },
+        "psr-4": { "Enqueue\\NullTransporter\\": "" },
         "exclude-from-classmap": [
             "/Tests/"
         ]


### PR DESCRIPTION
…atibility with new PHP versions

'null' is a reserved keyword as of PHP version 7.0 and should not be used to name a class, interface or trait or as part of a namespace (T_NAMESPACE)