### PR TITLE
MongoDB - Add combined index

### DIFF
--- a/pkg/mongodb/MongodbContext.php
+++ b/pkg/mongodb/MongodbContext.php
@@ -161,5 +161,6 @@ class MongodbContext implements Context
         $collection->createIndex(['queue' => 1], ['name' => 'enqueue_queue']);
         $collection->createIndex(['priority' => -1, 'published_at' => 1], ['name' => 'enqueue_priority']);
         $collection->createIndex(['delayed_until' => 1], ['name' => 'enqueue_delayed']);
+        $collection->createIndex(['queue' => 1, 'priority' => -1, 'published_at' => 1, 'delayed_until' => 1], ['name' => 'enqueue_combined']);
     }
 }


### PR DESCRIPTION
Hey there 👋

In Printify we are utilizing this library quite heavily.

Recently we had an incident with the super high CPU and I/O usage in MongoDB.

With multiple queues and thousands of messages per queue, MongoDB is doing a full collection scan.

The combined index solves that.