### PR TITLE
fix: do not reset attemps header when message is requeue

### DIFF
--- a/pkg/redis/RedisConsumer.php
+++ b/pkg/redis/RedisConsumer.php
@@ -42,9 +42,6 @@ class RedisConsumer implements Consumer
         return $this->redeliveryDelay;
     }
 
-    /**
-     * @param int $delay
-     */
     public function setRedeliveryDelay(int $delay): void
     {
         $this->redeliveryDelay = $delay;
@@ -103,7 +100,7 @@ class RedisConsumer implements Consumer
 
         if ($requeue) {
             $message = $this->getContext()->getSerializer()->toMessage($message->getReservedKey());
-            $message->setHeader('attempts', 0);
+            $message->setRedelivered(true);
 
             if ($message->getTimeToLive()) {
                 $message->setHeader('expires_at', time() + $message->getTimeToLive());

--- a/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
+++ b/pkg/redis/Tests/RedisConnectionFactoryConfigTest.php
@@ -195,7 +195,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
             ],
         ];
 
-        //check normal redis connection for php redis extension
+        // check normal redis connection for php redis extension
         yield [
             'redis+phpredis://localhost:1234?foo=bar',
             [
@@ -218,7 +218,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
             ],
         ];
 
-        //check normal redis connection for predis library
+        // check normal redis connection for predis library
         yield [
             'redis+predis://localhost:1234?foo=bar',
             [
@@ -241,7 +241,7 @@ class RedisConnectionFactoryConfigTest extends TestCase
             ],
         ];
 
-        //check tls connection for predis library
+        // check tls connection for predis library
         yield [
             'rediss+predis://localhost:1234?foo=bar&async=1',
             [
@@ -264,11 +264,11 @@ class RedisConnectionFactoryConfigTest extends TestCase
             ],
         ];
 
-        //check tls connection for predis library
+        // check tls connection for predis library
         yield [
             'rediss+phpredis://localhost:1234?foo=bar&async=1',
             [
-                'host' => 'tls://localhost',
+                'host' => 'localhost',
                 'scheme' => 'rediss',
                 'port' => 1234,
                 'timeout' => 5.,
@@ -376,7 +376,6 @@ class RedisConnectionFactoryConfigTest extends TestCase
         ];
 
         // from predis doc
-
         yield [
             'tls://127.0.0.1?ssl[cafile]=private.pem&ssl[verify_peer]=1',
             [

--- a/pkg/redis/Tests/RedisConsumerTest.php
+++ b/pkg/redis/Tests/RedisConsumerTest.php
@@ -112,6 +112,7 @@ class RedisConsumerTest extends \PHPUnit\Framework\TestCase
 
         $message = new RedisMessage();
         $message->setBody('text');
+        $message->setHeader('attempts', 0);
         $message->setReservedKey($serializer->toString($message));
 
         $consumer = new RedisConsumer($contextMock, new RedisDestination('aQueue'));


### PR DESCRIPTION
This change will allow to use `$message->getAttempts()` when `true === $message->isRedelivered()` to find how many times this message has been requeue/redelivered. Such information is useful to decide if the message should be `requeue` to retry again later or `rejected` to be completely removed from the queue in case of error.

Something similar was asked on https://github.com/php-enqueue/enqueue-dev/issues/940 but the suggestion on https://github.com/php-enqueue/enqueue-dev/issues/940#issuecomment-1017173629 is about adding another header with a similar purpose than `attempts`. 

On `\Enqueue\Redis\RedisConsumerHelperTrait::processResult()` we already increment `attempts` header, so if we don't reset it when the message is requeue we will have the accurate information about how many times the message has been consumed.
  