### PR TITLE
Ensure pass consumer tag as string to bunny amqp

### DIFF
--- a/pkg/amqp-bunny/AmqpSubscriptionConsumer.php
+++ b/pkg/amqp-bunny/AmqpSubscriptionConsumer.php
@@ -88,7 +88,7 @@ class AmqpSubscriptionConsumer implements InteropAmqpSubscriptionConsumer
         $frame = $this->context->getBunnyChannel()->consume(
             $bunnyCallback,
             $consumer->getQueue()->getQueueName(),
-            $consumer->getConsumerTag(),
+            $consumer->getConsumerTag() ?? '',
             (bool) ($consumer->getFlags() & InteropAmqpConsumer::FLAG_NOLOCAL),
             (bool) ($consumer->getFlags() & InteropAmqpConsumer::FLAG_NOACK),
             (bool) ($consumer->getFlags() & InteropAmqpConsumer::FLAG_EXCLUSIVE),


### PR DESCRIPTION
Fixes 8.1 compatibility

```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/vendor/bunny/bunny/src/Bunny/ClientMethods.php on line 1638
```