### PR TITLE
Set return type to flush function in RdkafkaProducer to be compatible to php-rdkafka

### DIFF
--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -115,11 +115,11 @@ class RdKafkaProducer implements Producer
         return null;
     }
 
-    public function flush(int $timeout): void
+    public function flush(int $timeout): ?int
     {
         // Flush method is exposed in phprdkafka 4.0
         if (method_exists($this->producer, 'flush')) {
-            $this->producer->flush($timeout);
+            return $this->producer->flush($timeout);
         }
     }
 }


### PR DESCRIPTION
 Looking at the rdkafka docs (https://arnaud.le-blanc.net/php-rdkafka-doc/phpdoc/rdkafka.flush.html) flush returns an integer instead of void in Producer class. This PR sets the same return type.