### PR TITLE
use explicitly nullable parameter types (implicit deprecated in php 8.4)

### DIFF
--- a/pkg/amqp-bunny/AmqpConsumer.php
+++ b/pkg/amqp-bunny/AmqpConsumer.php
@@ -48,7 +48,7 @@ class AmqpConsumer implements InteropAmqpConsumer
         $this->flags = self::FLAG_NOPARAM;
     }
 
-    public function setConsumerTag(string $consumerTag = null): void
+    public function setConsumerTag(?string $consumerTag = null): void
     {
         $this->consumerTag = $consumerTag;
     }

--- a/pkg/amqp-bunny/AmqpProducer.php
+++ b/pkg/amqp-bunny/AmqpProducer.php
@@ -79,7 +79,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $this->delayStrategy) {
             throw DeliveryDelayNotSupportedException::providerDoestNotSupportIt();
@@ -98,7 +98,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 
@@ -113,7 +113,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/amqp-ext/AmqpConsumer.php
+++ b/pkg/amqp-ext/AmqpConsumer.php
@@ -43,7 +43,7 @@ class AmqpConsumer implements InteropAmqpConsumer
         $this->flags = self::FLAG_NOPARAM;
     }
 
-    public function setConsumerTag(string $consumerTag = null): void
+    public function setConsumerTag(?string $consumerTag = null): void
     {
         $this->consumerTag = $consumerTag;
     }

--- a/pkg/amqp-ext/AmqpProducer.php
+++ b/pkg/amqp-ext/AmqpProducer.php
@@ -72,7 +72,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
         }
     }
 
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $this->delayStrategy) {
             throw DeliveryDelayNotSupportedException::providerDoestNotSupportIt();
@@ -88,7 +88,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
         return $this->deliveryDelay;
     }
 
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 
@@ -100,7 +100,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
         return $this->priority;
     }
 
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/amqp-lib/AmqpConsumer.php
+++ b/pkg/amqp-lib/AmqpConsumer.php
@@ -47,7 +47,7 @@ class AmqpConsumer implements InteropAmqpConsumer
         $this->flags = self::FLAG_NOPARAM;
     }
 
-    public function setConsumerTag(string $consumerTag = null): void
+    public function setConsumerTag(?string $consumerTag = null): void
     {
         $this->consumerTag = $consumerTag;
     }

--- a/pkg/amqp-lib/AmqpProducer.php
+++ b/pkg/amqp-lib/AmqpProducer.php
@@ -81,7 +81,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $this->delayStrategy) {
             throw DeliveryDelayNotSupportedException::providerDoestNotSupportIt();
@@ -100,7 +100,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 
@@ -115,7 +115,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/amqp-tools/DelayStrategyAware.php
+++ b/pkg/amqp-tools/DelayStrategyAware.php
@@ -6,5 +6,5 @@ namespace Enqueue\AmqpTools;
 
 interface DelayStrategyAware
 {
-    public function setDelayStrategy(DelayStrategy $delayStrategy = null): self;
+    public function setDelayStrategy(?DelayStrategy $delayStrategy = null): self;
 }

--- a/pkg/amqp-tools/DelayStrategyAwareTrait.php
+++ b/pkg/amqp-tools/DelayStrategyAwareTrait.php
@@ -11,7 +11,7 @@ trait DelayStrategyAwareTrait
      */
     protected $delayStrategy;
 
-    public function setDelayStrategy(DelayStrategy $delayStrategy = null): DelayStrategyAware
+    public function setDelayStrategy(?DelayStrategy $delayStrategy = null): DelayStrategyAware
     {
         $this->delayStrategy = $delayStrategy;
 

--- a/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
+++ b/pkg/amqp-tools/Tests/RabbitMqDelayPluginDelayStrategyTest.php
@@ -192,7 +192,7 @@ class TestProducer implements AmqpProducer, DelayStrategy
     {
     }
 
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         throw new \BadMethodCallException('This should not be called directly');
     }
@@ -202,7 +202,7 @@ class TestProducer implements AmqpProducer, DelayStrategy
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         throw new \BadMethodCallException('This should not be called directly');
     }
@@ -212,7 +212,7 @@ class TestProducer implements AmqpProducer, DelayStrategy
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         throw new \BadMethodCallException('This should not be called directly');
     }

--- a/pkg/async-event-dispatcher/AsyncEventDispatcher.php
+++ b/pkg/async-event-dispatcher/AsyncEventDispatcher.php
@@ -4,7 +4,7 @@ namespace Enqueue\AsyncEventDispatcher;
 
 class AsyncEventDispatcher extends AbstractAsyncEventDispatcher
 {
-    public function dispatch(object $event, string $eventName = null): object
+    public function dispatch(object $event, ?string $eventName = null): object
     {
         $this->parentDispatch($event, $eventName);
 

--- a/pkg/async-event-dispatcher/EventTransformer.php
+++ b/pkg/async-event-dispatcher/EventTransformer.php
@@ -12,7 +12,7 @@ interface EventTransformer
      *
      * @return Message
      */
-    public function toMessage($eventName, Event $event = null);
+    public function toMessage($eventName, ?Event $event = null);
 
     /**
      * If you able to transform message back to event return it.

--- a/pkg/async-event-dispatcher/PhpSerializerEventTransformer.php
+++ b/pkg/async-event-dispatcher/PhpSerializerEventTransformer.php
@@ -6,7 +6,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class PhpSerializerEventTransformer extends AbstractPhpSerializerEventTransformer implements EventTransformer
 {
-    public function toMessage($eventName, Event $event = null)
+    public function toMessage($eventName, ?Event $event = null)
     {
         return $this->context->createMessage(serialize($event));
     }

--- a/pkg/dbal/DbalConnectionFactory.php
+++ b/pkg/dbal/DbalConnectionFactory.php
@@ -92,7 +92,7 @@ class DbalConnectionFactory implements ConnectionFactory
         return $this->connection;
     }
 
-    private function parseDsn(string $dsn, array $config = null): array
+    private function parseDsn(string $dsn, ?array $config = null): array
     {
         $parsedDsn = Dsn::parseFirst($dsn);
 

--- a/pkg/dbal/DbalMessage.php
+++ b/pkg/dbal/DbalMessage.php
@@ -144,7 +144,7 @@ class DbalMessage implements Message
         $this->redelivered = $redelivered;
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -159,7 +159,7 @@ class DbalMessage implements Message
         return $this->priority;
     }
 
-    public function setPriority(int $priority = null): void
+    public function setPriority(?int $priority = null): void
     {
         $this->priority = $priority;
     }
@@ -172,7 +172,7 @@ class DbalMessage implements Message
     /**
      * Set delay in milliseconds.
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): void
+    public function setDeliveryDelay(?int $deliveryDelay = null): void
     {
         $this->deliveryDelay = $deliveryDelay;
     }
@@ -188,12 +188,12 @@ class DbalMessage implements Message
     /**
      * Set time to live in milliseconds.
      */
-    public function setTimeToLive(int $timeToLive = null): void
+    public function setTimeToLive(?int $timeToLive = null): void
     {
         $this->timeToLive = $timeToLive;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', $correlationId);
     }
@@ -203,7 +203,7 @@ class DbalMessage implements Message
         return $this->getHeader('correlation_id', null);
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', $messageId);
     }
@@ -220,7 +220,7 @@ class DbalMessage implements Message
         return null === $value ? null : $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
@@ -240,7 +240,7 @@ class DbalMessage implements Message
         return $this->redeliverAfter;
     }
 
