### PR TITLE
Fix AWS SDK token parameter

### DIFF
--- a/pkg/sns/Tests/SnsClientTest.php
+++ b/pkg/sns/Tests/SnsClientTest.php
@@ -16,7 +16,6 @@ class SnsClientTest extends TestCase
         $awsClient = (new Sdk(['Sns' => [
             'key' => '',
             'secret' => '',
-            'token' => false,
             'region' => '',
             'version' => '2010-03-31',
             'endpoint' => 'http://localhost',
@@ -32,7 +31,6 @@ class SnsClientTest extends TestCase
         $awsClient = (new Sdk(['Sns' => [
             'key' => '',
             'secret' => '',
-            'token' => false,
             'region' => '',
             'version' => '2010-03-31',
             'endpoint' => 'http://localhost',

--- a/pkg/sns/Tests/SnsClientTest.php
+++ b/pkg/sns/Tests/SnsClientTest.php
@@ -16,7 +16,7 @@ class SnsClientTest extends TestCase
         $awsClient = (new Sdk(['Sns' => [
             'key' => '',
             'secret' => '',
-            'token' => '',
+            'token' => false,
             'region' => '',
             'version' => '2010-03-31',
             'endpoint' => 'http://localhost',
@@ -32,7 +32,7 @@ class SnsClientTest extends TestCase
         $awsClient = (new Sdk(['Sns' => [
             'key' => '',
             'secret' => '',
-            'token' => '',
+            'token' => false,
             'region' => '',
             'version' => '2010-03-31',
             'endpoint' => 'http://localhost',

--- a/pkg/sqs/Tests/SqsClientTest.php
+++ b/pkg/sqs/Tests/SqsClientTest.php
@@ -16,7 +16,6 @@ class SqsClientTest extends TestCase
         $awsClient = (new Sdk(['Sqs' => [
             'key' => '',
             'secret' => '',
-            'token' => false,
             'region' => '',
             'version' => '2012-11-05',
             'endpoint' => 'http://localhost',
@@ -32,7 +31,6 @@ class SqsClientTest extends TestCase
         $awsClient = (new Sdk(['Sqs' => [
             'key' => '',
             'secret' => '',
-            'token' => false,
             'region' => '',
             'version' => '2012-11-05',
             'endpoint' => 'http://localhost',

--- a/pkg/sqs/Tests/SqsClientTest.php
+++ b/pkg/sqs/Tests/SqsClientTest.php
@@ -16,7 +16,7 @@ class SqsClientTest extends TestCase
         $awsClient = (new Sdk(['Sqs' => [
             'key' => '',
             'secret' => '',
-            'token' => '',
+            'token' => false,
             'region' => '',
             'version' => '2012-11-05',
             'endpoint' => 'http://localhost',
@@ -32,7 +32,7 @@ class SqsClientTest extends TestCase
         $awsClient = (new Sdk(['Sqs' => [
             'key' => '',
             'secret' => '',
-            'token' => '',
+            'token' => false,
             'region' => '',
             'version' => '2012-11-05',
             'endpoint' => 'http://localhost',


### PR DESCRIPTION
It looks like in recent versions the AWS SDK started enforcing parameter types, breaking our CI.

> `InvalidArgumentException: Invalid configuration value provided for "token". Expected Aws\Token\TokenInterface|Aws\CacheInterface|array|bool|callable, but got string(0) ""`

When passing `false`, it still breaks:
> `InvalidArgumentException: Token must be an instance of Aws\Token\TokenInterface, an associative array that contains "token" and an optional "expires" key-value pairs, a token provider function, or false.`

So let's just skip it in tests.
