### PR TITLE
Update uuid DbalProducer.php

### DIFF
--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -66,7 +66,7 @@ class DbalProducer implements Producer
         ;
 
         $dbalMessage = [
-            'id' => Uuid::uuid4(),
+            'id' => Uuid::uuid4()->toString(),
             'published_at' => $publishedAt,
             'body' => $body,
             'headers' => JSON::encode($message->getHeaders()),


### PR DESCRIPTION
From this thread https://github.com/ramsey/uuid/issues/327 ramsey/uuid 4.1 introduced Ramsey\Uuid\Lazy\LazyUuidFromString object which is used over the original Ramsey\Uuid\Uuid object when generating Uuids (I.E. when using Uuid::uuid4()).

This causes conversion issues when using the objects on inserting records.
But can simply use toString() from UuidInterface to convert to actual guid (string) when calling DBAL insert.

The change means that `'id' => DbalType::GUID` on parameter types array is correct, rather than throwing: 

> Doctrine\DBAL\Exception\DriverException:
An exception occurred while executing a query: SQLSTATE [IMSSP, -16]: An invalid PHP type for parameter 1 was specified.

This change is BC, tested with ramsey/uuid:3.9.7 and ramsey/uuid:4.7.5