### PR TITLE
update symfony version to v7

### DIFF
--- a/pkg/enqueue-bundle/composer.json
+++ b/pkg/enqueue-bundle/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/framework-bundle": "^5.4|^6.0",
+        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/enqueue": "^0.10",
@@ -39,10 +39,11 @@
         "doctrine/doctrine-bundle": "^2.3.2",
         "doctrine/mongodb-odm-bundle": "^3.5|^4.3",
         "alcaeus/mongo-php-adapter": "^1.0",
-        "symfony/browser-kit": "^5.4|^6.0",
-        "symfony/expression-language": "^5.4|^6.0",
-        "symfony/validator": "^5.4|^6.0",
-        "symfony/yaml": "^5.4|^6.0"
+        "symfony/browser-kit": "^5.4|^6.0|^7.0",
+        "symfony/expression-language": "^5.4|^6.0|^7.0",
+        "symfony/validator": "^5.4|^6.0|^7.0",
+        "symfony/yaml": "^5.4|^6.0|^7.0",
+        "dms/phpunit-arraysubset-asserts": "^0.5.0"
     },
     "suggest": {
         "enqueue/async-command": "If want to run Symfony command via message queue",
@@ -57,6 +58,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "0.10.x-dev"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
         }
     }
 }


### PR DESCRIPTION
Support for Symfony 7 like https://github.com/php-enqueue/enqueue-bundle/pull/8 but hopefully with fixed CI problems (duplicate from https://github.com/php-enqueue/enqueue-bundle/pull/12)