### PR TITLE
Fix PHP Deprecated message in PhpRedis.php

### DIFF
--- a/pkg/redis/PhpRedis.php
+++ b/pkg/redis/PhpRedis.php
@@ -109,15 +109,16 @@ class PhpRedis implements Redis
 
         $host = $this->config['scheme'] === 'rediss' ? 'tls://' . $this->config['host'] : $this->config['host'];
 
-        $result = call_user_func(
-            [$this->redis, $connectionMethod],
-            'unix' === $this->config['scheme'] ? $this->config['path'] : $host,
-            $this->config['port'],
-            $this->config['timeout'],
-            $this->config['persistent'] ? ($this->config['phpredis_persistent_id'] ?? null) : null,
-            $this->config['phpredis_retry_interval'] ?? null,
-            $this->config['read_write_timeout']
-        );
+        $args = [
+                'unix' === $this->config['scheme'] ? $this->config['path'] : $host,
+                $this->config['port'],
+                $this->config['timeout'],
+                $this->config['persistent'] ? ($this->config['phpredis_persistent_id'] ?? null) : null,
+                $this->config['phpredis_retry_interval'] ?? null,
+                $this->config['read_write_timeout'] ?? null,
+            ];
+
+        $result = $this->redis->$connectionMethod(...array_filter($args, fn ($arg) => isset($arg)));
 
         if (false == $result) {
             throw new ServerException('Failed to connect.');


### PR DESCRIPTION
Fixed  PHP Deprecated:  Redis::connect(): Passing null to parameter #5 of type int is deprecated in vendor/enqueue/redis/PhpRedis.php on line 119