### PR TITLE
Allow doctrine/persistence 3.1 version

### DIFF
--- a/pkg/dbal/composer.json
+++ b/pkg/dbal/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.4|^8.0",
         "queue-interop/queue-interop": "^0.8",
         "doctrine/dbal": "^2.12|^3.1",
-        "doctrine/persistence": "^2.0",
+        "doctrine/persistence": "^2.0|^3.1",
         "ramsey/uuid": "^3.5|^4"
     },
     "require-dev": {


### PR DESCRIPTION
Currently on Symfony 6.2 there is an issue related to the doctrine/persistence. Symfony recommends to use the doctrine/persistence in the latest version 3.1 to use of lazy ghost objects.

It's also related to the ecotone that is using enqueue: https://github.com/ecotoneframework/ecotone-dev/issues/111

@makasim 