### PR TITLE
Symfony config allow null

### DIFF
--- a/pkg/enqueue/Symfony/DependencyInjection/TransportFactory.php
+++ b/pkg/enqueue/Symfony/DependencyInjection/TransportFactory.php
@@ -132,15 +132,15 @@ final class TransportFactory
         $container->register($factoryFactoryId, $config['factory_class'] ?? ConnectionFactoryFactory::class);
 
         $factoryFactoryService = new Reference(
-            array_key_exists('factory_service', $config) ? $config['factory_service'] : $factoryFactoryId
+            $config['factory_service'] ?? $factoryFactoryId
         );
 
         unset($config['factory_service'], $config['factory_class']);
 
-        if (array_key_exists('connection_factory_class', $config)) {
-            $connectionFactoryClass = $config['connection_factory_class'];
-            unset($config['connection_factory_class']);
+        $connectionFactoryClass = $config['connection_factory_class'] ?? null;
+        unset($config['connection_factory_class']);
 
+        if (isset($connectionFactoryClass)) {
             $container->register($factoryId, $connectionFactoryClass)
                 ->addArgument($config)
             ;

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
@@ -279,11 +279,6 @@ class TransportFactoryTest extends TestCase
             [['dsn' => 'foo://bar/baz']],
             $container->getDefinition('enqueue.transport.default.connection_factory')->getArguments())
         ;
-
-        $this->assertEquals(
-            [new Reference('enqueue.transport.default.connection_factory_factory'), 'create'],
-            $container->getDefinition('enqueue.transport.default.connection_factory')->getFactory())
-        ;
     }
 
     public function testShouldBuildConnectionFactoryUsingCustomFactoryClass()

--- a/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
+++ b/pkg/enqueue/Tests/Symfony/DependencyInjection/TransportFactoryTest.php
@@ -259,7 +259,14 @@ class TransportFactoryTest extends TestCase
 
         $transport = new TransportFactory('default');
 
-        $transport->buildConnectionFactory($container, ['dsn' => 'foo://bar/baz']);
+        $config = [
+            'dsn' => 'foo://bar/baz',
+            'connection_factory_class' => null,
+            'factory_service' => null,
+            'factory_class' => null,
+        ];
+
+        $transport->buildConnectionFactory($container, $config);
 
         $this->assertTrue($container->hasDefinition('enqueue.transport.default.connection_factory'));
 
@@ -271,6 +278,11 @@ class TransportFactoryTest extends TestCase
         $this->assertSame(
             [['dsn' => 'foo://bar/baz']],
             $container->getDefinition('enqueue.transport.default.connection_factory')->getArguments())
+        ;
+
+        $this->assertEquals(
+            [new Reference('enqueue.transport.default.connection_factory_factory'), 'create'],
+            $container->getDefinition('enqueue.transport.default.connection_factory')->getFactory())
         ;
     }
 


### PR DESCRIPTION
The symfony [config reference](https://github.com/php-enqueue/enqueue-dev/blob/0b7bd9cfbc484cf3625a01baa5b3f5c711a11826/docs/bundle/config_reference.md) states as default

```yaml
transport:
    connection_factory_class: ~
    factory_service: ~
```
where ~ is null, but setting these values to null, throws an error, as the actual TransportFactory uses array_key_exists() which doesn't care if the value is null or not and in case sets e.g. the FactoryService to null which isn't supported

This change makes use of isset() and the Null Coalescing Operator which does also look up if the value is null