### PR TITLE
Improve log extension to avoid unique messages

### DIFF
--- a/pkg/enqueue/Consumption/Extension/LogExtension.php
+++ b/pkg/enqueue/Consumption/Extension/LogExtension.php
@@ -30,7 +30,7 @@ class LogExtension implements StartExtensionInterface, MessageReceivedExtensionI
     {
         $message = $context->getMessage();
 
-        $context->getLogger()->debug("Received from {queueName}", [
+        $context->getLogger()->debug('Received from {queueName}', [
             'queueName' => $context->getConsumer()->getQueue()->getQueueName(),
             'redelivered' => $message->isRedelivered(),
             'body' => Stringify::that($message->getBody()),
@@ -45,7 +45,7 @@ class LogExtension implements StartExtensionInterface, MessageReceivedExtensionI
         $queue = $context->getConsumer()->getQueue();
         $result = $context->getResult();
 
-        $logMessage = "Processed from {queueName}";
+        $logMessage = 'Processed from {queueName}';
 
         $reason = '';
         if ($result instanceof Result && $result->getReason()) {

--- a/pkg/enqueue/Consumption/Extension/LogExtension.php
+++ b/pkg/enqueue/Consumption/Extension/LogExtension.php
@@ -30,7 +30,7 @@ class LogExtension implements StartExtensionInterface, MessageReceivedExtensionI
     {
         $message = $context->getMessage();
 
-        $context->getLogger()->debug("Received from {queueName}\t{body}", [
+        $context->getLogger()->debug("Received from {queueName}", [
             'queueName' => $context->getConsumer()->getQueue()->getQueueName(),
             'redelivered' => $message->isRedelivered(),
             'body' => Stringify::that($message->getBody()),
@@ -45,12 +45,13 @@ class LogExtension implements StartExtensionInterface, MessageReceivedExtensionI
         $queue = $context->getConsumer()->getQueue();
         $result = $context->getResult();
 
+        $logMessage = "Processed from {queueName}";
+
         $reason = '';
-        $logMessage = "Processed from {queueName}\t{body}\t{result}";
         if ($result instanceof Result && $result->getReason()) {
             $reason = $result->getReason();
-            $logMessage .= ' {reason}';
         }
+
         $logContext = [
             'result' => str_replace('enqueue.', '', $result),
             'reason' => $reason,

--- a/pkg/enqueue/Tests/Client/ConsumptionExtension/LogExtensionTest.php
+++ b/pkg/enqueue/Tests/Client/ConsumptionExtension/LogExtensionTest.php
@@ -91,7 +91,7 @@ class LogExtensionTest extends TestCase
         $logger
             ->expects($this->once())
             ->method('debug')
-            ->with('Received from {queueName}	{body}', [
+            ->with('Received from {queueName}', [
                 'queueName' => 'aQueue',
                 'redelivered' => false,
                 'body' => Stringify::that('aBody'),
@@ -118,7 +118,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::INFO,
-                'Processed from {queueName}	{body}	{result}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),
@@ -148,7 +148,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::ERROR,
-                'Processed from {queueName}	{body}	{result}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),
@@ -178,7 +178,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::INFO,
-                'Processed from {queueName}	{body}	{result}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),
@@ -208,7 +208,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::INFO,
-                'Processed from {queueName}	{body}	{result} {reason}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),

--- a/pkg/enqueue/Tests/Consumption/Extension/LogExtensionTest.php
+++ b/pkg/enqueue/Tests/Consumption/Extension/LogExtensionTest.php
@@ -85,7 +85,7 @@ class LogExtensionTest extends TestCase
         $logger
             ->expects($this->once())
             ->method('debug')
-            ->with('Received from {queueName}	{body}', [
+            ->with('Received from {queueName}', [
                 'queueName' => 'aQueue',
                 'redelivered' => false,
                 'body' => Stringify::that('aBody'),
@@ -112,7 +112,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::INFO,
-                'Processed from {queueName}	{body}	{result}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),
@@ -142,7 +142,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::ERROR,
-                'Processed from {queueName}	{body}	{result}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),
@@ -172,7 +172,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::INFO,
-                'Processed from {queueName}	{body}	{result}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),
@@ -202,7 +202,7 @@ class LogExtensionTest extends TestCase
             ->expects($this->once())
             ->method('log')
             ->with(LogLevel::INFO,
-                'Processed from {queueName}	{body}	{result} {reason}',
+                'Processed from {queueName}',
                 [
                     'queueName' => 'aQueue',
                     'body' => Stringify::that('aBody'),


### PR DESCRIPTION
Currently the log extension is adding the processed message body to the log message. This creates unique logs, and duplicates the info as it's added in the log context. It's not an issue per se, but if you use Sentry (or similar tools), you receive issues for each message handled with error.

What do you think about excluding it?