-    public function setRedeliverAfter(int $redeliverAfter = null): void
+    public function setRedeliverAfter(?int $redeliverAfter = null): void
     {
         $this->redeliverAfter = $redeliverAfter;
     }
@@ -250,7 +250,7 @@ class DbalMessage implements Message
         return $this->publishedAt;
     }
 
-    public function setPublishedAt(int $publishedAt = null): void
+    public function setPublishedAt(?int $publishedAt = null): void
     {
         $this->publishedAt = $publishedAt;
     }

--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -128,7 +128,7 @@ class DbalProducer implements Producer
         }
     }
 
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         $this->deliveryDelay = $deliveryDelay;
 
@@ -140,7 +140,7 @@ class DbalProducer implements Producer
         return $this->deliveryDelay;
     }
 
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 
@@ -152,7 +152,7 @@ class DbalProducer implements Producer
         return $this->priority;
     }
 
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/dbal/Tests/DbalConsumerTest.php
+++ b/pkg/dbal/Tests/DbalConsumerTest.php
@@ -270,7 +270,7 @@ class InvalidMessage implements Message
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
     }
 
@@ -279,7 +279,7 @@ class InvalidMessage implements Message
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
     }
 
@@ -293,11 +293,11 @@ class InvalidMessage implements Message
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
     }
 

--- a/pkg/dsn/Dsn.php
+++ b/pkg/dsn/Dsn.php
@@ -140,27 +140,27 @@ class Dsn
         return $this->queryBag->toArray();
     }
 
-    public function getString(string $name, string $default = null): ?string
+    public function getString(string $name, ?string $default = null): ?string
     {
         return $this->queryBag->getString($name, $default);
     }
 
-    public function getDecimal(string $name, int $default = null): ?int
+    public function getDecimal(string $name, ?int $default = null): ?int
     {
         return $this->queryBag->getDecimal($name, $default);
     }
 
-    public function getOctal(string $name, int $default = null): ?int
+    public function getOctal(string $name, ?int $default = null): ?int
     {
         return $this->queryBag->getOctal($name, $default);
     }
 
-    public function getFloat(string $name, float $default = null): ?float
+    public function getFloat(string $name, ?float $default = null): ?float
     {
         return $this->queryBag->getFloat($name, $default);
     }
 
-    public function getBool(string $name, bool $default = null): ?bool
+    public function getBool(string $name, ?bool $default = null): ?bool
     {
         return $this->queryBag->getBool($name, $default);
     }

--- a/pkg/dsn/QueryBag.php
+++ b/pkg/dsn/QueryBag.php
@@ -21,12 +21,12 @@ class QueryBag
         return $this->query;
     }
 
-    public function getString(string $name, string $default = null): ?string
+    public function getString(string $name, ?string $default = null): ?string
     {
         return array_key_exists($name, $this->query) ? $this->query[$name] : $default;
     }
 
