### PR TITLE
Use `#[AsCommand]` attribute on commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.2'
           coverage: none
           extensions: mongodb, redis, :xdebug
           ini-values: memory_limit=2048M

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.2
 FROM makasim/nginx-php-fpm:${PHP_VERSION}-all-exts
 
 ARG PHP_VERSION

--- a/pkg/enqueue/Symfony/Client/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Client/ConsumeCommand.php
@@ -13,18 +13,20 @@ use Enqueue\Symfony\Consumption\QueueConsumerOptionsCommandTrait;
 use Interop\Queue\Processor;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand('enqueue:consume')]
 class ConsumeCommand extends Command
 {
-    use LimitsExtensionsCommandTrait;
-    use SetupBrokerExtensionCommandTrait;
-    use QueueConsumerOptionsCommandTrait;
     use ChooseLoggerCommandTrait;
+    use LimitsExtensionsCommandTrait;
+    use QueueConsumerOptionsCommandTrait;
+    use SetupBrokerExtensionCommandTrait;
 
     protected static $defaultName = 'enqueue:consume';
 

--- a/pkg/enqueue/Symfony/Client/ProduceCommand.php
+++ b/pkg/enqueue/Symfony/Client/ProduceCommand.php
@@ -6,12 +6,14 @@ use Enqueue\Client\Message;
 use Enqueue\Client\ProducerInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand('enqueue:produce')]
 class ProduceCommand extends Command
 {
     protected static $defaultName = 'enqueue:produce';

--- a/pkg/enqueue/Symfony/Client/RoutesCommand.php
+++ b/pkg/enqueue/Symfony/Client/RoutesCommand.php
@@ -6,6 +6,7 @@ use Enqueue\Client\DriverInterface;
 use Enqueue\Client\Route;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand('enqueue:routes')]
 class RoutesCommand extends Command
 {
     protected static $defaultName = 'enqueue:routes';

--- a/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
+++ b/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
@@ -5,12 +5,14 @@ namespace Enqueue\Symfony\Client;
 use Enqueue\Client\DriverInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand('enqueue:setup-broker')]
 class SetupBrokerCommand extends Command
 {
     protected static $defaultName = 'enqueue:setup-broker';

--- a/pkg/enqueue/Symfony/Consumption/ConfigurableConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConfigurableConsumeCommand.php
@@ -8,17 +8,19 @@ use Enqueue\Consumption\QueueSubscriberInterface;
 use Enqueue\ProcessorRegistryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand('enqueue:transport:consume')]
 class ConfigurableConsumeCommand extends Command
 {
+    use ChooseLoggerCommandTrait;
     use LimitsExtensionsCommandTrait;
     use QueueConsumerOptionsCommandTrait;
-    use ChooseLoggerCommandTrait;
 
     protected static $defaultName = 'enqueue:transport:consume';
 

--- a/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
@@ -7,16 +7,18 @@ use Enqueue\Consumption\Extension\ExitStatusExtension;
 use Enqueue\Consumption\QueueConsumerInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand('enqueue:transport:consume')]
 class ConsumeCommand extends Command
 {
+    use ChooseLoggerCommandTrait;
     use LimitsExtensionsCommandTrait;
     use QueueConsumerOptionsCommandTrait;
-    use ChooseLoggerCommandTrait;
 
     protected static $defaultName = 'enqueue:transport:consume';
 

--- a/pkg/sns/Tests/SnsClientTest.php
+++ b/pkg/sns/Tests/SnsClientTest.php
@@ -16,7 +16,7 @@ class SnsClientTest extends TestCase
         $awsClient = (new Sdk(['Sns' => [
             'key' => '',
             'secret' => '',
-            'region' => '',
+            'region' => 'us-west-2',
             'version' => '2010-03-31',
             'endpoint' => 'http://localhost',
         ]]))->createSns();
@@ -31,7 +31,7 @@ class SnsClientTest extends TestCase
         $awsClient = (new Sdk(['Sns' => [
             'key' => '',
             'secret' => '',
-            'region' => '',
+            'region' => 'us-west-2',
             'version' => '2010-03-31',
             'endpoint' => 'http://localhost',
         ]]))->createMultiRegionSns();

--- a/pkg/sqs/Tests/SqsClientTest.php
+++ b/pkg/sqs/Tests/SqsClientTest.php
@@ -16,7 +16,7 @@ class SqsClientTest extends TestCase
         $awsClient = (new Sdk(['Sqs' => [
             'key' => '',
             'secret' => '',
-            'region' => '',
+            'region' => 'us-west-2',
             'version' => '2012-11-05',
             'endpoint' => 'http://localhost',
         ]]))->createSqs();
@@ -31,7 +31,7 @@ class SqsClientTest extends TestCase
         $awsClient = (new Sdk(['Sqs' => [
             'key' => '',
             'secret' => '',
-            'region' => '',
+            'region' => 'us-west-2',
             'version' => '2012-11-05',
             'endpoint' => 'http://localhost',
         ]]))->createMultiRegionSqs();


### PR DESCRIPTION
Fixes the following deprecations:

```json
  {
    "message": "Since symfony/console 6.1: Relying on the static property \"$defaultName\" for setting a command name is deprecated. Add the \"Symfony\\Component\\Console\\Attribute\\AsCommand\" attribute to the \"Enqueue\\Symfony\\Consumption\\ConfigurableConsumeCommand\" class instead.",
    "count": 1
  },
  {
    "message": "Since symfony/console 6.1: Relying on the static property \"$defaultName\" for setting a command name is deprecated. Add the \"Symfony\\Component\\Console\\Attribute\\AsCommand\" attribute to the \"Enqueue\\Symfony\\Client\\ConsumeCommand\" class instead.",
    "count": 1
  },
  {
    "message": "Since symfony/console 6.1: Relying on the static property \"$defaultName\" for setting a command name is deprecated. Add the \"Symfony\\Component\\Console\\Attribute\\AsCommand\" attribute to the \"Enqueue\\Symfony\\Client\\ProduceCommand\" class instead.",
    "count": 1
  },
  {
    "message": "Since symfony/console 6.1: Relying on the static property \"$defaultName\" for setting a command name is deprecated. Add the \"Symfony\\Component\\Console\\Attribute\\AsCommand\" attribute to the \"Enqueue\\Symfony\\Client\\SetupBrokerCommand\" class instead.",
    "count": 1
  },
  {
    "message": "Since symfony/console 6.1: Relying on the static property \"$defaultName\" for setting a command name is deprecated. Add the \"Symfony\\Component\\Console\\Attribute\\AsCommand\" attribute to the \"Enqueue\\Symfony\\Client\\RoutesCommand\" class instead.",
    "count": 1
  },
```