### PR TITLE
fix: parenthesis missing allowed invalid delays

### DIFF
--- a/pkg/sqs/SqsProducer.php
+++ b/pkg/sqs/SqsProducer.php
@@ -56,7 +56,7 @@ class SqsProducer implements Producer
         ];
 
         if (null !== $this->deliveryDelay) {
-            $arguments['DelaySeconds'] = (int) ($this->deliveryDelay / 1000);
+            $arguments['DelaySeconds'] = (int) ceil($this->deliveryDelay / 1000);
         }
 
         if ($message->getDelaySeconds()) {

--- a/pkg/sqs/SqsProducer.php
+++ b/pkg/sqs/SqsProducer.php
@@ -56,7 +56,7 @@ class SqsProducer implements Producer
         ];
 
         if (null !== $this->deliveryDelay) {
-            $arguments['DelaySeconds'] = (int) $this->deliveryDelay / 1000;
+            $arguments['DelaySeconds'] = (int) ($this->deliveryDelay / 1000);
         }
 
         if ($message->getDelaySeconds()) {


### PR DESCRIPTION
Missing parenthesis here would allow the delay to be a fraction of a second and cause an error if the delay provided was not a multiple of 1000.