### PR TITLE
fix: bump composer php requirement in packages

### DIFF
--- a/pkg/amqp-bunny/composer.json
+++ b/pkg/amqp-bunny/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",
         "bunny/bunny": "^0.4|^0.5",

--- a/pkg/amqp-ext/composer.json
+++ b/pkg/amqp-ext/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-amqp": "^1.9.3|^2.0.0",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/amqp-lib/composer.json
+++ b/pkg/amqp-lib/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "php-amqplib/php-amqplib": "^3.2",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/amqp-tools/composer.json
+++ b/pkg/amqp-tools/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10"

--- a/pkg/async-command/composer.json
+++ b/pkg/async-command/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "enqueue/enqueue": "^0.10",
         "queue-interop/queue-interop": "^0.8",
         "symfony/console": "^5.4|^6.0",

--- a/pkg/async-event-dispatcher/composer.json
+++ b/pkg/async-event-dispatcher/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "enqueue/enqueue": "^0.10",
         "queue-interop/queue-interop": "^0.8",
         "symfony/event-dispatcher": "^5.4|^6.0"

--- a/pkg/dbal/composer.json
+++ b/pkg/dbal/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8",
         "doctrine/dbal": "^2.12|^3.1",
         "doctrine/persistence": "^2.0|^3.0",

--- a/pkg/dsn/composer.json
+++ b/pkg/dsn/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/pkg/enqueue/composer.json
+++ b/pkg/enqueue/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/null": "^0.10",

--- a/pkg/fs/composer.json
+++ b/pkg/fs/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "symfony/filesystem": "^5.4|^6.0",

--- a/pkg/gearman/composer.json
+++ b/pkg/gearman/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-gearman": "^2.0",
         "queue-interop/queue-interop": "^0.8"
     },

--- a/pkg/gps/composer.json
+++ b/pkg/gps/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8",
         "google/cloud-pubsub": "^1.4.3",
         "enqueue/dsn": "^0.10"

--- a/pkg/job-queue/composer.json
+++ b/pkg/job-queue/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "enqueue/enqueue": "^0.10",
         "enqueue/null": "^0.10",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/mongodb/composer.json
+++ b/pkg/mongodb/composer.json
@@ -10,7 +10,7 @@
   "homepage": "https://enqueue.forma-pro.com/",
   "license": "MIT",
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^8.1",
     "queue-interop/queue-interop": "^0.8",
     "mongodb/mongodb": "^1.2",
     "ext-mongodb": "^1.5"

--- a/pkg/monitoring/composer.json
+++ b/pkg/monitoring/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "enqueue/enqueue": "^0.10",
         "enqueue/dsn": "^0.10"
     },

--- a/pkg/null/composer.json
+++ b/pkg/null/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {

--- a/pkg/pheanstalk/composer.json
+++ b/pkg/pheanstalk/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "pda/pheanstalk": "^3.1",
         "queue-interop/queue-interop": "^0.8"
     },

--- a/pkg/rdkafka/composer.json
+++ b/pkg/rdkafka/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-rdkafka": "^4.0|^5.0|^6.0",
         "queue-interop/queue-interop": "^0.8.1"
     },

--- a/pkg/redis/composer.json
+++ b/pkg/redis/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "ramsey/uuid": "^3.5|^4"

--- a/pkg/simple-client/composer.json
+++ b/pkg/simple-client/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "enqueue/enqueue": "^0.10",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/sns/composer.json
+++ b/pkg/sns/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "aws/aws-sdk-php": "^3.290"

--- a/pkg/snsqs/composer.json
+++ b/pkg/snsqs/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "enqueue/sns": "^0.10",

--- a/pkg/sqs/composer.json
+++ b/pkg/sqs/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/dsn": "^0.10",
         "aws/aws-sdk-php": "^3.290"

--- a/pkg/stomp/composer.json
+++ b/pkg/stomp/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "enqueue/dsn": "^0.10",
         "stomp-php/stomp-php": "^4.5|^5.0",
         "queue-interop/queue-interop": "^0.8",

--- a/pkg/wamp/composer.json
+++ b/pkg/wamp/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "queue-interop/queue-interop": "^0.8.1",
         "enqueue/dsn": "^0.10.8",
         "thruway/client": "^0.5.5",


### PR DESCRIPTION
PHP version requirement was not bumped to 8.1 in the packages.

s. https://github.com/php-enqueue/enqueue-dev/issues/1367

