### PR TITLE
[ENQUEUE] Add missing throws tag to interfaces

### DIFF
--- a/pkg/enqueue/Client/PreSendCommandExtensionInterface.php
+++ b/pkg/enqueue/Client/PreSendCommandExtensionInterface.php
@@ -4,5 +4,8 @@ namespace Enqueue\Client;
 
 interface PreSendCommandExtensionInterface
 {
+    /**
+     * @throws \Exception
+     */
     public function onPreSendCommand(PreSend $context): void;
 }

--- a/pkg/enqueue/Client/PreSendEventExtensionInterface.php
+++ b/pkg/enqueue/Client/PreSendEventExtensionInterface.php
@@ -4,5 +4,8 @@ namespace Enqueue\Client;
 
 interface PreSendEventExtensionInterface
 {
+    /**
+     * @throws \Exception
+     */
     public function onPreSendEvent(PreSend $context): void;
 }

--- a/pkg/enqueue/Client/ProducerInterface.php
+++ b/pkg/enqueue/Client/ProducerInterface.php
@@ -10,6 +10,8 @@ interface ProducerInterface
      * The message could be pretty much everything as long as you have a client extension that transforms a body to string on onPreSendEvent.
      *
      * @param string|array|Message $message
+     *
+     * @throws \Exception
      */
     public function sendEvent(string $topic, $message): void;
 
@@ -18,6 +20,8 @@ interface ProducerInterface
      * The promise is returned if needReply argument is true.
      *
      * @param string|array|Message $message
+     *
+     * @throws \Exception
      */
     public function sendCommand(string $command, $message, bool $needReply = false): ?Promise;
 }


### PR DESCRIPTION
HI @makasim 

When calling `sendCommand` it's useful to know the method can throws Exception, it's currently the case for the proposed implementations.
Thanks to PHPStorm or static analysis tool like PHPStan, it will help people try/catching the calls and avoid error in production.