### PR TITLE
Fix timestamp handling in SqsMessage and add related tests

### DIFF
--- a/pkg/sqs/SqsMessage.php
+++ b/pkg/sqs/SqsMessage.php
@@ -176,9 +176,10 @@ class SqsMessage implements Message
 
     public function getTimestamp(): ?int
     {
-        $value = $this->getHeader('timestamp');
+        $value = $this->getAttribute('SentTimestamp');
 
-        return null === $value ? null : (int) $value;
+        // SQS SentTimestamp is milliseconds since epoch.
+        return null === $value ? null : (int) $intdiv($value, 1000);
     }
 
     public function setTimestamp(?int $timestamp = null): void

--- a/pkg/sqs/Tests/SqsConsumerTest.php
+++ b/pkg/sqs/Tests/SqsConsumerTest.php
@@ -341,6 +341,7 @@ class SqsConsumerTest extends TestCase
             'ApproximateReceiveCount' => '3',
             'SentTimestamp' => '1560512260079',
         ], $result->getAttributes());
+        $this->assertSame(1560512260, $result->getTimestamp());
         $this->assertTrue($result->isRedelivered());
         $this->assertEquals('The Receipt', $result->getReceiptHandle());
         $this->assertEquals('theMessageId', $result->getMessageId());

--- a/pkg/sqs/Tests/SqsMessageTest.php
+++ b/pkg/sqs/Tests/SqsMessageTest.php
@@ -52,6 +52,23 @@ class SqsMessageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['timestamp' => 12345], $message->getHeaders());
     }
 
+    public function testShouldGetTimestampFromSentTimestampAttribute()
+    {
+        $message = new SqsMessage();
+        $message->setAttributes([
+            'SentTimestamp' => '1560512260079',
+        ]);
+
+        $this->assertSame(1560512260, $message->getTimestamp());
+    }
+
+    public function testShouldReturnNullTimestampWhenSentTimestampAttributeIsMissing()
+    {
+        $message = new SqsMessage();
+
+        $this->assertNull($message->getTimestamp());
+    }
+
     public function testShouldSetReplyToAsHeader()
     {
         $message = new SqsMessage();


### PR DESCRIPTION
See https://github.com/php-enqueue/enqueue-dev/issues/1402

Guidelines followed, but several non-touched files with cs issues. Ignored for now. 