### PR TITLE
fixed symfony 6.1 deprecation notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
     "kwn/php-rdkafka-stubs": "^2.0.3",
     "friendsofphp/php-cs-fixer": "^3.4",
     "dms/phpunit-arraysubset-asserts": "^0.2.1",
-    "phpspec/prophecy-phpunit": "^2.0"
+    "phpspec/prophecy-phpunit": "^2.0",
+    "symfony/http-foundation": "^5.4|^6.0"
   },
   "autoload": {
     "psr-4": {
@@ -137,4 +138,3 @@
     }
   }
 }
-

--- a/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
+++ b/pkg/amqp-ext/Tests/Functional/AmqpCommonUseCasesTest.php
@@ -158,10 +158,11 @@ class AmqpCommonUseCasesTest extends TestCase
         $this->amqpContext->declareTopic($topic);
 
         $consumer = $this->amqpContext->createConsumer($topic);
-        //guard
+        // guard
         $this->assertNull($consumer->receive(1000));
 
         $message = $this->amqpContext->createMessage(__METHOD__);
+        $message->setDeliveryTag(1);
 
         $producer = $this->amqpContext->createProducer();
         $producer->send($topic, $message);
@@ -181,10 +182,11 @@ class AmqpCommonUseCasesTest extends TestCase
         $this->amqpContext->declareTopic($topic);
 
         $consumer = $this->amqpContext->createConsumer($topic);
-        //guard
+        // guard
         $this->assertNull($consumer->receive(1000));
 
         $message = $this->amqpContext->createMessage(__METHOD__);
+        $message->setDeliveryTag(1);
 
         $producer = $this->amqpContext->createProducer();
         $producer->send($topic, $message);

--- a/pkg/enqueue-bundle/Profiler/MessageQueueCollector.php
+++ b/pkg/enqueue-bundle/Profiler/MessageQueueCollector.php
@@ -4,11 +4,10 @@ namespace Enqueue\Bundle\Profiler;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Throwable;
 
 class MessageQueueCollector extends AbstractMessageQueueCollector
 {
-    public function collect(Request $request, Response $response, Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->collectInternal($request, $response);
     }

--- a/pkg/enqueue-bundle/Profiler/MessageQueueCollector.php
+++ b/pkg/enqueue-bundle/Profiler/MessageQueueCollector.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class MessageQueueCollector extends AbstractMessageQueueCollector
 {
-    public function collect(Request $request, Response $response, Throwable $exception = null)
+    public function collect(Request $request, Response $response, Throwable $exception = null): void
     {
         $this->collectInternal($request, $response);
     }

--- a/pkg/enqueue/Doctrine/DoctrineSchemaCompilerPass.php
+++ b/pkg/enqueue/Doctrine/DoctrineSchemaCompilerPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DoctrineSchemaCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('doctrine')) {
             return;

--- a/pkg/enqueue/Symfony/Client/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Client/ConsumeCommand.php
@@ -28,8 +28,6 @@ class ConsumeCommand extends Command
     use QueueConsumerOptionsCommandTrait;
     use SetupBrokerExtensionCommandTrait;
 
-    protected static $defaultName = 'enqueue:consume';
-
     /**
      * @var ContainerInterface
      */

--- a/pkg/enqueue/Symfony/Client/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Client/ConsumeCommand.php
@@ -20,13 +20,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('enqueue:consume')]
+#[AsCommand(self::COMMAND_NAME)]
 class ConsumeCommand extends Command
 {
     use ChooseLoggerCommandTrait;
     use LimitsExtensionsCommandTrait;
     use QueueConsumerOptionsCommandTrait;
     use SetupBrokerExtensionCommandTrait;
+
+    private const COMMAND_NAME = 'enqueue:consume';
 
     /**
      * @var ContainerInterface
@@ -66,7 +68,7 @@ class ConsumeCommand extends Command
         $this->driverIdPattern = $driverIdPattern;
         $this->processorIdPattern = $processorIdPatter;
 
-        parent::__construct(self::$defaultName);
+        parent::__construct(self::COMMAND_NAME);
     }
 
     protected function configure(): void

--- a/pkg/enqueue/Symfony/Client/ProduceCommand.php
+++ b/pkg/enqueue/Symfony/Client/ProduceCommand.php
@@ -13,9 +13,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('enqueue:produce')]
+#[AsCommand(self::COMMAND_NAME)]
 class ProduceCommand extends Command
 {
+    private const COMMAND_NAME = 'enqueue:produce';
+
     /**
      * @var ContainerInterface
      */
@@ -37,7 +39,7 @@ class ProduceCommand extends Command
         $this->defaultClient = $defaultClient;
         $this->producerIdPattern = $producerIdPattern;
 
-        parent::__construct(static::$defaultName);
+        parent::__construct(self::COMMAND_NAME);
     }
 
     protected function configure(): void

--- a/pkg/enqueue/Symfony/Client/ProduceCommand.php
+++ b/pkg/enqueue/Symfony/Client/ProduceCommand.php
@@ -16,8 +16,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand('enqueue:produce')]
 class ProduceCommand extends Command
 {
-    protected static $defaultName = 'enqueue:produce';
-
     /**
      * @var ContainerInterface
      */

--- a/pkg/enqueue/Symfony/Client/RoutesCommand.php
+++ b/pkg/enqueue/Symfony/Client/RoutesCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand('enqueue:routes')]
 class RoutesCommand extends Command
 {
-
     /**
      * @var ContainerInterface
      */

--- a/pkg/enqueue/Symfony/Client/RoutesCommand.php
+++ b/pkg/enqueue/Symfony/Client/RoutesCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand('enqueue:routes')]
 class RoutesCommand extends Command
 {
-    protected static $defaultName = 'enqueue:routes';
 
     /**
      * @var ContainerInterface

--- a/pkg/enqueue/Symfony/Client/RoutesCommand.php
+++ b/pkg/enqueue/Symfony/Client/RoutesCommand.php
@@ -14,9 +14,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('enqueue:routes')]
+#[AsCommand(self::COMMAND_NAME)]
 class RoutesCommand extends Command
 {
+    private const COMMAND_NAME = 'enqueue:routes';
     /**
      * @var ContainerInterface
      */
@@ -43,7 +44,7 @@ class RoutesCommand extends Command
         $this->defaultClient = $defaultClient;
         $this->driverIdPatter = $driverIdPatter;
 
-        parent::__construct(static::$defaultName);
+        parent::__construct(self::COMMAND_NAME);
     }
 
     protected function configure(): void

