### PR TITLE
Bump symfony config version support

### DIFF
--- a/pkg/async-command/composer.json
+++ b/pkg/async-command/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/config": "^5.4|^6.0",
+        "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/filesystem": "^5.4|^6.0",
         "symfony/yaml": "^5.4|^6.0",

--- a/pkg/async-event-dispatcher/composer.json
+++ b/pkg/async-event-dispatcher/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/config": "^5.4|^6.0",
+        "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/filesystem": "^5.4|^6.0",
         "symfony/yaml": "^5.4|^6.0",

--- a/pkg/enqueue/composer.json
+++ b/pkg/enqueue/composer.json
@@ -19,7 +19,7 @@
         "phpunit/phpunit": "^9.5",
         "symfony/console": "^5.41|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/config": "^5.4|^6.0",
+        "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/yaml": "^5.4|^6.0",
@@ -44,7 +44,7 @@
     "suggest": {
         "symfony/console": "^5.4|^6.0 If you want to use cli commands",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/config": "^5.4|^6.0",
+        "symfony/config": "^5.4|^6.0|^7.0",
         "enqueue/amqp-ext": "AMQP transport (based on php extension)",
         "enqueue/stomp": "STOMP transport",
         "enqueue/fs": "Filesystem transport",

--- a/pkg/simple-client/composer.json
+++ b/pkg/simple-client/composer.json
@@ -10,7 +10,7 @@
         "enqueue/enqueue": "^0.10",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",
-        "symfony/config": "^5.4|^6.0"
+        "symfony/config": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
[`symfony/config` cahngelog](https://github.com/symfony/config/blob/7.2/CHANGELOG.md)

Related to this issue https://github.com/php-enqueue/enqueue-dev/issues/1354