### PR TITLE
Add tagQueue and untagQueue to Amazon SQS client

### DIFF
--- a/pkg/sqs/SqsClient.php
+++ b/pkg/sqs/SqsClient.php
@@ -78,6 +78,16 @@ class SqsClient
         return $this->callApi('sendMessage', $args);
     }
 
+    public function tagQueue(array $args): Result
+    {
+        return $this->callApi('tagQueue', $args);
+    }
+
+    public function untagQueue(array $args): Result
+    {
+        return $this->callApi('untagQueue', $args);
+    }
+
     public function getAWSClient(): AwsSqsClient
     {
         $this->resolveClient();


### PR DESCRIPTION
AWS sdk contains `tagQueue` and `untagQueue` methods that were not exposed via this client. This is the only way to tag a queue, as tagging on creation does not work in AWS php sdk. 

I am aware that using it requires some work - writing custom SqsContext and changing declareQueue like this 
```
    public function declareQueue(SqsDestination $dest): void
    {
        $sqsClient = $this->decoratedContext->getSqsClient();
        $sqsClient = $this->decoratedContext->getSqsClient();

        $result = $sqsClient->createQueue(
            [
                '@region' => $dest->getRegion(),
                'Attributes' => $dest->getAttributes(),
                'QueueName' => $dest->getQueueName(),
            ]
        );

        if (!$result->hasKey('QueueUrl')) {
            throw new \RuntimeException(sprintf('Cannot create queue. queueName: "%s"', $dest->getQueueName()));
        }

        $sqsClient->tagQueue(
            [
                '@region' => $dest->getRegion(),
                'QueueUrl' => $result->get('QueueUrl'),
                'Tags' => [
                    'Product' => 'myProduc',
                    'ServiceName' => 'workers',
                    'Environment' => 'qa'
                ],
            ]
        );

        $this->queueUrls[$dest->getQueueName()] = $result->get('QueueUrl');
}
```

If the Authors of enqueue are interested in it I can PR a change to `SqsDestination` that would  allow setting tags and using them in this updated method. 


