### PR TITLE
Implement RdKafka getAssignment Method

### DIFF
--- a/pkg/rdkafka/RdKafkaConsumer.php
+++ b/pkg/rdkafka/RdKafkaConsumer.php
@@ -10,6 +10,7 @@ use Interop\Queue\Message;
 use Interop\Queue\Queue;
 use RdKafka\KafkaConsumer;
 use RdKafka\TopicPartition;
+use RdKafka\Exception as RdKafkaException;
 
 class RdKafkaConsumer implements Consumer
 {
@@ -86,6 +87,22 @@ class RdKafkaConsumer implements Consumer
     public function getQueue(): Queue
     {
         return $this->topic;
+    }
+
+    /** 
+     * @return  RdKafkaTopic[] 
+     */
+    public function getAssignment(): array
+    {
+        try {
+            return array_map(function (TopicPartition $partition) {
+                $topic = new RdKafkaTopic($partition->getTopic());
+                $topic->setPartition($partition->getPartition());
+                return $topic;
+            }, $this->consumer->getAssignment());
+        } catch (RdKafkaException) {
+            return [];
+        }
     }
 
     /**

--- a/pkg/rdkafka/Tests/RdKafkaConsumerTest.php
+++ b/pkg/rdkafka/Tests/RdKafkaConsumerTest.php
@@ -10,6 +10,8 @@ use Enqueue\RdKafka\Serializer;
 use PHPUnit\Framework\TestCase;
 use RdKafka\KafkaConsumer;
 use RdKafka\Message;
+use RdKafka\TopicPartition;
+use RdKafka\Exception as RdKafkaException;
 
 class RdKafkaConsumerTest extends TestCase
 {
@@ -258,6 +260,62 @@ class RdKafkaConsumerTest extends TestCase
         $this->assertSame($expectedSerializer, $consumer->getSerializer());
     }
 
+    public function testShouldGetAssignmentWhenThereAreNoPartitions(): void
+    {
+        $rdKafka = $this->createKafkaConsumerMock();
+        $rdKafka->expects($this->once())
+            ->method('getAssignment')
+            ->willReturn([]);
+
+        $consumer = new RdKafkaConsumer(
+            $rdKafka,
+            $this->createContextMock(),
+            new RdKafkaTopic(''),
+            $this->createSerializerMock()
+        );
+
+        $this->assertEquals([], $consumer->getAssignment());
+    }
+
+    public function testShouldGetAssignmentWhenThereArePartitions(): void
+    {
+        $partition = new TopicPartition('', 0);
+
+        $rdKafka = $this->createKafkaConsumerMock();
+        $rdKafka->expects($this->once())
+            ->method('getAssignment')
+            ->willReturn([$partition]);
+
+        $consumer = new RdKafkaConsumer(
+            $rdKafka,
+            $this->createContextMock(),
+            new RdKafkaTopic(''),
+            $this->createSerializerMock()
+        );
+
+        $expected = new RdKafkaTopic('');
+        $expected->setPartition(0);
+
+        $this->assertEquals([$expected], $consumer->getAssignment());
+    }
+
+    public function testShouldGetAssignmentReturnEmptyArrayWhenThrowException(): void
+    {
+        $rdKafka = $this->createKafkaConsumerMock();
+        $rdKafka->expects($this->once())
+            ->method('getAssignment')
+            ->willThrowException($this->createExceptionMock());
+
+        $consumer = new RdKafkaConsumer(
+            $rdKafka,
+            $this->createContextMock(),
+            new RdKafkaTopic(''),
+            $this->createSerializerMock()
+        );
+
+        $this->assertEquals([], $consumer->getAssignment());
+    }
+
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|KafkaConsumer
      */
@@ -280,5 +338,13 @@ class RdKafkaConsumerTest extends TestCase
     private function createSerializerMock()
     {
         return $this->createMock(Serializer::class);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|RdKafkaException
+     */
+    private function createExceptionMock()
+    {
+        return $this->createMock(RdKafkaException::class);
     }
 }


### PR DESCRIPTION
The [getAssignment](https://arnaud-lb.github.io/php-rdkafka-doc/phpdoc/rdkafka-kafkaconsumer.getassignment.html) method in RdKafka is useful for verifying the health of a Kafka consumer by checking if it has active partition assignments.  

#### **Benefits:**  

1. **Ensuring the Consumer is Active**  
   - A healthy consumer should have at least one assigned partition.  
   - If `getAssignment` returns an empty list, it may indicate that the consumer is not properly connected or is not receiving partition assignments.  

2. **Detecting Rebalance Issues**  
   - Kafka dynamically reassigns partitions when consumers join or leave a group.  
   - A consumer that remains without assigned partitions for an extended period might be experiencing rebalance failures.  

3. **Identifying Invalid States**  
   - If a consumer is running but has no assigned partitions, possible issues include:  
     - The consumer failed to join the group.  
     - Kafka has no partitions available for assignment.  
     - There is a communication failure between the consumer and the broker.  

4. **Health Check Integration for Auto-Scaling**  
   - This method can be used in readiness and liveness probes to ensure that only consumers with assigned partitions remain operational, preventing idle instances.  

#### **Example Usage:**  
```php
$consumer = new RdKafka\KafkaConsumer($config);

$assignment = [];
$consumer->getAssignment($assignment);

if (empty($assignment)) {
    echo "❌ No partitions assigned! The consumer might not be connected to Kafka.";
} else {
    echo "✅ Consumer is healthy! Assigned partitions: " ;
}
```

By incorporating `getAssignment` into health checks, we can improve the resilience of our Kafka consumer infrastructure and detect issues proactively.