--- a/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
+++ b/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
@@ -12,9 +12,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('enqueue:setup-broker')]
+#[AsCommand(self::COMMAND_NAME)]
 class SetupBrokerCommand extends Command
 {
+    private const COMMAND_NAME = 'enqueue:setup-broker';
+
     /**
      * @var ContainerInterface
      */
@@ -36,7 +38,7 @@ class SetupBrokerCommand extends Command
         $this->defaultClient = $defaultClient;
         $this->driverIdPattern = $driverIdPattern;
 
-        parent::__construct(static::$defaultName);
+        parent::__construct(self::COMMAND_NAME);
     }
 
     protected function configure(): void

--- a/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
+++ b/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand('enqueue:setup-broker')]
 class SetupBrokerCommand extends Command
 {
-
     /**
      * @var ContainerInterface
      */

--- a/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
+++ b/pkg/enqueue/Symfony/Client/SetupBrokerCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand('enqueue:setup-broker')]
 class SetupBrokerCommand extends Command
 {
-    protected static $defaultName = 'enqueue:setup-broker';
 
     /**
      * @var ContainerInterface

--- a/pkg/enqueue/Symfony/Consumption/ConfigurableConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConfigurableConsumeCommand.php
@@ -15,12 +15,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('enqueue:transport:consume')]
+#[AsCommand(self::COMMAND_NAME)]
 class ConfigurableConsumeCommand extends Command
 {
     use ChooseLoggerCommandTrait;
     use LimitsExtensionsCommandTrait;
     use QueueConsumerOptionsCommandTrait;
+
+    private const COMMAND_NAME = 'enqueue:transport:consume';
 
     /**
      * @var ContainerInterface
@@ -53,7 +55,7 @@ class ConfigurableConsumeCommand extends Command
         $this->queueConsumerIdPattern = $queueConsumerIdPattern;
         $this->processorRegistryIdPattern = $processorRegistryIdPattern;
 
-        parent::__construct(static::$defaultName);
+        parent::__construct(self::COMMAND_NAME);
     }
 
     protected function configure(): void

--- a/pkg/enqueue/Symfony/Consumption/ConfigurableConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConfigurableConsumeCommand.php
@@ -22,8 +22,6 @@ class ConfigurableConsumeCommand extends Command
     use LimitsExtensionsCommandTrait;
     use QueueConsumerOptionsCommandTrait;
 
-    protected static $defaultName = 'enqueue:transport:consume';
-
     /**
      * @var ContainerInterface
      */

--- a/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
@@ -20,8 +20,6 @@ class ConsumeCommand extends Command
     use LimitsExtensionsCommandTrait;
     use QueueConsumerOptionsCommandTrait;
 
-    protected static $defaultName = 'enqueue:transport:consume';
-
     /**
      * @var ContainerInterface
      */

--- a/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
+++ b/pkg/enqueue/Symfony/Consumption/ConsumeCommand.php
@@ -13,12 +13,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('enqueue:transport:consume')]
+#[AsCommand(self::COMMAND_NAME)]
 class ConsumeCommand extends Command
 {
     use ChooseLoggerCommandTrait;
     use LimitsExtensionsCommandTrait;
     use QueueConsumerOptionsCommandTrait;
+
+    private const COMMAND_NAME = 'enqueue:transport:consume';
 
     /**
      * @var ContainerInterface
@@ -41,7 +43,7 @@ class ConsumeCommand extends Command
         $this->defaultTransport = $defaultTransport;
         $this->queueConsumerIdPattern = $queueConsumerIdPattern;
 
-        parent::__construct(static::$defaultName);
+        parent::__construct(self::COMMAND_NAME);
     }
 
     protected function configure(): void


### PR DESCRIPTION
fixes https://github.com/php-enqueue/enqueue-dev/issues/1270

```
1x: Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Enqueue\Doctrine\DoctrineSchemaCompilerPass" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Enqueue\Symfony\Consumption\ConfigurableConsumeCommand".

  1x: The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Enqueue\Symfony\Client\ConsumeCommand".

  1x: The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Enqueue\Symfony\Client\ProduceCommand".

  1x: The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Enqueue\Symfony\Client\SetupBrokerCommand".

  1x: The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Enqueue\Symfony\Client\RoutesCommand".
```