### PR TITLE
Add beanstalkd port to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
 
   beanstalkd:
       image: 'jonbaldie/beanstalkd'
+      ports:
+        - "11300:11300"
 
   gearmand:
       image: 'artefactual/gearmand'


### PR DESCRIPTION
Lack of **beanstalkd** listening port (**11300**) in docker-compose.yml prevents run of tests (no connection)

Adding of required port to docker-compose.yml solves this issue