### PR TITLE
[amqp-lib] Replace amqp-lib deprecated public property with getters

### DIFF
--- a/pkg/amqp-lib/AmqpContext.php
+++ b/pkg/amqp-lib/AmqpContext.php
@@ -309,9 +309,9 @@ class AmqpContext implements InteropAmqpContext, DelayStrategyAware
         unset($headers['application_headers']);
 
         $message = new AmqpMessage($amqpMessage->getBody(), $properties, $headers);
-        $message->setDeliveryTag((int) $amqpMessage->delivery_info['delivery_tag']);
-        $message->setRedelivered($amqpMessage->delivery_info['redelivered']);
-        $message->setRoutingKey($amqpMessage->delivery_info['routing_key']);
+        $message->setDeliveryTag((int) $amqpMessage->getDeliveryTag());
+        $message->setRedelivered($amqpMessage->isRedelivered());
+        $message->setRoutingKey($amqpMessage->getRoutingKey());
 
         return $message;
     }

--- a/pkg/amqp-lib/AmqpSubscriptionConsumer.php
+++ b/pkg/amqp-lib/AmqpSubscriptionConsumer.php
@@ -102,13 +102,13 @@ class AmqpSubscriptionConsumer implements InteropAmqpSubscriptionConsumer
 
         $libCallback = function (LibAMQPMessage $message) {
             $receivedMessage = $this->context->convertMessage($message);
-            $receivedMessage->setConsumerTag($message->delivery_info['consumer_tag']);
+            $receivedMessage->setConsumerTag($message->getConsumerTag());
 
             /**
              * @var AmqpConsumer
              * @var callable     $callback
              */
-            list($consumer, $callback) = $this->subscribers[$message->delivery_info['consumer_tag']];
+            list($consumer, $callback) = $this->subscribers[$message->getConsumerTag()];
 
             if (false === call_user_func($callback, $receivedMessage, $consumer)) {
                 throw new StopBasicConsumptionException();

--- a/pkg/amqp-lib/Tests/AmqpConsumerTest.php
+++ b/pkg/amqp-lib/Tests/AmqpConsumerTest.php
@@ -115,10 +115,7 @@ class AmqpConsumerTest extends TestCase
     public function testShouldReturnMessageOnReceiveNoWait()
     {
         $libMessage = new \PhpAmqpLib\Message\AMQPMessage('body');
-        $libMessage->delivery_info['delivery_tag'] = 'delivery-tag';
-        $libMessage->delivery_info['routing_key'] = 'routing-key';
-        $libMessage->delivery_info['redelivered'] = true;
-        $libMessage->delivery_info['routing_key'] = 'routing-key';
+        $libMessage->setDeliveryInfo('delivery-tag', true, '', 'routing-key');
 
         $message = new AmqpMessage();
 
@@ -152,9 +149,7 @@ class AmqpConsumerTest extends TestCase
     public function testShouldReturnMessageOnReceiveWithReceiveMethodBasicGet()
     {
         $libMessage = new \PhpAmqpLib\Message\AMQPMessage('body');
-        $libMessage->delivery_info['delivery_tag'] = 'delivery-tag';
-        $libMessage->delivery_info['routing_key'] = 'routing-key';
-        $libMessage->delivery_info['redelivered'] = true;
+        $libMessage->setDeliveryInfo('delivery-tag', true, '', 'routing-key');
 
         $message = new AmqpMessage();
 

--- a/pkg/amqp-lib/composer.json
+++ b/pkg/amqp-lib/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
-        "php-amqplib/php-amqplib": "^3.0",
+        "php-amqplib/php-amqplib": "^3.2",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/amqp-tools": "^0.10"


### PR DESCRIPTION
Also, require more recent php-amqplib version.