### PR TITLE
GPS: revert the attributes and use the headers instead.

### DIFF
--- a/pkg/gps/GpsMessage.php
+++ b/pkg/gps/GpsMessage.php
@@ -25,11 +25,6 @@ class GpsMessage implements Message, \JsonSerializable
     private $headers;
 
     /**
-     * @var array
-     */
-    private $attributes;
-
-    /**
      * @var bool
      */
     private $redelivered;
@@ -39,12 +34,11 @@ class GpsMessage implements Message, \JsonSerializable
      */
     private $nativeMessage;
 
-    public function __construct(string $body = '', array $properties = [], array $headers = [], array $attributes = [])
+    public function __construct(string $body = '', array $properties = [], array $headers = [])
     {
         $this->body = $body;
         $this->properties = $properties;
         $this->headers = $headers;
-        $this->attributes = $attributes;
 
         $this->redelivered = false;
     }
@@ -157,7 +151,6 @@ class GpsMessage implements Message, \JsonSerializable
             'body' => $this->getBody(),
             'properties' => $this->getProperties(),
             'headers' => $this->getHeaders(),
-            'attributes' => $this->getAttributes(),
         ];
     }
 
@@ -168,7 +161,7 @@ class GpsMessage implements Message, \JsonSerializable
             throw new \InvalidArgumentException(sprintf('The malformed json given. Error %s and message %s', json_last_error(), json_last_error_msg()));
         }
 
-        return new self($data['body'] ?? $json, $data['properties'] ?? [], $data['headers'] ?? [], $data['attributes'] ?? []);
+        return new self($data['body'] ?? $json, $data['properties'] ?? [], $data['headers'] ?? []);
     }
 
     public function getNativeMessage(): ?GoogleMessage
@@ -179,15 +172,5 @@ class GpsMessage implements Message, \JsonSerializable
     public function setNativeMessage(?GoogleMessage $message = null): void
     {
         $this->nativeMessage = $message;
-    }
-
-    public function setAttributes(array $attributes): void
-    {
-        $this->attributes = $attributes;
-    }
-
-    public function getAttributes(): array
-    {
-        return $this->attributes;
     }
 }

--- a/pkg/gps/GpsProducer.php
+++ b/pkg/gps/GpsProducer.php
@@ -40,8 +40,8 @@ class GpsProducer implements Producer
 
         $params = ['data' => json_encode($message)];
 
