### PR TITLE
feat: allow rdkafka key to be set through properties

### DIFF
--- a/pkg/rdkafka/RdKafkaContext.php
+++ b/pkg/rdkafka/RdKafkaContext.php
@@ -63,7 +63,9 @@ class RdKafkaContext implements Context
      */
     public function createMessage(string $body = '', array $properties = [], array $headers = []): Message
     {
-        return new RdKafkaMessage($body, $properties, $headers);
+        $message = new RdKafkaMessage($body, $properties, $headers);
+        $message->setKey($properties['key'] ?? null);
+        return $message;
     }
 
     /**


### PR DESCRIPTION
Allow serialized envelopes having `properties.key` to be able to use the rdkafka key using https://github.com/sroze/messenger-enqueue-transport