### PR TITLE
Drop useless call to end method

### DIFF
--- a/pkg/enqueue/Symfony/Client/DependencyInjection/ClientFactory.php
+++ b/pkg/enqueue/Symfony/Client/DependencyInjection/ClientFactory.php
@@ -74,12 +74,8 @@ final class ClientFactory
             ->scalarNode('router_processor')->defaultNull()->end()
             ->integerNode('redelivered_delay_time')->min(0)->defaultValue(0)->end()
             ->scalarNode('default_queue')->defaultValue('default')->cannotBeEmpty()->end()
-            ->arrayNode('driver_options')
-                ->addDefaultsIfNotSet()
-                ->info('The array contains driver specific options')
-                ->ignoreExtraKeys(false)
+            ->arrayNode('driver_options')->addDefaultsIfNotSet()->info('The array contains driver specific options')->ignoreExtraKeys(false)->end()
             ->end()
-            ->end()->end()
         ;
 
         return $builder;


### PR DESCRIPTION
Due to this, upgrading from SF 6.4.7 to more recent versions is impossible.

Output from the `cache:clear` after upgrade:
```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  TypeError {#5946
!!    #message: "Symfony\Component\Config\Definition\Builder\NodeDefinition::end(): Return value must be of type Symfony\Component\Config\Definition\Builder\NodeParentInterface, null returned"
!!    #code: 0
!!    #file: "./vendor/symfony/config/Definition/Builder/NodeDefinition.php"
!!    #line: 98
!!    trace: {
!!      ./vendor/symfony/config/Definition/Builder/NodeDefinition.php:98 { …}
!!      ./vendor/enqueue/enqueue/Symfony/Client/DependencyInjection/ClientFactory.php:82 { …}
!!      ./vendor/enqueue/enqueue-bundle/DependencyInjection/Configuration.php:42 { …}
!!      ./vendor/symfony/config/Definition/Processor.php:46 { …}
!!      ./vendor/symfony/dependency-injection/Extension/Extension.php:109 { …}
!!      ./vendor/enqueue/enqueue-bundle/DependencyInjection/EnqueueExtension.php:34 { …}
!!      ./vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php:76 { …}
!!      ./vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php:42 { …}
!!      ./vendor/symfony/dependency-injection/Compiler/Compiler.php:80 { …}
!!      ./vendor/symfony/dependency-injection/ContainerBuilder.php:767 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:506 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:771 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:126 { …}
!!      ./vendor/symfony/framework-bundle/Console/Application.php:190 { …}
!!      ./vendor/symfony/framework-bundle/Console/Application.php:72 { …}
!!      ./vendor/symfony/console/Application.php:175 { …}
!!      ./bin/console:43 {
!!        › $application = new Application($kernel);
!!        › $application->run($input);
!!        › 
!!      }
!!    }
!!  }
!!  2024-09-17T12:45:24+00:00 [critical] Uncaught Error: Symfony\Component\Config\Definition\Builder\NodeDefinition::end(): Return value must be of type Symfony\Component\Config\Definition\Builder\NodeParentInterface, null returned
!!  
Script @auto-scripts was called via post-install-cmd
```