-        if (count($message->getAttributes()) > 0) {
-            $params['attributes'] = $message->getAttributes();
+        if (count($message->getHeaders()) > 0) {
+            $params['attributes'] = $message->getHeaders();
         }
 
         $topic->publish($params);

--- a/pkg/gps/Tests/GpsMessageTest.php
+++ b/pkg/gps/Tests/GpsMessageTest.php
@@ -18,14 +18,14 @@ class GpsMessageTest extends TestCase
 
     public function testColdBeSerializedToJson()
     {
-        $message = new GpsMessage('theBody', ['thePropFoo' => 'thePropFooVal'], ['theHeaderFoo' => 'theHeaderFooVal'], ['theAttributeFoo' => 'theAttributeFooVal']);
+        $message = new GpsMessage('theBody', ['thePropFoo' => 'thePropFooVal'], ['theHeaderFoo' => 'theHeaderFooVal']);
 
-        $this->assertEquals('{"body":"theBody","properties":{"thePropFoo":"thePropFooVal"},"headers":{"theHeaderFoo":"theHeaderFooVal"},"attributes":{"theAttributeFoo":"theAttributeFooVal"}}', json_encode($message));
+        $this->assertEquals('{"body":"theBody","properties":{"thePropFoo":"thePropFooVal"},"headers":{"theHeaderFoo":"theHeaderFooVal"}}', json_encode($message));
     }
 
     public function testCouldBeUnserializedFromJson()
     {
-        $message = new GpsMessage('theBody', ['thePropFoo' => 'thePropFooVal'], ['theHeaderFoo' => 'theHeaderFooVal'], ['theAttributeFoo' => 'theAttributeFooVal']);
+        $message = new GpsMessage('theBody', ['thePropFoo' => 'thePropFooVal'], ['theHeaderFoo' => 'theHeaderFooVal']);
 
         $json = json_encode($message);
 
@@ -40,7 +40,7 @@ class GpsMessageTest extends TestCase
 
     public function testMessageEntityCouldBeUnserializedFromJson()
     {
-        $json = '{"body":"theBody","properties":{"thePropFoo":"thePropFooVal"},"headers":{"theHeaderFoo":"theHeaderFooVal"},"attributes":{"theAttributeFoo":"theAttributeFooVal"}}';
+        $json = '{"body":"theBody","properties":{"thePropFoo":"thePropFooVal"},"headers":{"theHeaderFoo":"theHeaderFooVal"}}';
 
         $unserializedMessage = GpsMessage::jsonUnserialize($json);
 
@@ -49,7 +49,6 @@ class GpsMessageTest extends TestCase
         $this->assertEquals($decoded['body'], $unserializedMessage->getBody());
         $this->assertEquals($decoded['properties'], $unserializedMessage->getProperties());
         $this->assertEquals($decoded['headers'], $unserializedMessage->getHeaders());
-        $this->assertEquals($decoded['attributes'], $unserializedMessage->getAttributes());
     }
 
     public function testMessagePayloadCouldBeUnserializedFromJson()
@@ -62,7 +61,6 @@ class GpsMessageTest extends TestCase
         $this->assertEquals($json, $unserializedMessage->getBody());
         $this->assertEquals([], $unserializedMessage->getProperties());
         $this->assertEquals([], $unserializedMessage->getHeaders());
-        $this->assertEquals([], $unserializedMessage->getAttributes());
     }
 
     public function testThrowIfMalformedJsonGivenOnUnsterilizedFromJson()
@@ -71,14 +69,5 @@ class GpsMessageTest extends TestCase
         $this->expectExceptionMessage('The malformed json given.');
 
         GpsMessage::jsonUnserialize('{]');
-    }
-
-    public function testGetAttributes()
-    {
-        $message = new GpsMessage('the body', [], [], ['key1' => 'value1']);
-
-        $attributes = $message->getAttributes();
-
-        $this->assertSame(['key1' => 'value1'], $attributes);
     }
 }

--- a/pkg/gps/Tests/GpsProducerTest.php
+++ b/pkg/gps/Tests/GpsProducerTest.php
@@ -34,7 +34,7 @@ class GpsProducerTest extends TestCase
             ->expects($this->once())
             ->method('publish')
             ->with($this->identicalTo([
-                'data' => '{"body":"","properties":[],"headers":[],"attributes":[]}',
+                'data' => '{"body":"","properties":[],"headers":[]}',
             ]));
 
         $client = $this->createPubSubClientMock();
@@ -56,16 +56,16 @@ class GpsProducerTest extends TestCase
         $producer->send($topic, $message);
     }
 
-    public function testShouldSendMessageWithAttributes()
+    public function testShouldSendMessageWithHeaders()
     {
         $topic = new GpsTopic('topic-name');
-        $message = new GpsMessage('', [], [], ['key1' => 'value1']);
+        $message = new GpsMessage('', [], ['key1' => 'value1']);
 
         $gtopic = $this->createGTopicMock();
         $gtopic
             ->expects($this->once())
             ->method('publish')
-            ->with($this->identicalTo(['data' => '{"body":"","properties":[],"headers":[],"attributes":{"key1":"value1"}}', 'attributes' => ['key1' => 'value1']]))
+            ->with($this->identicalTo(['data' => '{"body":"","properties":[],"headers":{"key1":"value1"}}', 'attributes' => ['key1' => 'value1']]))
         ;
 
         $client = $this->createPubSubClientMock();


### PR DESCRIPTION
I found that i was go in wrong direction. 
The GPS attributes are the Interop Message headers. 

I revert to use the `headers` and remove the `attributes`