-    public function getDecimal(string $name, int $default = null): ?int
+    public function getDecimal(string $name, ?int $default = null): ?int
     {
         $value = $this->getString($name);
         if (null === $value) {
@@ -40,7 +40,7 @@ class QueryBag
         return (int) $value;
     }
 
-    public function getOctal(string $name, int $default = null): ?int
+    public function getOctal(string $name, ?int $default = null): ?int
     {
         $value = $this->getString($name);
         if (null === $value) {
@@ -54,7 +54,7 @@ class QueryBag
         return intval($value, 8);
     }
 
-    public function getFloat(string $name, float $default = null): ?float
+    public function getFloat(string $name, ?float $default = null): ?float
     {
         $value = $this->getString($name);
         if (null === $value) {
@@ -68,7 +68,7 @@ class QueryBag
         return (float) $value;
     }
 
-    public function getBool(string $name, bool $default = null): ?bool
+    public function getBool(string $name, ?bool $default = null): ?bool
     {
         $value = $this->getString($name);
         if (null === $value) {

--- a/pkg/enqueue-bundle/Tests/Functional/App/TestAsyncEventTransformer.php
+++ b/pkg/enqueue-bundle/Tests/Functional/App/TestAsyncEventTransformer.php
@@ -21,7 +21,7 @@ class TestAsyncEventTransformer implements EventTransformer
         $this->context = $context;
     }
 
-    public function toMessage($eventName, Event $event = null)
+    public function toMessage($eventName, ?Event $event = null)
     {
         if (Event::class === get_class($event)) {
             return $this->context->createMessage(json_encode(''));

--- a/pkg/enqueue/Client/Config.php
+++ b/pkg/enqueue/Client/Config.php
@@ -153,13 +153,13 @@ class Config
     }
 
     public static function create(
-        string $prefix = null,
-        string $separator = null,
-        string $app = null,
-        string $routerTopic = null,
-        string $routerQueue = null,
-        string $defaultQueue = null,
-        string $routerProcessor = null,
+        ?string $prefix = null,
+        ?string $separator = null,
+        ?string $app = null,
+        ?string $routerTopic = null,
+        ?string $routerQueue = null,
+        ?string $defaultQueue = null,
+        ?string $routerProcessor = null,
         array $transportConfig = [],
         array $driverConfig = []
     ): self {

--- a/pkg/enqueue/Client/Driver/AmqpDriver.php
+++ b/pkg/enqueue/Client/Driver/AmqpDriver.php
@@ -58,7 +58,7 @@ class AmqpDriver extends GenericDriver
         return $transportMessage;
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/DbalDriver.php
+++ b/pkg/enqueue/Client/Driver/DbalDriver.php
@@ -16,7 +16,7 @@ class DbalDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/FsDriver.php
+++ b/pkg/enqueue/Client/Driver/FsDriver.php
@@ -18,7 +18,7 @@ class FsDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/GenericDriver.php
+++ b/pkg/enqueue/Client/Driver/GenericDriver.php
@@ -120,7 +120,7 @@ class GenericDriver implements DriverInterface
         return new DriverSendResult($queue, $transportMessage);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
     }
 

--- a/pkg/enqueue/Client/Driver/GpsDriver.php
+++ b/pkg/enqueue/Client/Driver/GpsDriver.php
@@ -20,7 +20,7 @@ class GpsDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/MongodbDriver.php
+++ b/pkg/enqueue/Client/Driver/MongodbDriver.php
@@ -16,7 +16,7 @@ class MongodbDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/RabbitMqStompDriver.php
+++ b/pkg/enqueue/Client/Driver/RabbitMqStompDriver.php
@@ -62,7 +62,7 @@ class RabbitMqStompDriver extends StompDriver
         return $transportMessage;
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/RdKafkaDriver.php
+++ b/pkg/enqueue/Client/Driver/RdKafkaDriver.php
@@ -19,7 +19,7 @@ class RdKafkaDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $logger->debug('[RdKafkaDriver] setup broker');

--- a/pkg/enqueue/Client/Driver/SnsQsDriver.php
+++ b/pkg/enqueue/Client/Driver/SnsQsDriver.php
@@ -19,7 +19,7 @@ class SnsQsDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/SqsDriver.php
+++ b/pkg/enqueue/Client/Driver/SqsDriver.php
@@ -18,7 +18,7 @@ class SqsDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $log = function ($text, ...$args) use ($logger) {

--- a/pkg/enqueue/Client/Driver/StompDriver.php
+++ b/pkg/enqueue/Client/Driver/StompDriver.php
@@ -22,7 +22,7 @@ class StompDriver extends GenericDriver
         parent::__construct($context, ...$args);
     }
 
-    public function setupBroker(LoggerInterface $logger = null): void
+    public function setupBroker(?LoggerInterface $logger = null): void
     {
         $logger = $logger ?: new NullLogger();
         $logger->debug('[StompDriver] Stomp protocol does not support broker configuration');

--- a/pkg/enqueue/Client/Driver/StompManagementClient.php
+++ b/pkg/enqueue/Client/Driver/StompManagementClient.php
@@ -37,7 +37,7 @@ class StompManagementClient
         return $this->client->exchanges()->create($this->vhost, $name, $options);
     }
 
-    public function bind(string $exchange, string $queue, string $routingKey = null, $arguments = null)
+    public function bind(string $exchange, string $queue, ?string $routingKey = null, $arguments = null)
     {
         return $this->client->bindings()->create($this->vhost, $exchange, $queue, $routingKey, $arguments);
     }

--- a/pkg/enqueue/Client/DriverInterface.php
+++ b/pkg/enqueue/Client/DriverInterface.php
@@ -27,7 +27,7 @@ interface DriverInterface
      * Prepare broker for work.
      * Creates all required queues, exchanges, topics, bindings etc.
      */
-    public function setupBroker(LoggerInterface $logger = null): void;
+    public function setupBroker(?LoggerInterface $logger = null): void;
 
     public function getConfig(): Config;
 

--- a/pkg/enqueue/Client/PreSend.php
+++ b/pkg/enqueue/Client/PreSend.php
@@ -48,7 +48,7 @@ final class PreSend
         $this->commandOrTopic = $newTopic;
     }
 
-    public function changeBody($body, string $contentType = null): void
+    public function changeBody($body, ?string $contentType = null): void
     {
         $this->message->setBody($body);
 

--- a/pkg/enqueue/Client/Producer.php
+++ b/pkg/enqueue/Client/Producer.php
@@ -27,7 +27,7 @@ final class Producer implements ProducerInterface
     public function __construct(
         DriverInterface $driver,
         RpcFactory $rpcFactory,
-        ExtensionInterface $extension = null
+        ?ExtensionInterface $extension = null
     ) {
         $this->driver = $driver;
         $this->rpcFactory = $rpcFactory;

--- a/pkg/enqueue/Client/TraceableProducer.php
+++ b/pkg/enqueue/Client/TraceableProducer.php
@@ -71,7 +71,7 @@ final class TraceableProducer implements ProducerInterface
         $this->traces = [];
     }
 
-    private function collectTrace(string $topic = null, string $command = null, $message): void
+    private function collectTrace(?string $topic, ?string $command, $message): void
     {
         $trace = [
             'topic' => $topic,

--- a/pkg/enqueue/Consumption/QueueConsumer.php
+++ b/pkg/enqueue/Consumption/QueueConsumer.php
@@ -63,9 +63,9 @@ final class QueueConsumer implements QueueConsumerInterface
      */
     public function __construct(
         InteropContext $interopContext,
-        ExtensionInterface $extension = null,
+        ?ExtensionInterface $extension = null,
         array $boundProcessors = [],
-        LoggerInterface $logger = null,
+        ?LoggerInterface $logger = null,
         int $receiveTimeout = 10000
     ) {
         $this->interopContext = $interopContext;
@@ -122,7 +122,7 @@ final class QueueConsumer implements QueueConsumerInterface
         return $this->bind($queue, new CallbackProcessor($processor));
     }
 
-    public function consume(ExtensionInterface $runtimeExtension = null): void
+    public function consume(?ExtensionInterface $runtimeExtension = null): void
     {
         $extension = $runtimeExtension ?
             new ChainExtension([$this->staticExtension, $runtimeExtension]) :
@@ -286,7 +286,7 @@ final class QueueConsumer implements QueueConsumerInterface
         $this->fallbackSubscriptionConsumer = $fallbackSubscriptionConsumer;
     }
 
-    private function onEnd(ExtensionInterface $extension, int $startTime, ?int $exitStatus = null, SubscriptionConsumer $subscriptionConsumer = null): void
+    private function onEnd(ExtensionInterface $extension, int $startTime, ?int $exitStatus = null, ?SubscriptionConsumer $subscriptionConsumer = null): void
     {
         $endTime = (int) (microtime(true) * 1000);
 

--- a/pkg/enqueue/Consumption/QueueConsumerInterface.php
+++ b/pkg/enqueue/Consumption/QueueConsumerInterface.php
@@ -38,5 +38,5 @@ interface QueueConsumerInterface
      *
      * @throws \Exception
      */
-    public function consume(ExtensionInterface $runtimeExtension = null): void;
+    public function consume(?ExtensionInterface $runtimeExtension = null): void;
 }

--- a/pkg/enqueue/Consumption/Result.php
+++ b/pkg/enqueue/Consumption/Result.php
@@ -84,7 +84,7 @@ class Result
     /**
      * @param InteropMessage|null $reply
      */
-    public function setReply(InteropMessage $reply = null)
+    public function setReply(?InteropMessage $reply = null)
     {
         $this->reply = $reply;
     }

--- a/pkg/enqueue/Rpc/RpcClient.php
+++ b/pkg/enqueue/Rpc/RpcClient.php
@@ -23,7 +23,7 @@ class RpcClient
      * @param Context    $context
      * @param RpcFactory $promiseFactory
      */
-    public function __construct(Context $context, RpcFactory $promiseFactory = null)
+    public function __construct(Context $context, ?RpcFactory $promiseFactory = null)
     {
         $this->context = $context;
         $this->rpcFactory = $promiseFactory ?: new RpcFactory($context);

--- a/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
+++ b/pkg/enqueue/Tests/Consumption/QueueConsumerTest.php
@@ -1470,7 +1470,7 @@ class QueueConsumerTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|InteropContext
      */
-    private function createContextStub(Consumer $consumer = null): InteropContext
+    private function createContextStub(?Consumer $consumer = null): InteropContext
     {
         $context = $this->createContextWithoutSubscriptionConsumerMock();
         $context

--- a/pkg/fs/FsMessage.php
+++ b/pkg/fs/FsMessage.php
@@ -96,7 +96,7 @@ class FsMessage implements Message, \JsonSerializable
         $this->redelivered = $redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', (string) $correlationId);
     }
@@ -106,7 +106,7 @@ class FsMessage implements Message, \JsonSerializable
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', (string) $messageId);
     }
@@ -123,12 +123,12 @@ class FsMessage implements Message, \JsonSerializable
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }

--- a/pkg/fs/FsProducer.php
+++ b/pkg/fs/FsProducer.php
@@ -67,7 +67,7 @@ class FsProducer implements Producer
         });
     }
 
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $deliveryDelay) {
             return $this;
@@ -81,7 +81,7 @@ class FsProducer implements Producer
         return null;
     }
 
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (null === $priority) {
             return $this;
@@ -95,7 +95,7 @@ class FsProducer implements Producer
         return null;
     }
 
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/gearman/GearmanMessage.php
+++ b/pkg/gearman/GearmanMessage.php
@@ -101,7 +101,7 @@ class GearmanMessage implements Message, \JsonSerializable
         $this->redelivered = $redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', (string) $correlationId);
     }
@@ -111,7 +111,7 @@ class GearmanMessage implements Message, \JsonSerializable
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', (string) $messageId);
     }
