### PR TITLE
feat: allow creating PRedis with a client

### DIFF
--- a/pkg/redis/PRedis.php
+++ b/pkg/redis/PRedis.php
@@ -34,6 +34,18 @@ class PRedis implements Redis
             throw new \LogicException('The package "predis/predis" must be installed. Please run "composer req predis/predis:^1.1" to install it');
         }
 
+        if (array_key_exists('client', $config) && null !== $config['client']) {
+            if (!$config['client'] instanceof Client) {
+                throw new \InvalidArgumentException(sprintf('%s configuration property is expected to be an instance of %s class. %s was passed instead.', 'client', Client::class, gettype($config['client'])));
+            }
+            $this->redis = $config['client'];
+
+            $this->options = [];
+            $this->parameters = [];
+
+            return;
+        }
+
         $this->options = $config['predis_options'];
 
         $this->parameters = [
@@ -52,6 +64,11 @@ class PRedis implements Redis
         if ($config['ssl']) {
             $this->parameters['ssl'] = $config['ssl'];
         }
+    }
+
+    public static function createWithClient(Client $client): self
+    {
+        return new self(['client' => $client]);
     }
 
     public function eval(string $script, array $keys = [], array $args = [])


### PR DESCRIPTION
This pull request introduces the ability to create a `PRedis` instance using an already initialized `Predis\Client`. A new static method `createWithClient` has been added to facilitate this functionality.

Use Case
If a user already has a configured `Predis\Client` instance, they can now pass it directly to the `PRedis` class. This avoids the need to reconfigure the client or duplicate configuration logic. For example, I want to pass through enqueue because I have a predis client configured with Sentinel.

Changes
1. Added a check in the constructor to accept a `client` key in the configuration array. If provided, it validates that the value is an instance of `Predis\Client` and uses it directly.
2. Added a static method `createWithClient(Client $client): self` to simplify the creation of a `PRedis` instance with an existing `Predis\Client`.

Example Usage
```php
use Predis\Client;
use Enqueue\Redis\PRedis;

$predisClient = new Client(['host' => '127.0.0.1', 'port' => 6379]);
$predis = PRedis::createWithClient($predisClient);

// Pass the PRedis instance to the RedisConnectionFactory
$connectionFactory = new RedisConnectionFactory($predis);

// Get the RedisContext
$redisContext = $connectionFactory->createContext();