### PR TITLE
Add support for rediss and phpredis

### DIFF
--- a/pkg/redis/PhpRedis.php
+++ b/pkg/redis/PhpRedis.php
@@ -94,7 +94,7 @@ class PhpRedis implements Redis
             return;
         }
 
-        $supportedSchemes = ['redis', 'tcp', 'unix'];
+        $supportedSchemes = ['redis', 'rediss', 'tcp', 'unix'];
         if (false == in_array($this->config['scheme'], $supportedSchemes, true)) {
             throw new \LogicException(sprintf(
                 'The given scheme protocol "%s" is not supported by php extension. It must be one of "%s"',
@@ -107,9 +107,11 @@ class PhpRedis implements Redis
 
         $connectionMethod = $this->config['persistent'] ? 'pconnect' : 'connect';
 
+        $host = $this->config['scheme'] === 'rediss' ? 'tls://' . $this->config['host'] : $this->config['host'];
+
         $result = call_user_func(
             [$this->redis, $connectionMethod],
-            'unix' === $this->config['scheme'] ? $this->config['path'] : $this->config['host'],
+            'unix' === $this->config['scheme'] ? $this->config['path'] : $host,
             $this->config['port'],
             $this->config['timeout'],
             $this->config['persistent'] ? ($this->config['phpredis_persistent_id'] ?? null) : null,

--- a/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
+++ b/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
@@ -51,15 +51,6 @@ class RedisConnectionFactoryConfigTest extends TestCase
         $this->assertSame($redisMock, $context->getRedis());
     }
 
-    public function testThrowIfRedissConnectionUsedWithPhpRedisExtension()
-    {
-        $factory = new RedisConnectionFactory('rediss+phpredis:?lazy=0');
-
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The given scheme protocol "rediss" is not supported by php extension. It must be one of "redis", "tcp", "unix"');
-        $factory->createContext();
-    }
-
     /**
      * @dataProvider provideConfigs
      *
@@ -261,6 +252,29 @@ class RedisConnectionFactoryConfigTest extends TestCase
                 'database' => null,
                 'password' => null,
                 'scheme_extensions' => ['predis'],
+                'path' => null,
+                'async' => true,
+                'persistent' => false,
+                'lazy' => true,
+                'read_write_timeout' => null,
+                'predis_options' => null,
+                'ssl' => null,
+                'foo' => 'bar',
+                'redelivery_delay' => 300,
+            ],
+        ];
+
+        //check tls connection for predis library
+        yield [
+            'rediss+phpredis://localhost:1234?foo=bar&async=1',
+            [
+                'host' => 'tls://localhost',
+                'scheme' => 'rediss',
+                'port' => 1234,
+                'timeout' => 5.,
+                'database' => null,
+                'password' => null,
+                'scheme_extensions' => ['phpredis'],
                 'path' => null,
                 'async' => true,
                 'persistent' => false,


### PR DESCRIPTION
Since v5 PHPRedis supports providing a host scheme, so you can configure it to use tls