### PR TITLE
Add `void` return type in DoctrineSchemaCompilerPass and MessageQueueCollector

### DIFF
--- a/pkg/enqueue-bundle/Profiler/MessageQueueCollector.php
+++ b/pkg/enqueue-bundle/Profiler/MessageQueueCollector.php
@@ -8,6 +8,9 @@ use Throwable;
 
 class MessageQueueCollector extends AbstractMessageQueueCollector
 {
+    /**
+     * @return void
+     */
     public function collect(Request $request, Response $response, Throwable $exception = null)
     {
         $this->collectInternal($request, $response);

--- a/pkg/enqueue/Doctrine/DoctrineSchemaCompilerPass.php
+++ b/pkg/enqueue/Doctrine/DoctrineSchemaCompilerPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DoctrineSchemaCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('doctrine')) {
             return;


### PR DESCRIPTION
Fixes these deprecations on Symfony 6.3:

```
Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Enqueue\Doctrine\DoctrineSchemaCompilerPass" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect()" might add "void" as a native return type declaration in the future. Do the same in implementation "Enqueue\Bundle\Profiler\MessageQueueCollector" now to avoid errors or add an explicit @return annotation to suppress this message.
```