### PR TITLE
[ENQUEUE] Precise phpdoc for static analysis

### DIFF
--- a/pkg/enqueue/Client/CommandSubscriberInterface.php
+++ b/pkg/enqueue/Client/CommandSubscriberInterface.php
@@ -2,6 +2,15 @@
 
 namespace Enqueue\Client;
 
+/**
+ * @phpstan-type CommandConfig = array{
+ *     command: string,
+ *     processor?: string,
+ *     queue?: string,
+ *     prefix_queue?: bool,
+ *     exclusive?: bool,
+ * }
+ */
 interface CommandSubscriberInterface
 {
     /**
@@ -44,6 +53,8 @@ interface CommandSubscriberInterface
      * Note: If you set "prefix_queue" to true then the "queue" is used as is and therefor the driver is not used to create a transport queue name.
      *
      * @return string|array
+     *
+     * @phpstan-return string|CommandConfig|array<CommandConfig>
      */
     public static function getSubscribedCommand();
 }


### PR DESCRIPTION
HI @makasim,

The `CommandSubscriberInterface::getSubscribedCommand` is currently annotated with `string|array` return type.
Static analysis tool allows to provide a more precise return type.
This PR allow PHPStan and Psalm users to have to proper static analysis of the return type when implementing the interface.

I based the array type on the current phpdoc, talking about 
```
     * [
     *   'command' => 'aSubscribedCommand',
     *   'processor' => 'aProcessorName',
     *   'queue' => 'a_client_queue_name',
     *   'prefix_queue' => true,
     *   'exclusive' => true,
     * ]
```