@@ -128,12 +128,12 @@ class GearmanMessage implements Message, \JsonSerializable
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -171,7 +171,7 @@ class GearmanMessage implements Message, \JsonSerializable
         return $this->job;
     }
 
-    public function setJob(\GearmanJob $job = null): void
+    public function setJob(?\GearmanJob $job = null): void
     {
         $this->job = $job;
     }

--- a/pkg/gearman/GearmanProducer.php
+++ b/pkg/gearman/GearmanProducer.php
@@ -40,7 +40,7 @@ class GearmanProducer implements Producer
         }
     }
 
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $deliveryDelay) {
             return $this;
@@ -54,7 +54,7 @@ class GearmanProducer implements Producer
         return null;
     }
 
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (null === $priority) {
             return $this;
@@ -68,7 +68,7 @@ class GearmanProducer implements Producer
         return null;
     }
 
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         if (null === $timeToLive) {
             return $this;

--- a/pkg/job-queue/Doctrine/JobStorage.php
+++ b/pkg/job-queue/Doctrine/JobStorage.php
@@ -124,7 +124,7 @@ class JobStorage
     /**
      * @throws DuplicateJobException
      */
-    public function saveJob(Job $job, \Closure $lockCallback = null)
+    public function saveJob(Job $job, ?\Closure $lockCallback = null)
     {
         $class = $this->getEntityRepository()->getClassName();
         if (!$job instanceof $class) {

--- a/pkg/job-queue/JobRunner.php
+++ b/pkg/job-queue/JobRunner.php
@@ -17,7 +17,7 @@ class JobRunner
     /**
      * @param Job $rootJob
      */
-    public function __construct(JobProcessor $jobProcessor, Job $rootJob = null)
+    public function __construct(JobProcessor $jobProcessor, ?Job $rootJob = null)
     {
         $this->jobProcessor = $jobProcessor;
         $this->rootJob = $rootJob;

--- a/pkg/mongodb/MongodbMessage.php
+++ b/pkg/mongodb/MongodbMessage.php
@@ -65,7 +65,7 @@ class MongodbMessage implements Message
         $this->redelivered = false;
     }
 
-    public function setId(string $id = null): void
+    public function setId(?string $id = null): void
     {
         $this->id = $id;
     }
@@ -135,7 +135,7 @@ class MongodbMessage implements Message
         $this->redelivered = $redelivered;
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -150,7 +150,7 @@ class MongodbMessage implements Message
         return $this->priority;
     }
 
-    public function setPriority(int $priority = null): void
+    public function setPriority(?int $priority = null): void
     {
         $this->priority = $priority;
     }
@@ -163,7 +163,7 @@ class MongodbMessage implements Message
     /**
      * In milliseconds.
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): void
+    public function setDeliveryDelay(?int $deliveryDelay = null): void
     {
         $this->deliveryDelay = $deliveryDelay;
     }
@@ -176,12 +176,12 @@ class MongodbMessage implements Message
     /**
      * In milliseconds.
      */
-    public function setTimeToLive(int $timeToLive = null): void
+    public function setTimeToLive(?int $timeToLive = null): void
     {
         $this->timeToLive = $timeToLive;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', $correlationId);
     }
@@ -191,7 +191,7 @@ class MongodbMessage implements Message
         return $this->getHeader('correlation_id', null);
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', $messageId);
     }
@@ -208,7 +208,7 @@ class MongodbMessage implements Message
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
@@ -221,7 +221,7 @@ class MongodbMessage implements Message
     /**
      * In milliseconds.
      */
-    public function setPublishedAt(int $publishedAt = null): void
+    public function setPublishedAt(?int $publishedAt = null): void
     {
         $this->publishedAt = $publishedAt;
     }

--- a/pkg/mongodb/MongodbProducer.php
+++ b/pkg/mongodb/MongodbProducer.php
@@ -111,7 +111,7 @@ class MongodbProducer implements Producer
     /**
      * @return self
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         $this->deliveryDelay = $deliveryDelay;
 
@@ -126,7 +126,7 @@ class MongodbProducer implements Producer
     /**
      * @return self
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 
@@ -141,7 +141,7 @@ class MongodbProducer implements Producer
     /**
      * @return self
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/mongodb/Tests/MongodbConsumerTest.php
+++ b/pkg/mongodb/Tests/MongodbConsumerTest.php
@@ -183,7 +183,7 @@ class InvalidMessage implements Message
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
     }
 
@@ -192,7 +192,7 @@ class InvalidMessage implements Message
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
     }
 
@@ -206,11 +206,11 @@ class InvalidMessage implements Message
         throw new \BadMethodCallException('This should not be called directly');
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
     }
 

--- a/pkg/monitoring/ConsumedMessageStats.php
+++ b/pkg/monitoring/ConsumedMessageStats.php
@@ -102,12 +102,12 @@ class ConsumedMessageStats implements Stats
         array $properties,
         bool $redelivered,
         string $status,
-        string $errorClass = null,
-        string $errorMessage = null,
-        int $errorCode = null,
-        string $errorFile = null,
-        int $errorLine = null,
-        string $trace = null
+        ?string $errorClass = null,
+        ?string $errorMessage = null,
+        ?int $errorCode = null,
+        ?string $errorFile = null,
+        ?int $errorLine = null,
+        ?string $trace = null
     ) {
         $this->consumerId = $consumerId;
         $this->timestampMs = $timestampMs;

--- a/pkg/monitoring/ConsumerStats.php
+++ b/pkg/monitoring/ConsumerStats.php
@@ -121,12 +121,12 @@ class ConsumerStats implements Stats
         int $requeued,
         int $memoryUsage,
         float $systemLoad,
-        string $errorClass = null,
-        string $errorMessage = null,
-        int $errorCode = null,
-        string $errorFile = null,
-        int $errorLine = null,
-        string $trace = null
+        ?string $errorClass = null,
+        ?string $errorMessage = null,
+        ?int $errorCode = null,
+        ?string $errorFile = null,
+        ?int $errorLine = null,
+        ?string $trace = null
     ) {
         $this->consumerId = $consumerId;
         $this->timestampMs = $timestampMs;

--- a/pkg/null/NullMessage.php
+++ b/pkg/null/NullMessage.php
@@ -97,7 +97,7 @@ class NullMessage implements Message
         $this->redelivered = $redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $headers = $this->getHeaders();
         $headers['correlation_id'] = (string) $correlationId;
@@ -110,7 +110,7 @@ class NullMessage implements Message
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $headers = $this->getHeaders();
         $headers['message_id'] = (string) $messageId;
@@ -130,7 +130,7 @@ class NullMessage implements Message
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $headers = $this->getHeaders();
         $headers['timestamp'] = (int) $timestamp;
@@ -138,7 +138,7 @@ class NullMessage implements Message
         $this->setHeaders($headers);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }

--- a/pkg/null/NullProducer.php
+++ b/pkg/null/NullProducer.php
@@ -23,7 +23,7 @@ class NullProducer implements Producer
     /**
      * @return NullProducer
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         $this->deliveryDelay = $deliveryDelay;
 
@@ -38,7 +38,7 @@ class NullProducer implements Producer
     /**
      * @return NullProducer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 
@@ -53,7 +53,7 @@ class NullProducer implements Producer
     /**
      * @return NullProducer
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/pheanstalk/PheanstalkMessage.php
+++ b/pkg/pheanstalk/PheanstalkMessage.php
@@ -103,7 +103,7 @@ class PheanstalkMessage implements Message, \JsonSerializable
         $this->redelivered = $redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', (string) $correlationId);
     }
@@ -113,7 +113,7 @@ class PheanstalkMessage implements Message, \JsonSerializable
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', (string) $messageId);
     }
@@ -130,12 +130,12 @@ class PheanstalkMessage implements Message, \JsonSerializable
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -203,7 +203,7 @@ class PheanstalkMessage implements Message, \JsonSerializable
         return $this->job;
     }
 
-    public function setJob(Job $job = null): void
+    public function setJob(?Job $job = null): void
     {
         $this->job = $job;
     }

--- a/pkg/pheanstalk/PheanstalkProducer.php
+++ b/pkg/pheanstalk/PheanstalkProducer.php
@@ -73,7 +73,7 @@ class PheanstalkProducer implements Producer
     /**
      * @return PheanstalkProducer
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         $this->deliveryDelay = $deliveryDelay;
 
@@ -88,7 +88,7 @@ class PheanstalkProducer implements Producer
     /**
      * @return PheanstalkProducer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 
@@ -103,7 +103,7 @@ class PheanstalkProducer implements Producer
     /**
      * @return PheanstalkProducer
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -71,7 +71,7 @@ class RdKafkaConsumer implements Consumer
         return $this->offset;
     }
 
-    public function setOffset(int $offset = null): void
+    public function setOffset(?int $offset = null): void
     {
         if ($this->subscribed) {
             throw new \LogicException('The consumer has already subscribed.');

--- a/pkg/rdkafka/RdKafkaMessage.php
+++ b/pkg/rdkafka/RdKafkaMessage.php
@@ -112,7 +112,7 @@ class RdKafkaMessage implements Message
         $this->redelivered = $redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', (string) $correlationId);
     }
@@ -122,7 +122,7 @@ class RdKafkaMessage implements Message
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', (string) $messageId);
     }
@@ -139,12 +139,12 @@ class RdKafkaMessage implements Message
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -159,7 +159,7 @@ class RdKafkaMessage implements Message
         return $this->partition;
     }
 
-    public function setPartition(int $partition = null): void
+    public function setPartition(?int $partition = null): void
     {
         $this->partition = $partition;
     }
@@ -169,7 +169,7 @@ class RdKafkaMessage implements Message
         return $this->key;
     }
 
-    public function setKey(string $key = null): void
+    public function setKey(?string $key = null): void
     {
         $this->key = $key;
     }
@@ -179,7 +179,7 @@ class RdKafkaMessage implements Message
         return $this->kafkaMessage;
     }
 
-    public function setKafkaMessage(VendorMessage $message = null): void
+    public function setKafkaMessage(?VendorMessage $message = null): void
     {
         $this->kafkaMessage = $message;
     }

--- a/pkg/rdkafka/RdKafkaProducer.php
+++ b/pkg/rdkafka/RdKafkaProducer.php
@@ -70,7 +70,7 @@ class RdKafkaProducer implements Producer
     /**
      * @return RdKafkaProducer
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $deliveryDelay) {
             return $this;
@@ -87,7 +87,7 @@ class RdKafkaProducer implements Producer
     /**
      * @return RdKafkaProducer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (null === $priority) {
             return $this;
@@ -101,7 +101,7 @@ class RdKafkaProducer implements Producer
         return null;
     }
 
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         if (null === $timeToLive) {
             return $this;

--- a/pkg/rdkafka/RdKafkaTopic.php
+++ b/pkg/rdkafka/RdKafkaTopic.php
@@ -50,7 +50,7 @@ class RdKafkaTopic implements Topic, Queue
         return $this->conf;
     }
 
-    public function setConf(TopicConf $conf = null): void
+    public function setConf(?TopicConf $conf = null): void
     {
         $this->conf = $conf;
     }
@@ -60,7 +60,7 @@ class RdKafkaTopic implements Topic, Queue
         return $this->partition;
     }
 
-    public function setPartition(int $partition = null): void
+    public function setPartition(?int $partition = null): void
     {
         $this->partition = $partition;
     }
@@ -70,7 +70,7 @@ class RdKafkaTopic implements Topic, Queue
         return $this->key;
     }
 
-    public function setKey(string $key = null): void
+    public function setKey(?string $key = null): void
     {
         $this->key = $key;
     }

--- a/pkg/redis/RedisMessage.php
+++ b/pkg/redis/RedisMessage.php
@@ -107,7 +107,7 @@ class RedisMessage implements Message
         return $this->redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', $correlationId);
     }
@@ -117,7 +117,7 @@ class RedisMessage implements Message
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', $messageId);
     }
@@ -134,12 +134,12 @@ class RedisMessage implements Message
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -168,7 +168,7 @@ class RedisMessage implements Message
     /**
      * Set time to live in milliseconds.
      */
-    public function setTimeToLive(int $timeToLive = null): void
+    public function setTimeToLive(?int $timeToLive = null): void
     {
         $this->setHeader('time_to_live', $timeToLive);
     }
@@ -181,7 +181,7 @@ class RedisMessage implements Message
     /**
      * Set delay in milliseconds.
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): void
+    public function setDeliveryDelay(?int $deliveryDelay = null): void
     {
         $this->setHeader('delivery_delay', $deliveryDelay);
     }

--- a/pkg/redis/RedisProducer.php
+++ b/pkg/redis/RedisProducer.php
@@ -74,7 +74,7 @@ class RedisProducer implements Producer
     /**
      * @return self
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         $this->deliveryDelay = $deliveryDelay;
 
@@ -89,7 +89,7 @@ class RedisProducer implements Producer
     /**
      * @return RedisProducer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (null === $priority) {
             return $this;
@@ -106,7 +106,7 @@ class RedisProducer implements Producer
     /**
      * @return self
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->timeToLive = $timeToLive;
 

--- a/pkg/simple-client/SimpleClient.php
+++ b/pkg/simple-client/SimpleClient.php
@@ -117,7 +117,7 @@ final class SimpleClient
      *
      * @param string|array $config
      */
-    public function __construct($config, LoggerInterface $logger = null)
+    public function __construct($config, ?LoggerInterface $logger = null)
     {
         if (is_string($config)) {
             $config = [
@@ -134,7 +134,7 @@ final class SimpleClient
     /**
      * @param callable|Processor $processor
      */
-    public function bindTopic(string $topic, $processor, string $processorName = null): void
+    public function bindTopic(string $topic, $processor, ?string $processorName = null): void
     {
         if (is_callable($processor)) {
             $processor = new CallbackProcessor($processor);
@@ -153,7 +153,7 @@ final class SimpleClient
     /**
      * @param callable|Processor $processor
      */
-    public function bindCommand(string $command, $processor, string $processorName = null): void
+    public function bindCommand(string $command, $processor, ?string $processorName = null): void
     {
         if (is_callable($processor)) {
             $processor = new CallbackProcessor($processor);
@@ -185,7 +185,7 @@ final class SimpleClient
         $this->producer->sendEvent($topic, $message);
     }
 
-    public function consume(ExtensionInterface $runtimeExtension = null): void
+    public function consume(?ExtensionInterface $runtimeExtension = null): void
     {
         $this->setupBroker();
 

--- a/pkg/sns/SnsDestination.php
+++ b/pkg/sns/SnsDestination.php
@@ -34,7 +34,7 @@ class SnsDestination implements Topic, Queue
     /**
      * The policy that defines who can access your topic. By default, only the topic owner can publish or subscribe to the topic.
      */
-    public function setPolicy(string $policy = null): void
+    public function setPolicy(?string $policy = null): void
     {
         $this->setAttribute('Policy', $policy);
     }
@@ -47,7 +47,7 @@ class SnsDestination implements Topic, Queue
     /**
      * The display name to use for a topic with SMS subscriptions.
      */
-    public function setDisplayName(string $displayName = null): void
+    public function setDisplayName(?string $displayName = null): void
     {
         $this->setAttribute('DisplayName', $displayName);
     }
@@ -60,7 +60,7 @@ class SnsDestination implements Topic, Queue
     /**
      * The display name to use for a topic with SMS subscriptions.
      */
-    public function setDeliveryPolicy(int $deliveryPolicy = null): void
+    public function setDeliveryPolicy(?int $deliveryPolicy = null): void
     {
         $this->setAttribute('DeliveryPolicy', $deliveryPolicy);
     }

--- a/pkg/sns/SnsMessage.php
+++ b/pkg/sns/SnsMessage.php
@@ -63,11 +63,11 @@ class SnsMessage implements Message
         string $body = '',
         array $properties = [],
         array $headers = [],
-        array $messageAttributes = null,
-        string $messageStructure = null,
-        string $phoneNumber = null,
-        string $subject = null,
-        string $targetArn = null
+        ?array $messageAttributes = null,
+        ?string $messageStructure = null,
+        ?string $phoneNumber = null,
+        ?string $subject = null,
+        ?string $targetArn = null
     ) {
         $this->body = $body;
         $this->properties = $properties;
@@ -192,7 +192,7 @@ class SnsMessage implements Message
      * of each user is processed in a FIFO fashion.
      * For more information, see: https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html
      */
-    public function setMessageGroupId(string $id = null): void
+    public function setMessageGroupId(?string $id = null): void
     {
         $this->messageGroupId = $id;
     }
@@ -210,7 +210,7 @@ class SnsMessage implements Message
      * aren't delivered during the 5-minute deduplication interval.
      * For more information, see https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
      */
-    public function setMessageDeduplicationId(string $id = null): void
+    public function setMessageDeduplicationId(?string $id = null): void
     {
         $this->messageDeduplicationId = $id;
     }

--- a/pkg/sns/SnsProducer.php
+++ b/pkg/sns/SnsProducer.php
@@ -99,7 +99,7 @@ class SnsProducer implements Producer
      *
      * @return SnsProducer
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $deliveryDelay) {
             return $this;
@@ -118,7 +118,7 @@ class SnsProducer implements Producer
      *
      * @return SnsProducer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (null === $priority) {
             return $this;
@@ -137,7 +137,7 @@ class SnsProducer implements Producer
      *
      * @return SnsProducer
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         if (null === $timeToLive) {
             return $this;

--- a/pkg/snsqs/SnsQsConsumer.php
+++ b/pkg/snsqs/SnsQsConsumer.php
@@ -44,7 +44,7 @@ class SnsQsConsumer implements Consumer
      * The duration (in seconds) that the received messages are hidden from subsequent retrieve
      * requests after being retrieved by a ReceiveMessage request.
      */
-    public function setVisibilityTimeout(int $visibilityTimeout = null): void
+    public function setVisibilityTimeout(?int $visibilityTimeout = null): void
     {
         $this->consumer->setVisibilityTimeout($visibilityTimeout);
     }

--- a/pkg/snsqs/SnsQsMessage.php
+++ b/pkg/snsqs/SnsQsMessage.php
@@ -41,7 +41,7 @@ class SnsQsMessage implements Message
         string $body = '',
         array $properties = [],
         array $headers = [],
-        array $messageAttributes = null
+        ?array $messageAttributes = null
     ) {
         $this->body = $body;
         $this->properties = $properties;
@@ -77,7 +77,7 @@ class SnsQsMessage implements Message
      * any messages sent with the same MessageDeduplicationId are accepted successfully but aren't delivered during the 5-minute
      * deduplication interval. For more information, see http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing.
      */
-    public function setMessageDeduplicationId(string $id = null): void
+    public function setMessageDeduplicationId(?string $id = null): void
     {
         $this->messageDeduplicationId = $id;
     }
@@ -96,7 +96,7 @@ class SnsQsMessage implements Message
      * for multiple users). In this scenario, multiple readers can process the queue, but the session data
      * of each user is processed in a FIFO fashion.
      */
-    public function setMessageGroupId(string $id = null): void
+    public function setMessageGroupId(?string $id = null): void
     {
         $this->messageGroupId = $id;
     }

--- a/pkg/snsqs/SnsQsProducer.php
+++ b/pkg/snsqs/SnsQsProducer.php
@@ -82,7 +82,7 @@ class SnsQsProducer implements Producer
     /**
      * Delivery delay is supported by SQSProducer.
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         $this->getSqsProducer()->setDeliveryDelay($deliveryDelay);
 
@@ -97,7 +97,7 @@ class SnsQsProducer implements Producer
         return $this->getSqsProducer()->getDeliveryDelay();
     }
 
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->getSnsProducer()->setPriority($priority);
         $this->getSqsProducer()->setPriority($priority);
@@ -110,7 +110,7 @@ class SnsQsProducer implements Producer
         return $this->getSnsProducer()->getPriority();
     }
 
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         $this->getSnsProducer()->setTimeToLive($timeToLive);
         $this->getSqsProducer()->setTimeToLive($timeToLive);

--- a/pkg/sqs/SqsConsumer.php
+++ b/pkg/sqs/SqsConsumer.php
@@ -53,7 +53,7 @@ class SqsConsumer implements Consumer
      * The duration (in seconds) that the received messages are hidden from subsequent retrieve
      * requests after being retrieved by a ReceiveMessage request.
      */
-    public function setVisibilityTimeout(int $visibilityTimeout = null): void
+    public function setVisibilityTimeout(?int $visibilityTimeout = null): void
     {
         $this->visibilityTimeout = $visibilityTimeout;
     }

--- a/pkg/sqs/SqsDestination.php
+++ b/pkg/sqs/SqsDestination.php
@@ -62,7 +62,7 @@ class SqsDestination implements Topic, Queue
      *  The number of seconds for which the delivery of all messages in the queue is delayed.
      *  Valid values: An integer from 0 to 900 seconds (15 minutes). The default is 0 (zero).
      */
-    public function setDelaySeconds(int $seconds = null): void
+    public function setDelaySeconds(?int $seconds = null): void
     {
         if (null == $seconds) {
             unset($this->attributes['DelaySeconds']);
@@ -76,7 +76,7 @@ class SqsDestination implements Topic, Queue
      * Valid values: An integer from 1,024 bytes (1 KiB) to 262,144 bytes (256 KiB).
      * The default is 262,144 (256 KiB).
      */
-    public function setMaximumMessageSize(int $bytes = null): void
+    public function setMaximumMessageSize(?int $bytes = null): void
     {
         if (null == $bytes) {
             unset($this->attributes['MaximumMessageSize']);
@@ -90,7 +90,7 @@ class SqsDestination implements Topic, Queue
      * Valid values: An integer from 60 seconds (1 minute) to 1,209,600 seconds (14 days).
      * The default is 345,600 (4 days).
      */
-    public function setMessageRetentionPeriod(int $seconds = null): void
+    public function setMessageRetentionPeriod(?int $seconds = null): void
     {
         if (null == $seconds) {
             unset($this->attributes['MessageRetentionPeriod']);
@@ -103,7 +103,7 @@ class SqsDestination implements Topic, Queue
      * The queue's policy. A valid AWS policy. For more information about policy structure,
      * see http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html.
      */
-    public function setPolicy(string $policy = null): void
+    public function setPolicy(?string $policy = null): void
     {
         if (null == $policy) {
             unset($this->attributes['Policy']);
@@ -116,7 +116,7 @@ class SqsDestination implements Topic, Queue
      * The number of seconds for which a ReceiveMessage action waits for a message to arrive.
      * Valid values: An integer from 0 to 20 (seconds). The default is 0 (zero).
      */
-    public function setReceiveMessageWaitTimeSeconds(int $seconds = null): void
+    public function setReceiveMessageWaitTimeSeconds(?int $seconds = null): void
     {
         if (null == $seconds) {
             unset($this->attributes['ReceiveMessageWaitTimeSeconds']);
@@ -145,7 +145,7 @@ class SqsDestination implements Topic, Queue
      * The default is 30. For more information about the visibility timeout,
      * see http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html.
      */
-    public function setVisibilityTimeout(int $seconds = null): void
+    public function setVisibilityTimeout(?int $seconds = null): void
     {
         if (null == $seconds) {
             unset($this->attributes['VisibilityTimeout']);
@@ -208,7 +208,7 @@ class SqsDestination implements Topic, Queue
         $this->queueOwnerAWSAccountId = $queueOwnerAWSAccountId;
     }
 
-    public function setRegion(string $region = null): void
+    public function setRegion(?string $region = null): void
     {
         $this->region = $region;
     }

--- a/pkg/sqs/SqsMessage.php
+++ b/pkg/sqs/SqsMessage.php
@@ -144,7 +144,7 @@ class SqsMessage implements Message
         $this->redelivered = $redelivered;
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -154,7 +154,7 @@ class SqsMessage implements Message
         return $this->getHeader('reply_to');
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', $correlationId);
     }
@@ -164,7 +164,7 @@ class SqsMessage implements Message
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', $messageId);
     }
@@ -181,7 +181,7 @@ class SqsMessage implements Message
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
@@ -211,7 +211,7 @@ class SqsMessage implements Message
      * any messages sent with the same MessageDeduplicationId are accepted successfully but aren't delivered during the 5-minute
      * deduplication interval. For more information, see http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing.
      */
-    public function setMessageDeduplicationId(string $id = null): void
+    public function setMessageDeduplicationId(?string $id = null): void
     {
         $this->messageDeduplicationId = $id;
     }
@@ -230,7 +230,7 @@ class SqsMessage implements Message
      * for multiple users). In this scenario, multiple readers can process the queue, but the session data
      * of each user is processed in a FIFO fashion.
      */
-    public function setMessageGroupId(string $id = null): void
+    public function setMessageGroupId(?string $id = null): void
     {
         $this->messageGroupId = $id;
     }
@@ -247,7 +247,7 @@ class SqsMessage implements Message
      * If you receive a message more than once, each time you receive it, you get a different receipt handle.
      * You must provide the most recently received receipt handle when you request to delete the message (otherwise, the message might not be deleted).
      */
-    public function setReceiptHandle(string $receipt = null): void
+    public function setReceiptHandle(?string $receipt = null): void
     {
         $this->receiptHandle = $receipt;
     }

--- a/pkg/sqs/SqsProducer.php
+++ b/pkg/sqs/SqsProducer.php
@@ -81,7 +81,7 @@ class SqsProducer implements Producer
     /**
      * @return SqsProducer
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         $this->deliveryDelay = $deliveryDelay;
 
@@ -96,7 +96,7 @@ class SqsProducer implements Producer
     /**
      * @return SqsProducer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (null === $priority) {
             return $this;
@@ -113,7 +113,7 @@ class SqsProducer implements Producer
     /**
      * @return SqsProducer
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         if (null === $timeToLive) {
             return $this;

--- a/pkg/stomp/StompDestination.php
+++ b/pkg/stomp/StompDestination.php
@@ -122,7 +122,7 @@ class StompDestination implements Topic, Queue
         return $this->routingKey;
     }
 
-    public function setRoutingKey(string $routingKey = null): void
+    public function setRoutingKey(?string $routingKey = null): void
     {
         $this->routingKey = $routingKey;
     }

--- a/pkg/stomp/StompMessage.php
+++ b/pkg/stomp/StompMessage.php
@@ -120,7 +120,7 @@ class StompMessage implements Message
         $this->redelivered = $redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', (string) $correlationId);
     }
@@ -130,7 +130,7 @@ class StompMessage implements Message
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', (string) $messageId);
     }
@@ -147,7 +147,7 @@ class StompMessage implements Message
         return null === $value ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
@@ -157,12 +157,12 @@ class StompMessage implements Message
         return $this->frame;
     }
 
-    public function setFrame(Frame $frame = null): void
+    public function setFrame(?Frame $frame = null): void
     {
         $this->frame = $frame;
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply-to', $replyTo);
     }

--- a/pkg/stomp/StompProducer.php
+++ b/pkg/stomp/StompProducer.php
@@ -45,7 +45,7 @@ class StompProducer implements Producer
     /**
      * @return $this|Producer
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (empty($deliveryDelay)) {
             return $this;
@@ -64,7 +64,7 @@ class StompProducer implements Producer
      *
      * @return $this|Producer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (empty($priority)) {
             return $this;
@@ -81,7 +81,7 @@ class StompProducer implements Producer
     /**
      * @return $this|Producer
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         if (empty($timeToLive)) {
             return $this;

--- a/pkg/wamp/WampProducer.php
+++ b/pkg/wamp/WampProducer.php
@@ -117,7 +117,7 @@ class WampProducer implements Producer
      *
      * @return WampProducer
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $deliveryDelay) {
             return $this;
@@ -136,7 +136,7 @@ class WampProducer implements Producer
      *
      * @return WampProducer
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         if (null === $priority) {
             return $this;
@@ -155,7 +155,7 @@ class WampProducer implements Producer
      *
      * @return WampProducer
      */
-    public function setTimeToLive(int $timeToLive = null): Producer
+    public function setTimeToLive(?int $timeToLive = null): Producer
     {
         if (null === $timeToLive) {
             return $this;


### PR DESCRIPTION
> PHP supports nullable type declarations as of PHP 7.1 with the [?T syntax](https://wiki.php.net/rfc/nullable_types), and with the [T|null syntax](https://wiki.php.net/rfc/union_types_v2) as of PHP 8.0 when generalized support for union types was added.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

enqueue packages declares to require at least php ^7.4, therefore the ?T syntax is used here.

I believe that many of those parameters dont actually need a default value, but I leave that out because it might be BC if someone is actually calling those setters with no params.